### PR TITLE
Fix TLS configuration and public path resolution

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -227,7 +227,19 @@
 
                                 <div>
                                     <label class="block text-sm font-medium text-gray-700 mb-2">IMAP Port</label>
-                                    <input type="number" id="accountImapPort" class="w-full px-3 py-2 border border-gray-300 rounded-md" placeholder="993" value="993">
+                                    <input type="number" id="accountImapPort" class="w-full px-3 py-2 border border-gray-300 rounded-md" placeholder="993" value="993" onchange="onImapPortChange()">
+                                </div>
+
+                                <div>
+                                    <label class="flex items-center">
+                                        <input type="checkbox" id="accountImapTls" class="mr-2" checked>
+                                        <span class="text-sm font-medium text-gray-700">Use Implicit TLS (SSL from start)</span>
+                                    </label>
+                                    <p class="text-xs text-gray-500 mt-1 ml-6">
+                                        ✓ Checked = Implicit TLS (port 993)<br>
+                                        ✗ Unchecked = STARTTLS upgrade (port 143, 1143)<br>
+                                        <span class="text-amber-600">Proton Bridge: Use port 1143 and UNCHECK this box</span>
+                                    </p>
                                 </div>
                             </div>
                         </details>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -773,8 +773,25 @@ function onEmailChange() {
   if (provider) {
     document.getElementById('accountProvider').value = provider.id;
     onProviderChange();
+    onImapPortChange(); // Update TLS checkbox based on detected port
     showAccountFormMessage(`✓ Detected ${provider.displayName}`, 'success');
   }
+}
+
+function onImapPortChange() {
+  const port = parseInt(document.getElementById('accountImapPort').value);
+  const tlsCheckbox = document.getElementById('accountImapTls');
+
+  // Auto-detect TLS setting based on common ports
+  // Port 993 = implicit TLS (checked)
+  // Port 143, 1143 = STARTTLS or plain (unchecked for STARTTLS)
+  // Port 465 = legacy SSL (checked)
+  if (port === 993 || port === 465) {
+    tlsCheckbox.checked = true;
+  } else if (port === 143 || port === 1143) {
+    tlsCheckbox.checked = false; // STARTTLS or plain
+  }
+  // For other ports, leave as-is
 }
 
 function onSmtpToggle() {
@@ -879,6 +896,12 @@ async function testAccountConnection() {
   showAccountFormMessage('Testing connection...', 'info');
 
   try {
+    // Get TLS setting from checkbox
+    const useTls = document.getElementById('accountImapTls').checked;
+    const port = parseInt(imapPort);
+
+    console.log('Testing connection with:', { email, host: imapHost, port, tls: useTls });
+
     const response = await fetch('/api/test-connection', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -886,17 +909,21 @@ async function testAccountConnection() {
         email: email,
         password: password,
         host: imapHost,
-        port: parseInt(imapPort),
-        tls: true
+        port: port,
+        tls: useTls
       })
     });
 
     const result = await response.json();
+    console.log('Test connection result:', result);
 
     if (result.success) {
       showAccountFormMessage('✅ Connection successful!', 'success');
     } else {
       showAccountFormMessage('❌ Connection failed: ' + result.error, 'error');
+      if (result.help) {
+        console.log('Help:', result.help);
+      }
     }
   } catch (error) {
     showAccountFormMessage('❌ Test failed: ' + error.message, 'error');
@@ -917,12 +944,16 @@ async function saveAccount() {
   showAccountFormMessage('Saving account...', 'info');
 
   try {
+    // Get TLS setting from checkbox
+    const useTls = document.getElementById('accountImapTls').checked;
+    const port = parseInt(imapPort);
+
     const accountData = {
       email: email,
       password: password,
       host: imapHost,  // Backend expects 'host', not 'imapHost'
-      port: parseInt(imapPort),
-      tls: true  // Backend expects 'tls', not 'imapSecure'
+      port: port,
+      tls: useTls  // From checkbox
     };
 
     // Add SMTP configuration if enabled

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -203,6 +203,8 @@ export class ImapService {
     }
 
     try {
+      console.error(`[IMAP] Connecting to ${account.host}:${account.port} (TLS: ${account.tls ? 'implicit' : 'STARTTLS'})`);
+
       const client = new ImapFlow({
         host: account.host,
         port: account.port,
@@ -216,12 +218,17 @@ export class ImapService {
         verifyOnly: false,
         // ImapFlow has built-in keepalive, but we can configure it
         socketTimeout: account.connTimeout || 10000,
-        greetingTimeout: account.authTimeout || 3000
+        greetingTimeout: account.authTimeout || 3000,
+        // For Proton Bridge and other self-signed certs (localhost, etc.)
+        tls: {
+          rejectUnauthorized: account.host === 'localhost' || account.host === '127.0.0.1' ? false : true
+        }
       });
 
       // Set up event listeners
       client.on('error', (err) => {
         console.error(`[IMAP] Connection error for account ${accountId}:`, err.message);
+        console.error(`[IMAP] Error details:`, err);
         this.updateConnectionState(accountId, ConnectionState.ERROR);
         this.recordCircuitBreakerFailure(accountId);
 
@@ -237,6 +244,7 @@ export class ImapService {
 
       // Connect
       await client.connect();
+      console.error(`[IMAP] Successfully connected to ${account.host}:${account.port}`);
 
       this.activeConnections.set(accountId, client);
       this.updateConnectionState(accountId, ConnectionState.CONNECTED);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -103,8 +103,8 @@ export class WebUIServer {
 
     // Serve static files from public directory
     // In development: __dirname = src/web, public is at ../../public
-    // In production: __dirname = web (inside install dir), public is at ../public
-    const publicPath = path.join(__dirname, '../public');
+    // In production: __dirname = dist/web, public is at ../../public
+    const publicPath = path.join(__dirname, '../../public');
     this.app.use(express.static(publicPath));
   }
 
@@ -162,14 +162,18 @@ export class WebUIServer {
           }
         }
 
+        // Set default port and auto-detect TLS if not specified
+        const finalPort = imapPort || 993;
+        const finalTls = useTls !== undefined ? useTls : (finalPort === 993 || finalPort === 465);
+
         const account = this.db.createAccount({
           user_id: this.defaultUserId,
           name: name || email,
           host: imapHost,
-          port: imapPort || 993,
+          port: finalPort,
           username: email,
           password,
-          tls: useTls !== false,
+          tls: finalTls,
           smtp_host: smtp?.host,
           smtp_port: smtp?.port,
           smtp_username: smtp?.user || email,
@@ -200,16 +204,21 @@ export class WebUIServer {
 
       try {
         const { email, password, host, port, tls } = req.body;
+        console.error('[API] Test connection request:', { email, host, port, tls: tls });
+
+        // Auto-detect TLS based on port if not explicitly specified
+        const imapPort = port || 993;
+        const useTls = tls !== undefined ? tls : (imapPort === 993 || imapPort === 465);
 
         // Create temporary account for testing
         const testAccount: ImapAccount = {
           id: 'test-' + Date.now(),
           name: 'Test',
           host: host || 'imap.gmail.com',
-          port: port || 993,
+          port: imapPort,
           user: email,
           password,
-          tls: tls !== false,
+          tls: useTls,
         };
 
         // Try to connect


### PR DESCRIPTION
- Add implicit TLS toggle to UI with port-based auto-detection
- Fix STARTTLS support for Proton Bridge and port 143/1143
- Update IMAP service to handle implicit TLS vs STARTTLS
- Fix public path resolution for production builds
- Add self-signed cert support for localhost/127.0.0.1
- Improve error logging and connection diagnostics