### PR TITLE
release: v2.15.0 — bump + CHANGELOG + docs for v2.0 (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,79 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.0] - 2026-04-30
+
+### v2.0 Reliability & Attachments — full ship
+
+Completes the v2.0 spec (tracker #97). Four work packages, all merged:
+
+- **WP4** Sent Folder Placement (#98 / PR #110)
+- **WP3** SMTP Send Hardening (#99 / PR #111)
+- **WP1** Attachment-by-Reference (#100 / PR #112)
+- **WP2** Attachment Staging API (#101 / PR #113)
+
+Tool surface: **80 → 91** (+11). Schema: **1.7.0 → 1.10.0** (3 reversible migrations).
+
+#### ✨ Added
+
+**Sent Folder Placement (WP4, PR #110)**
+- `imap_send_email` now appends sent messages to the user's IMAP Sent folder by default. Resolution chain: cache → SPECIAL-USE `\Sent` (RFC 6154) → provider preset (Gmail / Outlook / iCloud / Fastmail / Yahoo / Hostinger / Zoho / GMX / ProtonMail / Mailbox.org / Posteo) → fallback name probe → optional auto-create → failed.
+- New params on `imap_send_email`: `appendToSent` (default `true`), `sentFolderOverride`, `forceAppendToSent`, `isReply`.
+- Bcc preserved in the Sent copy per RFC 5322 §3.6.3 (via `MailComposer` with `keepBcc=true`); SMTP delivery path still strips Bcc as required.
+- Gmail special-case: APPEND auto-skipped because Gmail server-copies sent messages (override with `forceAppendToSent`).
+- Structured `result` codes: `sent_and_archived`, `sent_not_archived`, `send_failed`. APPEND failure does **not** fail the SMTP send.
+- Durable APPEND retry queue: failed APPENDs queued AES-256-GCM encrypted, retried every 5 min for 24 h, surfaced via `imap_list_unarchived_sends`.
+- New tools: `imap_test_sent_folder`, `imap_list_unarchived_sends`.
+
+**SMTP Send Hardening (WP3, PR #111)**
+- Pooled SMTP transports via nodemailer pool, keyed by accountId; configurable max-connections / idle-timeout / max-lifetime / health-check.
+- Retry classifier with 4 categories: transient / permanent / authentication / configuration. Exponential backoff with jitter, default 3 attempts / 1 s base / 30 s cap. Auth failures explicitly do **not** retry.
+- Provider-aware error guidance for the common auth-failure modes (Gmail app passwords, Outlook modern auth, Yahoo / iCloud / Fastmail app passwords, ProtonMail Bridge).
+- Per-account SMTP metrics: send total, success/failure, retry counts split by category, durations, last-error.
+- New tools: `imap_test_smtp` (TLS info, EHLO capabilities, AUTH methods, RTT, optional verbose transcript), `imap_get_smtp_metrics`, `imap_reset_smtp_metrics`.
+
+**Attachment-by-Reference (WP1, PR #112)**
+- New `imap_send_email` params: `attachmentPaths` (string[]), `attachmentContentTypes` (string[]), `attachmentFilenames` (string[]). Server reads, validates, encodes — no base64 in the JSON payload.
+- Validation gate: absolute path required; literal `..` segments rejected before realpath; `fs.realpath` then containment check inside allowed dirs (allowed dirs themselves realpath'd up front to handle e.g. macOS `/tmp` → `/private/tmp` symlinks); regular-file + readable + per-file size cap + aggregate size cap.
+- Multi-tenant per-user override: `users.allowed_attachment_dirs` column (CSV) takes precedence over the global `IMAP_MCP_ALLOWED_ATTACHMENT_DIRS`.
+- MIME detection via `mime-types`; filenames sanitized per RFC 2183 (separators → `_`, leading dots stripped, control chars dropped, capped at 255 bytes).
+- Existing base64 `content` workflow unchanged.
+
+**Attachment Staging API (WP2, PR #113)**
+- 4-step chunked upload: `imap_attachment_stage_init` → `imap_attachment_stage_append × N` → `imap_attachment_stage_finalize` → `imap_send_email stagedAttachmentIds=[...]`. Or `imap_attachment_stage_cancel` to discard.
+- Out-of-order chunks reassemble correctly; duplicate `chunkIndex` is idempotent.
+- Storage: `{stagingDir}/{userId}/{stagingId}/chunk-NNNNNN.bin`; finalize streams through SHA-256 and concatenates into `assembled.bin`.
+- Per-user disk quota enforced at init (`IMAP_MCP_MAX_STAGING_BYTES_PER_USER`, default 500 MiB). Default 1-hour TTL, configurable per session.
+- 15-min GC sweep drops expired sessions; consumed sessions cleaned on send success.
+- New tools: `imap_attachment_stage_init`, `imap_attachment_stage_append`, `imap_attachment_stage_finalize`, `imap_attachment_stage_cancel`, `imap_list_staged_attachments`.
+
+#### 🛠️ Changed
+
+- `imap_send_email` returns a structured `result` field: `sent_and_archived` / `sent_not_archived` / `send_failed` / `attachment_validation_failed` / `staged_attachments_not_found` / `staged_attachments_unavailable` / `staged_attachments_unauthorized`. Existing callers that only checked `success: true` still work but now also have actionable diagnostic info on failure paths.
+- `imap_send_email`'s `attachments[]` legacy form is unchanged; new `attachmentPaths`, `stagedAttachmentIds`, and additional/optional params are additive.
+
+#### 🐛 Fixed
+
+- **`imap_append_message` had been silently failing** with "Command failed" since it was added (PR #52). The wrapper passed `{ flags, internalDate }` as a single object to ImapFlow's `client.append()` whose API takes `(path, content, flags, idate)` as **positional args**. Surfaced during WP4 verification against a real IMAP server. Affects every prior caller of `imap_append_message`.
+
+#### 📊 Schema migrations (1.7.0 → 1.10.0, all reversible)
+
+- `1.7.0 → 1.8.0` — `sent_folder_cache` + `append_retry_queue` (WP4)
+- `1.8.0 → 1.9.0` — `users.allowed_attachment_dirs` column (WP1)
+- `1.9.0 → 1.10.0` — `attachment_staging` table (WP2)
+
+#### 🛡️ Backward compatibility
+
+No breaking changes. Existing tool invocations without the new params behave identically (defaults preserve prior behavior; e.g., `appendToSent` defaults to `true` but Gmail auto-skips so no unexpected duplicates). All 17 `IMAP_MCP_*` env vars from earlier releases continue to work; new ones are additive.
+
+#### 🧪 Verification
+
+Each WP shipped with a live-data harness that ran against real IMAP/SMTP accounts. Results captured in the per-PR descriptions:
+- WP4: 4/4 against Hostinger + Gmail
+- WP3: 7/7 (classifier table + provider lookup + backoff + live `testSmtp` + pool reuse + auth-no-retry)
+- WP1: 15/15 (validator gate cases)
+- WP2: 8/8 (10 MiB chunked upload SHA-256 match, out-of-order, duplicate, quota, cancel, GC, multi-user)
+
 ## [2.14.0] - 2026-04-29
 
 ### Anthropic SDK Alignment & Claude Desktop Extension (.mcpb)

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -202,6 +202,151 @@ For each account in parallel:
 
 ---
 
+## 8. Sending an attachment via path (v2.0)
+
+**You:** Send the Q1 report from `~/Documents/imap-attachments/q1.pdf` to `cfo@example.com`.
+
+**Claude:** I'll use `attachmentPaths` so you don't have to base64 the PDF into the request.
+
+> *Tool call: `imap_send_email`*
+> ```json
+> {
+>   "accountId": "...",
+>   "to": "cfo@example.com",
+>   "subject": "Q1 Report",
+>   "text": "Attached.",
+>   "attachmentPaths": ["/Users/me/Documents/imap-attachments/q1.pdf"]
+> }
+> ```
+
+**Result:**
+
+```json
+{
+  "success": true,
+  "messageId": "<...@bitterfield.com>",
+  "result": "sent_and_archived",
+  "archive": { "folder": "INBOX.Sent", "uid": 642, "method": "special_use", "cacheHit": true }
+}
+```
+
+**Claude:** Sent and archived to the Sent folder (resolved via SPECIAL-USE — cached for 24 hours).
+
+If the path isn't whitelisted, Claude gets a structured error:
+
+```json
+{
+  "success": false,
+  "result": "attachment_validation_failed",
+  "errors": ["Path resolves outside allowed dirs: /etc/passwd -> /etc/passwd"],
+  "errorDetails": [{ "kind": "outside-allowed-dirs", "path": "/etc/passwd", "resolved": "/etc/passwd" }]
+}
+```
+
+The configured allowed directories live in `IMAP_MCP_ALLOWED_ATTACHMENT_DIRS` (or `users.allowed_attachment_dirs` per-user).
+
+---
+
+## 9. Chunked upload from a web client (v2.0)
+
+A web UI can't put files on the server's filesystem, so it uses the staging API instead.
+
+**Client (browser):**
+
+```js
+// Read the file
+const file = input.files[0];
+
+// 1. init
+const { stagingId, chunkSizeBytes } = await mcp.call('imap_attachment_stage_init', {
+  filename: file.name,
+  expectedSize: file.size,
+  contentType: file.type,
+});
+
+// 2. upload in chunks (256 KiB by default)
+for (let off = 0, idx = 0; off < file.size; off += chunkSizeBytes, idx++) {
+  const slice = file.slice(off, off + chunkSizeBytes);
+  const buf = new Uint8Array(await slice.arrayBuffer());
+  const chunkData = btoa(String.fromCharCode(...buf));  // base64
+  await mcp.call('imap_attachment_stage_append', {
+    stagingId,
+    chunkIndex: idx,
+    chunkData,
+    isFinal: off + chunkSizeBytes >= file.size,  // auto-finalize on last chunk
+  });
+}
+```
+
+**Then prompt:**
+
+> Send a quick note to ops@example.com with the file I just uploaded.
+
+> *Tool call: `imap_send_email`*
+> ```json
+> {
+>   "accountId": "...",
+>   "to": "ops@example.com",
+>   "subject": "Logs",
+>   "text": "Attached the bundle from this morning.",
+>   "stagedAttachmentIds": ["<the stagingId>"]
+> }
+> ```
+
+The server attaches the assembled blob and deletes the staging session on send success. Out-of-order chunk uploads are fine (each chunk is keyed by index, not arrival order).
+
+---
+
+## 10. Diagnosing a flaky SMTP server (v2.0)
+
+**You:** I'm getting intermittent send failures on my Yahoo account. What's wrong?
+
+**Claude:**
+
+> *Tool call: `imap_test_smtp`*
+> `{ "accountId": "...", "verbose": false }`
+
+**Result:**
+
+```json
+{
+  "success": true,
+  "smtpHost": "smtp.mail.yahoo.com",
+  "secure": false,
+  "tlsVersion": "TLSv1.3",
+  "tlsCipher": "TLS_AES_256_GCM_SHA384",
+  "rttMs": 387,
+  "authResult": "ok",
+  "capabilities": ["STARTTLS", "PIPELINING", "SIZE", "8BITMIME", "AUTH"],
+  "providerGuidance": "Yahoo / AOL require an app password. Generate one in Account Security → App passwords."
+}
+```
+
+> *Tool call: `imap_get_smtp_metrics`*
+> `{ "accountId": "..." }`
+
+**Result:**
+
+```json
+{
+  "accounts": [{
+    "smtpHost": "smtp.mail.yahoo.com",
+    "sendTotal": 17,
+    "sendSuccessTotal": 14,
+    "sendFailureTotal": 3,
+    "retryTotal": 6,
+    "retryByCategory": { "transient": 6, "permanent": 0, "authentication": 0, "configuration": 0 },
+    "lastSendDurationMs": 2104,
+    "lastError": null
+  }],
+  "pool": { "configured": 1 }
+}
+```
+
+**Claude:** Yahoo's SMTP is up (TLS 1.3, auth ok, 387 ms RTT). Of your 17 recent sends, 3 failed initially but **all 6 retries were classified as transient** (4xx codes, connection blips) — no auth failures, no permanent errors. Last error is null, meaning the eventual outcome was successful for everything attempted. The flakiness is on Yahoo's side; the retry classifier is absorbing it.
+
+---
+
 ## Tips for working with the tools
 
 - **Default to `responseMode='auto'`** — the server picks the right tier (inline / handle / file) based on size. Override only when you know better.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An enterprise-grade Model Context Protocol (MCP) server that provides production
 
 ## Features
 
+**91 MCP tools** across email/folder/account/category/scoring/subscription/dns-firewall/usercheck/staging/diagnostics — every IMAP4rev2 (RFC 9051) operation we use is exposed.
+
 ### Core Features
 - 🔐 **Secure Account Management**: Encrypted credential storage with AES-256 encryption
 - 🚀 **Connection Pooling**: Efficient IMAP connection management
@@ -17,6 +19,14 @@ An enterprise-grade Model Context Protocol (MCP) server that provides production
 - 🌐 **Web-Based Setup Wizard**: Easy account configuration with provider presets
 - 📱 **15+ Email Providers**: Pre-configured settings for Gmail, Outlook, Yahoo, and more
 - 🔗 **Auto SMTP Configuration**: Automatic SMTP settings based on IMAP provider
+
+### v2.0 Reliability & Attachments (v2.15.0+)
+
+- **Auto-Sent-folder placement**: every `imap_send_email` archives to the right Sent folder by provider (Gmail / Outlook / iCloud / Fastmail / Yahoo / Hostinger / Zoho / GMX / ProtonMail). Bcc preserved in the archive copy per RFC 5322 §3.6.3. Failures queue for background retry, not lost.
+- **Pooled SMTP with classified retry**: nodemailer pool, exponential backoff for transient failures, immediate surface (no retry) for auth failures with provider-specific guidance (e.g. "Gmail requires an app password, generate at...").
+- **Path-based attachments** (`attachmentPaths`): pass absolute file paths instead of base64. Server validates against an allowed-dirs whitelist (with per-user override), realpath + symlink-target check, size caps, RFC 2183 filename sanitization.
+- **Chunked attachment uploads**: for clients without server filesystem access. 4-tool workflow (`stage_init` → `stage_append × N` → `stage_finalize` → `imap_send_email stagedAttachmentIds=[...]`). Out-of-order chunks reassemble; duplicate `chunkIndex` is idempotent; SHA-256 verification on finalize.
+- **Diagnostic tools**: `imap_test_smtp`, `imap_test_sent_folder`, `imap_get_smtp_metrics`, `imap_list_unarchived_sends`, `imap_list_staged_attachments`.
 
 ### Enterprise Features (Pro Edition)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,13 +25,18 @@ src/
 │   │                              #   auto-migration on construct
 │   ├── migration-service.ts      # Schema_version ledger + migration runner
 │   ├── imap-service.ts           # ImapFlow connection pool, search/fetch/store/move
-│   ├── smtp-service.ts           # nodemailer-based send
+│   ├── smtp-service.ts           # nodemailer pool, retry classification (WP3)
+│   ├── smtp-error-classifier.ts  # WP3: transient/permanent/auth/config + provider guidance
+│   ├── sent-folder-service.ts    # WP4: 6-step Sent folder resolution + cache
+│   ├── append-retry-service.ts   # WP4: durable encrypted retry queue for failed APPENDs
+│   ├── attachment-validator.ts   # WP1: path validation gate (allowed dirs, realpath, size)
+│   ├── attachment-staging-service.ts  # WP2: chunked-upload sessions + GC
 │   ├── results-service.ts        # Tool-result cache (handle/file modes), LRU eviction
 │   ├── file-export-service.ts    # Encrypted JSON/JSONL writer for file-mode results
 │   └── encryption/               # Key storage paths (keyring vs file)
-├── tools/                        # 81 MCP tools across 12 files
+├── tools/                        # 91 MCP tools across 12 files
 │   ├── account-tools.ts          # 8  add/remove/list/share accounts
-│   ├── email-tools.ts            # 22 search/get/mark/delete/move/copy/send/bulk
+│   ├── email-tools.ts            # 32 search/get/mark/delete/move/copy/send/bulk + WP1/2/3/4
 │   ├── folder-tools.ts           # 6  list/status/create/delete/rename
 │   ├── meta-tools.ts             # 7  about/list-tools/connect/disconnect/metrics
 │   ├── capability-tools.ts       # 1  imap_get_capabilities
@@ -267,6 +272,50 @@ Claude Desktop captures stderr to per-server log files:
 | Linux | `~/.local/state/Claude/logs/mcp-server-imap-mcp-pro.log` |
 
 ---
+
+## v2.0 send pipeline (WP1 + WP2 + WP3 + WP4)
+
+`imap_send_email` orchestrates four cooperating pieces:
+
+```
+                          ┌─────────────────────────────────────────────────┐
+                          │  imap_send_email handler                        │
+                          └─────────────────────────────────────────────────┘
+                                                │
+                  ┌─────────────────────────────┼─────────────────────────────┐
+                  ▼                             ▼                             ▼
+   ┌────────────────────────┐   ┌────────────────────────┐   ┌──────────────────────────┐
+   │ AttachmentValidator    │   │ AttachmentStaging      │   │ legacy attachments[]     │
+   │  (WP1: paths)          │   │  (WP2: stagedIds)      │   │  (base64 inline)         │
+   └────────────┬───────────┘   └────────────┬───────────┘   └────────────┬─────────────┘
+                └─────────────────┬──────────┴──────────────────────┬─────┘
+                                  ▼                                 ▼
+                          ┌──────────────────────────────────────────┐
+                          │ SmtpService.sendEmailWithCopy            │
+                          │  - MailComposer w/ keepBcc=true (WP4)    │
+                          │  - pool + retry classifier (WP3)         │
+                          └────────────┬─────────────────────────────┘
+                                       │ rawMessage (Bcc preserved)
+                                       ▼
+                          ┌──────────────────────────────────────────┐
+                          │ SentFolderService.resolveSentFolder      │
+                          │  cache → SPECIAL-USE → preset → fallback │
+                          └────────────┬─────────────────────────────┘
+                                       │
+                                       ▼ on failure → AppendRetryService.enqueue
+                          ┌──────────────────────────────────────────┐
+                          │ ImapService.appendMessage                │
+                          │  (positional flags, idate)               │
+                          └──────────────────────────────────────────┘
+```
+
+Result codes returned to the caller:
+
+- `sent_and_archived` — both stages OK
+- `sent_not_archived` — SMTP success but APPEND failed (queued for retry, see `imap_list_unarchived_sends`)
+- `send_failed` — SMTP failed; classified error with provider guidance
+- `attachment_validation_failed` — `attachmentPaths` validation rejected an entry
+- `staged_attachments_*` — staging-related failures (not found / unauthorized / unavailable)
 
 ## References
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ const {
 
     // 2. Construct McpServer with explicit capabilities (closes #80)
     const server = new McpServer(
-      { name: 'imap-mcp-pro', version: '2.14.0' },
+      { name: 'imap-mcp-pro', version: '2.15.0' },
       { capabilities: SERVER_CAPABILITIES }
     );
 
@@ -175,7 +175,7 @@ async function buildToolsManifest(): Promise<unknown> {
 
   // Construct the same server object but never call server.connect().
   const tmpServer = new McpServer(
-    { name: 'imap-mcp-pro', version: '2.14.0' },
+    { name: 'imap-mcp-pro', version: '2.15.0' },
     { capabilities: SERVER_CAPABILITIES }
   );
   const tmpDb = new DatabaseService();


### PR DESCRIPTION
## Summary

Release prep for **v2.15.0** — captures the v2.0 reliability/attachments work (tracker #97) into a shipped version.

## What's in this PR

- **Version bump**: `package.json` 2.14.0 → 2.15.0; `McpServer` ctor strings in `src/index.ts` updated at both call sites
- **CHANGELOG.md**: full `[2.15.0]` section above `[2.14.0]` covering all four WPs with the headline `imap_append_message` bug fix that surfaced during WP4 verification
- **README.md**: "91 MCP tools" headline + new "v2.0 Reliability & Attachments (v2.15.0+)" feature section
- **EXAMPLES.md**: three new worked examples — sending via `attachmentPaths`, chunked upload from a web client, diagnosing a flaky SMTP server with `imap_test_smtp` + `imap_get_smtp_metrics`
- **docs/ARCHITECTURE.md**: services/ tree refreshed for the 5 new modules, tool count corrected, new "v2.0 send pipeline" section with an ASCII diagram + the 7 documented `result` codes returned by `imap_send_email`

## Test plan

- [x] `npm run build` clean at v2.15.0
- [x] 91 tools register (was 80 before this session, +11 from v2.0 effort)
- [x] `--validate-config` passes
- [x] Server starts, handshake completes, SIGTERM clean

## Next steps after merge

1. Tag `v2.15.0` and push the tag — triggers `.github/workflows/build-dxt.yml` to build 4 platform `.mcpb` archives and attach them to the GH Release with SHA-256 checksums
2. Verify the `.mcpb` install in Claude Desktop
3. Open follow-up tracking issue for the Zod v4 migration to unlock SDK 1.23+

🤖 Generated with [Claude Code](https://claude.com/claude-code)
