### PR TITLE
Fix #91: date-only search parsing and IMAP-disabled error messages

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -13,6 +13,7 @@
 import { ImapFlow } from 'imapflow';
 import type { FetchMessageObject, MailboxObject, ListResponse } from 'imapflow';
 import { simpleParser } from 'mailparser';
+import { getProviderByEmail } from '../providers/email-providers.js';
 import {
   ImapAccount,
   EmailMessage,
@@ -271,13 +272,40 @@ export class ImapService {
       const errorMessage = error instanceof Error ? error.message : String(error);
       let failureReason = errorMessage;
 
+      // Issue #91: Some providers disable IMAP at the account level (not
+      // auth-denied but service-disabled). Surface a provider-specific hint
+      // using the email-providers directory when possible.
+      const lower = errorMessage.toLowerCase();
+      const imapDisabled =
+        lower.includes('imap access is disabled') ||
+        lower.includes('imap is disabled') ||
+        lower.includes('web login required') ||
+        lower.includes('[alert] please log in') ||
+        (lower.includes('authenticationfailed') && lower.includes('imap'));
+
+      const provider = getProviderByEmail(account.user);
+
+      if (imapDisabled) {
+        const helpSuffix = provider?.helpUrl
+          ? ` Enable IMAP in ${provider.displayName} settings: ${provider.helpUrl}`
+          : ' Enable IMAP access in your provider settings (typically under account security or forwarding settings).';
+        failureReason = `IMAP access disabled for ${account.user}`;
+        const enhancedError = new Error(`${failureReason}.${helpSuffix}`);
+        enhancedError.name = 'ImapDisabledError';
+        this.recordCircuitBreakerFailure(accountId, failureReason);
+        throw enhancedError;
+      }
+
       // Enhance error message for authentication failures
-      if (errorMessage.toLowerCase().includes('auth') ||
-          errorMessage.toLowerCase().includes('invalid credentials') ||
-          errorMessage.toLowerCase().includes('login') ||
-          errorMessage.toLowerCase().includes('authentication failed')) {
+      if (lower.includes('auth') ||
+          lower.includes('invalid credentials') ||
+          lower.includes('login') ||
+          lower.includes('authentication failed')) {
         failureReason = `Authentication failed for ${account.user}`;
-        const enhancedError = new Error(`${failureReason}. Please verify your password. Many providers (Gmail, Yahoo, Outlook, etc.) require app-specific passwords instead of your regular account password.`);
+        const appPwHint = provider?.requiresAppPassword && provider?.helpUrl
+          ? ` ${provider.displayName} requires an app-specific password; generate one at ${provider.helpUrl}.`
+          : ' Many providers (Gmail, Yahoo, Outlook, etc.) require app-specific passwords instead of your regular account password.';
+        const enhancedError = new Error(`${failureReason}. Please verify your password.${appPwHint}`);
         enhancedError.name = 'AuthenticationError';
         this.recordCircuitBreakerFailure(accountId, failureReason);
         throw enhancedError;

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -5,6 +5,22 @@ import { SmtpService } from '../services/smtp-service.js';
 import { z } from 'zod';
 import { withErrorHandling, AccountNotFoundError } from '../utils/error-handler.js';
 
+/**
+ * Parse a date-only string (YYYY-MM-DD) as midnight in the local timezone.
+ * `new Date("2026-04-01")` interprets the string as UTC midnight, which on
+ * non-UTC systems shifts the date by the TZ offset (e.g. -07:00 turns
+ * 2026-04-01 into 2026-03-31T17:00Z). For IMAP SINCE/BEFORE semantics the
+ * caller intends a calendar day in their own timezone, so parse components
+ * explicitly. Full ISO timestamps fall through to the Date constructor.
+ *
+ * Issue #91.
+ */
+function parseDateOnly(input: string): Date {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(input);
+  if (!m) return new Date(input);
+  return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+}
+
 export function emailTools(
   server: McpServer,
   imapService: ImapService,
@@ -39,8 +55,8 @@ export function emailTools(
     if (searchCriteria.to) criteria.to = searchCriteria.to;
     if (searchCriteria.subject) criteria.subject = searchCriteria.subject;
     if (searchCriteria.body) criteria.body = searchCriteria.body;
-    if (searchCriteria.since) criteria.since = new Date(searchCriteria.since);
-    if (searchCriteria.before) criteria.before = new Date(searchCriteria.before);
+    if (searchCriteria.since) criteria.since = parseDateOnly(searchCriteria.since);
+    if (searchCriteria.before) criteria.before = parseDateOnly(searchCriteria.before);
     if (searchCriteria.unreadOnly !== undefined) criteria.unreadOnly = searchCriteria.unreadOnly;  // Issue #82
     if (searchCriteria.seen !== undefined) criteria.seen = searchCriteria.seen;
     if (searchCriteria.flagged !== undefined) criteria.flagged = searchCriteria.flagged;


### PR DESCRIPTION
## Summary

Closes #91.

Two small upstream fixes ported:

### 1. Date-only search parsing (timezone bug)

`imap_search_emails` previously passed `since`/`before` strings straight to `new Date(...)`, which parses `YYYY-MM-DD` as **UTC midnight**. On systems in negative-offset timezones (e.g. America/Los_Angeles), that shifted the IMAP SINCE/BEFORE criterion to the previous calendar day — so a user searching for mail "since 2026-04-01" actually got mail since 2026-03-31.

Added `parseDateOnly(input)` in `src/tools/email-tools.ts`:
- Matches `YYYY-MM-DD` explicitly and constructs the Date from numeric components → lands on local midnight.
- Full ISO timestamps fall through to the regular `Date` constructor unchanged.

### 2. Provider-aware IMAP connect errors

`ImapService.connect()` now recognises "IMAP access disabled" variants (Gmail/Yahoo/others surface these when IMAP is toggled off at the account level — distinct from auth failure) and attaches the provider's help URL from `email-providers.ts`.

The auth-failure branch likewise pulls `provider.helpUrl` when `requiresAppPassword=true`, giving a direct link to generate one instead of the generic "many providers..." message.

## Files changed

- `src/tools/email-tools.ts` — `parseDateOnly()` helper + call sites for `since`/`before`
- `src/services/imap-service.ts` — import `getProviderByEmail`; new `ImapDisabledError` branch; provider-aware auth-error hint

## Test plan

- [x] `npm run build` — clean
- [ ] On a non-UTC system, run `imap_search_emails({since:"2026-04-01"})` and confirm the lowest-date message returned is on/after 2026-04-01 in local tz
- [ ] Disable IMAP on a Gmail account in Google settings, try to connect, confirm the error includes `https://support.google.com/mail/answer/7126229`
- [ ] Enter a wrong password for a Gmail account, confirm the auth-error message includes the Google help URL

Generated with Claude Code
