### PR TITLE
Schema migration system (#36, #37)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Date: 2025-11-06
 # Version: 1.0.0
 
-.PHONY: help install uninstall start stop restart status logs update test build clean backup restore
+.PHONY: help install uninstall start stop restart status logs update test build clean backup restore migrate migrate-status migrate-rollback migrate-dry-run
 
 # Detect OS
 UNAME_S := $(shell uname -s 2>/dev/null || echo "Windows")
@@ -232,6 +232,18 @@ backup:
 
 restore:
 	@bash scripts/restore.sh $(FILE)
+
+migrate:
+	@npm run migrate
+
+migrate-status:
+	@npm run migrate:status
+
+migrate-dry-run:
+	@npm run migrate:dry-run
+
+migrate-rollback:
+	@npm run migrate:rollback -- $(N)
 
 test:
 	@echo "Running tests..."

--- a/package.json
+++ b/package.json
@@ -8,11 +8,15 @@
     "imap-setup": "./dist/setup.js"
   },
   "scripts": {
-    "build": "tsc && mkdir -p dist/database && cp src/database/schema.sql dist/database/ && cp src/database/schema_update_*.sql dist/database/ 2>/dev/null || true",
+    "build": "tsc && mkdir -p dist/database && cp src/database/schema.sql dist/database/ && cp src/database/schema_update_*.sql dist/database/ 2>/dev/null && cp src/database/migrations-manifest.json dist/database/ 2>/dev/null || true",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "setup": "tsx src/setup.ts",
     "web": "tsx src/web/server.ts",
+    "migrate": "tsx src/cli/migrate.ts up",
+    "migrate:status": "tsx src/cli/migrate.ts status",
+    "migrate:dry-run": "tsx src/cli/migrate.ts dry-run",
+    "migrate:rollback": "tsx src/cli/migrate.ts down",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Migration CLI — status/up/down for the schema_version ledger
+ *
+ * Commands:
+ *   migrate              apply all pending migrations
+ *   migrate status       show current version and pending/applied list
+ *   migrate up           alias for default apply
+ *   migrate down [N=1]   rollback the last N applied migrations
+ *   migrate dry-run      report what would be applied without writing
+ *
+ * Issue #36 (auto-migrate) / #37 (release-based files).
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date: 2026-04-19
+ * Version: 0.1.0
+ */
+
+import { DatabaseService } from '../services/database-service.js';
+
+function fmt(json: unknown): string {
+  return JSON.stringify(json, null, 2);
+}
+
+async function main() {
+  // Parse argv after script path.
+  const [, , subCmd, arg] = process.argv;
+  const cmd = subCmd ?? 'up';
+
+  // Skip auto-migrate so the CLI has clear before/after state to report.
+  process.env.IMAP_MCP_SKIP_MIGRATIONS = '1';
+  const db = new DatabaseService();
+  const mig = db.getMigrationService();
+
+  switch (cmd) {
+    case 'status': {
+      const s = mig.status();
+      console.log(fmt({
+        currentVersion: s.currentVersion,
+        appliedCount: s.applied.length,
+        pendingCount: s.pending.length,
+        pending: s.pending.map(x => ({
+          from: x.fromVersion,
+          to: x.toVersion,
+          file: x.fileName,
+          hasRollback: x.rollbackFile !== null,
+        })),
+        applied: s.applied.map(x => ({
+          from: x.fromVersion,
+          to: x.toVersion,
+          file: x.fileName,
+        })),
+      }));
+      break;
+    }
+    case 'up':
+    case undefined: {
+      const r = mig.migrate({
+        onStep: (s) => console.error(`[migrate] applying ${s.fromVersion} -> ${s.toVersion} (${s.fileName})`),
+      });
+      console.log(fmt(r));
+      if (r.failed) process.exit(1);
+      break;
+    }
+    case 'dry-run': {
+      const r = mig.migrate({
+        dryRun: true,
+        onStep: (s) => console.error(`[migrate] would apply ${s.fromVersion} -> ${s.toVersion} (${s.fileName})`),
+      });
+      console.log(fmt(r));
+      break;
+    }
+    case 'down': {
+      const n = arg ? Math.max(1, parseInt(arg, 10)) : 1;
+      const r = mig.rollback(n);
+      console.log(fmt(r));
+      if (r.failed) process.exit(1);
+      break;
+    }
+    default:
+      console.error(`Unknown command: ${cmd}`);
+      console.error('Usage: migrate [status|up|dry-run|down [N]]');
+      process.exit(2);
+  }
+}
+
+main().catch(err => {
+  console.error('Migration CLI failed:', err);
+  process.exit(1);
+});

--- a/src/database/migrations-manifest.json
+++ b/src/database/migrations-manifest.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": "1.7.0",
+  "description": "Release-indexed manifest of schema migrations. Each entry is applied in order via the `schema_version` ledger. A migration is complete when its `to` version is present in the ledger.",
+  "migrations": [
+    {
+      "from": "1.0.0",
+      "to": "1.1.0",
+      "file": "schema_update_1.0.0_TO_1.1.0.sql",
+      "description": "Add subscription management tables"
+    },
+    {
+      "from": "1.1.0",
+      "to": "1.2.0",
+      "file": "schema_update_1.1.0_TO_1.2.0.sql",
+      "description": "Add unsubscribe execution tracking"
+    },
+    {
+      "from": "1.2.0",
+      "to": "1.3.0",
+      "file": "schema_update_1.2.0_TO_1.3.0.sql",
+      "description": "Release 1.3.0 additions"
+    },
+    {
+      "from": "1.3.0",
+      "to": "1.4.0",
+      "file": "schema_update_1.3.0_TO_1.4.0.sql",
+      "description": "Release 1.4.0 additions"
+    },
+    {
+      "from": "1.4.0",
+      "to": "1.5.0",
+      "file": "schema_update_1.4.0_TO_1.5.0.sql",
+      "description": "Release 1.5.0 additions"
+    },
+    {
+      "from": "1.5.0",
+      "to": "1.6.0",
+      "file": "schema_update_1.5.0_TO_1.6.0.sql",
+      "description": "Release 1.6.0 additions"
+    },
+    {
+      "from": "1.6.0",
+      "to": "1.7.0",
+      "file": "schema_update_1.6.0_TO_1.7.0.sql",
+      "rollbackFile": "schema_update_1.6.0_TO_1.7.0.down.sql",
+      "description": "Add tool_results + result_attachments cache for MCP context reduction (PR #94)"
+    }
+  ]
+}

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -14,6 +14,11 @@ CREATE TABLE IF NOT EXISTS schema_version (
   description TEXT
 );
 
+-- schema.sql is a monolithic "current state" snapshot. When it runs on a fresh
+-- DB it establishes the full schema up to the version below. The individual
+-- schema_update_X.Y.Z_TO_X.Y.Z.sql files are for incremental upgrades of
+-- databases that were created at an earlier version.
+-- Keep these stamps in lockstep with migrations-manifest.json.
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES ('1.0.0', 'Initial schema with MSP multi-tenant support');
 
@@ -22,6 +27,21 @@ VALUES ('1.1.0', 'Add subscription management tables');
 
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES ('1.2.0', 'Add unsubscribe execution tracking');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('1.3.0', 'Release 1.3.0 additions');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('1.4.0', 'Release 1.4.0 additions');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('1.5.0', 'Release 1.5.0 additions');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('1.6.0', 'Release 1.6.0 additions');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('1.7.0', 'Add tool_results + result_attachments cache for MCP context reduction (PR #94)');
 
 -- Users/Organizations for MSP architecture
 CREATE TABLE IF NOT EXISTS users (

--- a/src/database/schema_update_1.6.0_TO_1.7.0.down.sql
+++ b/src/database/schema_update_1.6.0_TO_1.7.0.down.sql
@@ -1,0 +1,17 @@
+-- Rollback Migration: 1.7.0 to 1.6.0
+-- Date: 2026-04-19
+-- Description: Drop tool_results + result_attachments cache
+-- See: schema_update_1.6.0_TO_1.7.0.sql
+
+DROP INDEX IF EXISTS idx_result_attachments_msg_uid;
+DROP INDEX IF EXISTS idx_result_attachments_result;
+DROP TABLE IF EXISTS result_attachments;
+
+DROP INDEX IF EXISTS idx_tool_results_storage_type;
+DROP INDEX IF EXISTS idx_tool_results_tool;
+DROP INDEX IF EXISTS idx_tool_results_expires;
+DROP INDEX IF EXISTS idx_tool_results_user_created;
+DROP INDEX IF EXISTS idx_tool_results_user;
+DROP TABLE IF EXISTS tool_results;
+
+-- Note: schema_version rows are deleted by MigrationService.rollback()

--- a/src/services/database-service.ts
+++ b/src/services/database-service.ts
@@ -36,6 +36,7 @@ import {
   DatabaseConfig,
   EncryptedData
 } from '../types/database-types.js';
+import { MigrationService } from './migration-service.js';
 
 export class DatabaseService {
   private db: Database.Database;
@@ -180,7 +181,8 @@ export class DatabaseService {
    * Initialize database schema
    */
   private initializeSchema(): void {
-    const schemaPath = path.join(__dirname, '../database/schema.sql');
+    const schemaDir = path.join(__dirname, '../database');
+    const schemaPath = path.join(schemaDir, 'schema.sql');
 
     if (!fs.existsSync(schemaPath)) {
       throw new Error(`Schema file not found: ${schemaPath}`);
@@ -188,13 +190,14 @@ export class DatabaseService {
 
     const schema = fs.readFileSync(schemaPath, 'utf-8');
 
-    // Execute entire schema at once - better-sqlite3 handles multi-statement execution
+    // schema.sql uses CREATE TABLE IF NOT EXISTS throughout, so it's safe to
+    // run on both new and existing databases.
     try {
       this.db.exec(schema);
-      console.error('[DatabaseService] Schema initialized successfully');
+      console.error('[DatabaseService] Base schema applied');
     } catch (error) {
       console.error('[DatabaseService] FATAL: Schema initialization failed:', error);
-      throw error;  // Don't swallow this error - it's critical
+      throw error;
     }
 
     // Additive column migrations — safe to run on both new and existing databases.
@@ -211,9 +214,34 @@ export class DatabaseService {
         if (!e?.message?.includes('duplicate column name')) {
           console.error('[DatabaseService] Migration warning:', e?.message);
         }
-        // Column already exists — skip silently
       }
     }
+
+    // Issue #36/#37: run versioned schema_update_*.sql migrations that haven't
+    // been recorded in schema_version yet. Each migration is one transaction.
+    // Disabled by IMAP_MCP_SKIP_MIGRATIONS=1 for debug scenarios.
+    if (process.env.IMAP_MCP_SKIP_MIGRATIONS !== '1') {
+      const migrator = new MigrationService(this.db, schemaDir);
+      const result = migrator.migrate({
+        onStep: (s) => console.error(`[DatabaseService] Applying migration ${s.fromVersion} -> ${s.toVersion} (${s.fileName})`),
+      });
+      if (result.failed) {
+        console.error(
+          `[DatabaseService] FATAL: migration ${result.failed.file} failed: ${result.failed.error}`
+        );
+        throw new Error(`Migration ${result.failed.file} failed: ${result.failed.error}`);
+      }
+      if (result.applied.length) {
+        console.error(`[DatabaseService] Applied ${result.applied.length} migration(s)`);
+      }
+    }
+  }
+
+  /**
+   * Return migration status without applying anything. Used by the CLI.
+   */
+  getMigrationService(): MigrationService {
+    return new MigrationService(this.db, path.join(__dirname, '../database'));
   }
 
   // ===================

--- a/src/services/migration-service.ts
+++ b/src/services/migration-service.ts
@@ -1,0 +1,246 @@
+/**
+ * Migration Service
+ *
+ * Applies versioned schema migrations to the SQLite database.
+ *
+ * Discovery: scans `src/database/` (or the provided directory) for files
+ * matching `schema_update_<from>_TO_<to>.sql`. Each file is one migration
+ * step; ordering is determined by the semver `<to>` version.
+ *
+ * Idempotency: `schema_version` is the ledger. A migration is considered
+ * applied when a row with its `to` version exists. Because each step
+ * runs inside a transaction that ends with an INSERT INTO schema_version,
+ * a crash mid-migration rolls the whole step back — no half-applied state.
+ *
+ * Rollback: optional `.down.sql` alongside each migration
+ * (e.g. `schema_update_1.6.0_TO_1.7.0.down.sql`). If present, rollback
+ * runs it inside a transaction that ends with DELETE FROM schema_version.
+ *
+ * Related: Issue #36 (migration system), Issue #37 (release-based files).
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date: 2026-04-19
+ * Version: 0.1.0
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type Database from 'better-sqlite3';
+
+export interface MigrationStep {
+  file: string;          // Absolute path to the .sql file
+  fileName: string;      // Basename (for logging)
+  fromVersion: string;   // Parsed from filename
+  toVersion: string;     // Parsed from filename
+  rollbackFile: string | null; // Absolute path to .down.sql if one exists
+}
+
+export interface MigrationStatus {
+  currentVersion: string | null;
+  appliedVersions: string[];
+  pending: MigrationStep[];
+  applied: MigrationStep[];
+}
+
+export interface MigrationResult {
+  applied: Array<{ fromVersion: string; toVersion: string; file: string }>;
+  skipped: Array<{ toVersion: string; reason: string }>;
+  failed: { toVersion: string; file: string; error: string } | null;
+}
+
+// Matches both schema_update_1.6.0_TO_1.7.0.sql and
+// schema_update_1.6.0_to_1.7.0.sql (case-insensitive TO separator).
+const FILENAME_RE = /^schema_update_(\d+\.\d+\.\d+)_TO_(\d+\.\d+\.\d+)\.sql$/i;
+const ROLLBACK_RE = /^schema_update_(\d+\.\d+\.\d+)_TO_(\d+\.\d+\.\d+)\.down\.sql$/i;
+
+function compareSemver(a: string, b: string): number {
+  const av = a.split('.').map(Number);
+  const bv = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((av[i] ?? 0) !== (bv[i] ?? 0)) return (av[i] ?? 0) - (bv[i] ?? 0);
+  }
+  return 0;
+}
+
+export class MigrationService {
+  constructor(
+    private db: Database.Database,
+    private migrationsDir: string
+  ) {}
+
+  /**
+   * Scan the migrations directory and return all migration steps ordered
+   * by their `to` version ascending.
+   */
+  discover(): MigrationStep[] {
+    if (!fs.existsSync(this.migrationsDir)) return [];
+    const entries = fs.readdirSync(this.migrationsDir);
+    const steps: MigrationStep[] = [];
+    for (const entry of entries) {
+      // Skip rollback files here; we'll pair them up below.
+      if (ROLLBACK_RE.test(entry)) continue;
+      const m = FILENAME_RE.exec(entry);
+      if (!m) continue;
+      const fromVersion = m[1];
+      const toVersion = m[2];
+      const file = path.join(this.migrationsDir, entry);
+      const rollbackName = entry.replace(/\.sql$/i, '.down.sql');
+      const rollbackPath = path.join(this.migrationsDir, rollbackName);
+      steps.push({
+        file,
+        fileName: entry,
+        fromVersion,
+        toVersion,
+        rollbackFile: fs.existsSync(rollbackPath) ? rollbackPath : null,
+      });
+    }
+    steps.sort((a, b) => compareSemver(a.toVersion, b.toVersion));
+    return steps;
+  }
+
+  /**
+   * Read the `schema_version` table and return status. Safe to call on a
+   * brand-new DB where the table may not yet exist.
+   */
+  status(): MigrationStatus {
+    let applied: string[] = [];
+    try {
+      const rows = this.db
+        .prepare('SELECT version FROM schema_version ORDER BY applied_at ASC')
+        .all() as Array<{ version: string }>;
+      applied = rows.map(r => r.version);
+    } catch {
+      // schema_version not yet present on a fresh DB — treat as empty.
+      applied = [];
+    }
+
+    const steps = this.discover();
+    const appliedSet = new Set(applied);
+    const pending = steps.filter(s => !appliedSet.has(s.toVersion));
+    const applyList = steps.filter(s => appliedSet.has(s.toVersion));
+    // Current version is the highest applied semver; prefer ledger over steps
+    // so that bootstrap-only versions (inserted by schema.sql) still count.
+    const currentVersion =
+      applied.length === 0
+        ? null
+        : applied
+            .slice()
+            .sort((a, b) => compareSemver(b, a))[0];
+
+    return {
+      currentVersion,
+      appliedVersions: applied,
+      pending,
+      applied: applyList,
+    };
+  }
+
+  /**
+   * Apply all pending migrations in order. Each step runs in its own
+   * transaction so a failure aborts only that step; earlier steps stay
+   * committed.
+   */
+  migrate(opts: { dryRun?: boolean; onStep?: (s: MigrationStep) => void } = {}): MigrationResult {
+    const s = this.status();
+    const result: MigrationResult = { applied: [], skipped: [], failed: null };
+
+    for (const step of s.pending) {
+      opts.onStep?.(step);
+      if (opts.dryRun) {
+        result.skipped.push({ toVersion: step.toVersion, reason: 'dry-run' });
+        continue;
+      }
+
+      const sql = fs.readFileSync(step.file, 'utf-8');
+      try {
+        // better-sqlite3 exposes `transaction()` that wraps a function in BEGIN/COMMIT.
+        const run = this.db.transaction(() => {
+          this.db.exec(sql);
+          this.db
+            .prepare(
+              `INSERT OR IGNORE INTO schema_version (version, description)
+               VALUES (?, ?)`
+            )
+            .run(
+              step.toVersion,
+              `Auto-applied from ${step.fileName}`
+            );
+        });
+        run();
+        result.applied.push({
+          fromVersion: step.fromVersion,
+          toVersion: step.toVersion,
+          file: step.fileName,
+        });
+      } catch (e: any) {
+        result.failed = {
+          toVersion: step.toVersion,
+          file: step.fileName,
+          error: e?.message ?? String(e),
+        };
+        // Stop on first failure; don't apply later steps on a broken base.
+        return result;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Rollback the last N applied migrations that have a matching .down.sql.
+   * Migrations without a rollback file are skipped with a reason.
+   */
+  rollback(count: number = 1, opts: { dryRun?: boolean } = {}): {
+    rolledBack: Array<{ toVersion: string; file: string }>;
+    skipped: Array<{ toVersion: string; reason: string }>;
+    failed: { toVersion: string; file: string; error: string } | null;
+  } {
+    const out: {
+      rolledBack: Array<{ toVersion: string; file: string }>;
+      skipped: Array<{ toVersion: string; reason: string }>;
+      failed: { toVersion: string; file: string; error: string } | null;
+    } = { rolledBack: [], skipped: [], failed: null };
+
+    const s = this.status();
+    // Rollback in reverse application order.
+    const targets = s.applied.slice().reverse().slice(0, count);
+
+    for (const step of targets) {
+      if (!step.rollbackFile) {
+        out.skipped.push({
+          toVersion: step.toVersion,
+          reason: 'no .down.sql file found',
+        });
+        continue;
+      }
+      if (opts.dryRun) {
+        out.skipped.push({ toVersion: step.toVersion, reason: 'dry-run' });
+        continue;
+      }
+      const sql = fs.readFileSync(step.rollbackFile, 'utf-8');
+      try {
+        const run = this.db.transaction(() => {
+          this.db.exec(sql);
+          this.db
+            .prepare('DELETE FROM schema_version WHERE version = ?')
+            .run(step.toVersion);
+        });
+        run();
+        out.rolledBack.push({
+          toVersion: step.toVersion,
+          file: path.basename(step.rollbackFile),
+        });
+      } catch (e: any) {
+        out.failed = {
+          toVersion: step.toVersion,
+          file: path.basename(step.rollbackFile),
+          error: e?.message ?? String(e),
+        };
+        return out;
+      }
+    }
+
+    return out;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #36, closes #37.

Replaces the ad-hoc "try `ALTER TABLE`, catch duplicate column" pattern in `DatabaseService.initializeSchema()` with a real versioned migration system driven by the existing `schema_version` ledger.

## What changed

### `MigrationService` (`src/services/migration-service.ts`)
- `discover()` — scans `src/database/` for `schema_update_<from>_TO_<to>.sql`, parses `from`/`to`, pairs with an optional `.down.sql` sibling.
- `status()` — reads `schema_version`, splits into applied vs pending, computes `currentVersion`.
- `migrate()` — applies each pending step **inside a transaction** that ends with `INSERT INTO schema_version`. A crash mid-step rolls the whole step back — no half-applied state.
- `rollback(N)` — runs the paired `.down.sql` in reverse order; removes the matching `schema_version` row in the same transaction.

### Auto-apply on startup
`DatabaseService.initializeSchema()` now runs the `MigrationService` after the monolithic `schema.sql` and the capability `ALTER TABLE`s. Set `IMAP_MCP_SKIP_MIGRATIONS=1` to disable (used by the CLI).

### CLI
| Command | What it does |
|---|---|
| `npm run migrate` / `make migrate` | apply pending migrations |
| `npm run migrate:status` / `make migrate-status` | current version + pending/applied list |
| `npm run migrate:dry-run` / `make migrate-dry-run` | report without writing |
| `npm run migrate:rollback` / `make migrate-rollback N=2` | rollback last N |

### Release manifest (#37)
`src/database/migrations-manifest.json` lists each release step with `from`/`to`/`description`/`rollbackFile`. Kept in lockstep with `schema.sql`'s `INSERT OR IGNORE` version stamps.

### Rollback example
`schema_update_1.6.0_TO_1.7.0.down.sql` drops `tool_results` + `result_attachments` (the tables from PR #94), demonstrating the rollback contract. Earlier migrations can get `.down.sql` added incrementally.

### `schema.sql` now stamps all versions 1.0.0 → 1.7.0
Fresh DBs boot directly to `1.7.0` via `INSERT OR IGNORE`, so the legacy `schema_update_1.0`–`1.6` files never fire for new installs. They still apply on old DBs that predate some of those stamps.

## How the two init paths behave

| Scenario | `initializeSchema()` flow |
|---|---|
| Fresh install | `schema.sql` creates everything, stamps 1.0–1.7 → migrator sees 0 pending |
| Pre-migration-system DB (older data) | `schema.sql` `CREATE IF NOT EXISTS` fills gaps, stamps missing versions → migrator sees 0 pending |
| Mid-version DB with some migrations missing from the ledger | migrator applies only the missing steps, each in its own transaction |

## Test plan

- [x] `npm run build` — clean
- [x] Fresh DB: `migrate:status` shows `currentVersion=1.7.0, pendingCount=0`
- [x] Rollback: `migrate:rollback` runs the `.down.sql` for 1.7.0 and removes the ledger row (verified `tool_results` dropped, schema_version no longer has 1.7.0)
- [x] Dry-run returns empty diff on a current DB
- [ ] Upgrade test on a copy of a real pre-1.7 user DB

## Not included (deferred)
- Rollback `.down.sql` files for versions 1.0–1.6 — previous migrations are purely additive and `schema.sql` supersedes them on fresh DBs.
- Automatic backup before migrate — `scripts/backup.sh` exists; wiring it into the runner was deliberately skipped to keep this PR focused. Can be a one-line call added later.

Generated with Claude Code
