### PR TITLE
release: v2.16.0 — node:sqlite, .mcpb fixes, tool annotations, breaker fix (closes #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.0] - 2026-04-30
+
+### Hardened Claude Desktop install path
+
+This release makes the `.mcpb` extension actually install and run inside Claude Desktop on macOS — the v2.15.0 build was blocked by macOS library validation rejecting our locally-built `better_sqlite3.node` (different Apple Team ID from Anthropic's). Switching to `node:sqlite` removes the native binding entirely; the runtime now inherits Claude Desktop's process signature and loads cleanly.
+
+Tool count: 91 → 93.
+
+#### 🛠️ Changed
+
+- **`better-sqlite3` → `node:sqlite`** (Node 22.5+ built-in). Same SQLite file format → existing `~/.imap-mcp/data.db` opens transparently with no migration required. The native binding ships inside Node itself, sidestepping the library-validation rejection that affects any third-party `.node` in a hardened/notarized macOS app. Issue #117 (long-running bulk-operation persistence) leans on this.
+  - `database-service.ts` — `import { DatabaseSync } from 'node:sqlite'` replaces `import Database from 'better-sqlite3'`. All 33 SQL `@param` placeholders converted to `$param` (node:sqlite doesn't accept the `@`-prefix).
+  - `migration-service.ts` — `db.transaction(fn)` (better-sqlite3 specific) replaced with a manual `BEGIN / COMMIT / ROLLBACK` helper.
+  - `results-service.ts`, `append-retry-service.ts` — BLOB-read sites now coerce `Uint8Array` (node:sqlite return type for BLOB) to `Buffer` before `.toString('hex')`.
+  - `attachment-staging-service.ts`, `database-service.ts` — `stmt.all() as T[]` casts updated to `as unknown as T[]` for the stricter `Record<string, SQLOutputValue>[]` return type.
+  - `dxt/build.mjs` — `npm rebuild better-sqlite3 --runtime=electron --target=...` step removed (no native deps to rebuild).
+  - `better-sqlite3` and `@types/better-sqlite3` removed from dependencies.
+
+- **DXT manifest spec compliance** — multiple validation errors when installing the v2.15.0 `.mcpb`:
+  - `dxt_version: "0.1"` → `manifest_version: "0.3"` (current spec).
+  - `tools[]` entries no longer include `inputSchema` (DXT spec only allows `name` + `description`; full schemas are served via runtime `tools/list`).
+  - `user_config.log_level` no longer uses `enum` (the `string`/`number`/`boolean`/`directory`/`file` types are the only valid `type` values; enums are surfaced via description).
+  - `dxt/build.mjs` updated accordingly.
+
+- **MCP tool annotations** for all 91 → 93 tools. Drives Claude Desktop's "Tool Permissions" UI: tools appear under **Read-only** vs **Write/delete** groups based on `readOnlyHint` and `destructiveHint`; tools that hit external systems (IMAP/SMTP/UserCheck/DNS) also carry `openWorldHint: true`.
+  - New `src/tools/annotations.ts` — central table mapping every tool name to `{ readOnlyHint, destructiveHint, idempotentHint?, openWorldHint? }`.
+  - `src/tools/index.ts` transparently injects annotations on every `server.registerTool` call — no churn across the 12 tool files.
+
+- **Build script bundle pruning** — `dxt/build.mjs` now drops `electron` and `@electron/*` from the bundled `node_modules` (kept as a devDep for native-binding rebuild experiments). Bundle size: 33 MB.
+
+#### 🐛 Fixed
+
+- **Circuit breaker false-positive OPEN state** (Issue #116). Hostinger and other providers that aggressively close idle IMAP connections were tripping the breaker via the `client.on('error')` socket-event handler — even though the auto-reconnect path absorbed every event. Fix: don't increment the breaker on transient socket events; only on hard failures (auth, IMAP-disabled, all-retries-exhausted).
+- **Circuit breaker / metrics inconsistency** — `recordCircuitBreakerFailure` now also bumps `metadata.metrics.failedOperations` and `totalOperations` so a tripped breaker always correlates with a non-zero failure count in `imap_get_metrics` output.
+- **`imap_append_message` (PR from WP4 in v2.15.0) — already shipped, noting here for completeness:** ImapFlow's `append(path, content, flags?, idate?)` takes flags + idate as positional args, not as a single options object. The wrapper had been silently failing for every prior caller.
+
+#### ✨ Added
+
+- **`imap_get_circuit_breaker`** — read-only diagnostic returning the per-account breaker state, failure count, threshold, last-failure reason, and timeout. Use to understand why operations are being blocked when `imap_get_metrics` shows zero failures.
+- **`imap_reset_circuit_breaker`** — destructive tool that manually resets the breaker to CLOSED with zero counters. Useful when the 60s `setTimeout` HALF_OPEN transition feels too slow.
+- **MCP tool annotations** — all 93 tools categorized; Claude Desktop's Tool Permissions UI now groups them automatically.
+
+#### 📦 Distribution
+
+- `.mcpb` install path verified end-to-end on macOS arm64. Server reports `serverInfo: { name: "imap-mcp-pro", version: "2.16.0" }` to Claude Desktop, all 93 tools are listed via `tools/list`, and tool calls succeed against a live `~/.imap-mcp/data.db`.
+
+#### 🛡️ Backward compatibility
+
+- No schema changes (DB stays at 1.10.0).
+- All env vars from v2.15.0 continue to work.
+- All tool surfaces preserved; +2 new diagnostic tools.
+
 ## [2.15.0] - 2026-04-30
 
 ### v2.0 Reliability & Attachments — full ship

--- a/dxt/build.mjs
+++ b/dxt/build.mjs
@@ -97,6 +97,8 @@ function pruneNodeModules() {
     'typescript',
     'tsx',
     'nodemon',
+    'electron',           // 300+ MB — only used as a devDep for testing
+    '@electron',          // any sub-packages
   ];
   for (const d of drop) {
     rmrf(path.join(nm, d));
@@ -122,16 +124,18 @@ function pruneNodeModules() {
 }
 pruneNodeModules();
 
-// 4. Rebuild native modules for the target platform.
-// On a macOS arm64 host this is a no-op for arm64 builds, but ensures
-// better-sqlite3 has freshly-built bindings. Skip with --skip-rebuild.
-if (!skipRebuild) {
-  try {
-    run('npm rebuild better-sqlite3', { cwd: serverDir });
-  } catch (e) {
-    log(`WARN: better-sqlite3 rebuild failed (${e.message}); bindings as-shipped will be used`);
-  }
-}
+// 4. Native module rebuild — no longer needed.
+//
+// We migrated from better-sqlite3 to node:sqlite (Node 22.5+ built-in)
+// in v2.16. node:sqlite ships inside Node itself, so its native binding
+// inherits the host process's code signature. This means it loads cleanly
+// inside macOS-hardened apps like Claude Desktop, where third-party
+// .node binaries are rejected by library-validation regardless of which
+// Electron headers they were built against.
+//
+// If a future native dep gets reintroduced, mirror the previous
+// `npm rebuild --runtime=electron --target=...` pattern here.
+void skipRebuild;
 
 // 5. Copy assets
 cpr(path.join(dxtDir, 'icon.png'), path.join(buildDir, 'icon.png'));
@@ -158,10 +162,13 @@ try {
   process.exit(1);
 }
 
+// Per the MCPB manifest spec (manifest v0.3), tools entries take only
+// `name` and `description`. The full inputSchema lives on the server
+// itself and is fetched via tools/list at runtime; the manifest is just
+// for the extension store / settings UI.
 manifest.tools = toolsManifest.tools.map((t) => ({
   name: t.name,
   description: t.description ?? '',
-  inputSchema: t.inputSchema ?? { type: 'object' },
 }));
 
 log(`merged ${manifest.tools.length} tools into manifest`);

--- a/dxt/manifest.template.json
+++ b/dxt/manifest.template.json
@@ -1,5 +1,5 @@
 {
-  "dxt_version": "0.1",
+  "manifest_version": "0.3",
   "name": "imap-mcp-pro",
   "display_name": "IMAP MCP Pro",
   "version": "__VERSION__",
@@ -70,8 +70,7 @@
     "log_level": {
       "type": "string",
       "title": "Log Level",
-      "description": "Verbosity of server logs. Logs are captured by Claude Desktop at ~/Library/Logs/Claude/mcp-server-imap-mcp-pro.log (macOS).",
-      "enum": ["DEBUG", "INFO", "WARNING", "ERROR"],
+      "description": "Server log verbosity. One of: DEBUG, INFO, WARNING, ERROR. Logs are captured by Claude Desktop at ~/Library/Logs/Claude/mcp-server-imap-mcp-pro.log (macOS) or %APPDATA%\\Claude\\logs\\ (Windows).",
       "default": "INFO",
       "required": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,18 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "@journeyapps/sqlcipher": "^5.3.1",
         "@modelcontextprotocol/sdk": "^1.22.0",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/nodemailer": "^6.4.17",
-        "better-sqlite3": "^12.8.0",
         "body-parser": "^2.2.0",
         "chalk": "^5.4.1",
         "commander": "^14.0.0",
@@ -45,9 +43,42 @@
         "@types/mailparser": "^3.4.6",
         "@types/mime-types": "^3.0.1",
         "@types/node": "^24.0.14",
+        "electron": "^41.3.0",
         "nodemon": "^3.1.10",
         "tsx": "^4.20.3",
         "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -595,13 +626,30 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*"
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@types/body-parser": {
@@ -613,6 +661,19 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/@types/connect": {
@@ -660,6 +721,13 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -673,6 +741,16 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mailparser": {
       "version": "3.4.6",
@@ -700,12 +778,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
-      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/nodemailer": {
@@ -731,6 +809,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
@@ -752,6 +840,17 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@zone-eu/mailsplit": {
@@ -916,20 +1015,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -941,15 +1026,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -1003,6 +1079,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1050,6 +1135,16 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -1072,6 +1167,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1174,6 +1298,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone-response/node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/color-support": {
@@ -1350,6 +1497,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -1360,6 +1536,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delegates": {
@@ -1385,6 +1580,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -1473,6 +1676,25 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/electron": {
+      "version": "41.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.3.0.tgz",
+      "integrity": "sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^24.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
@@ -1518,6 +1740,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1547,6 +1779,14 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/esbuild": {
       "version": "0.25.6",
@@ -1595,6 +1835,20 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1711,6 +1965,27 @@
         "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1733,11 +2008,15 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1792,6 +2071,21 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -1964,6 +2258,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
@@ -2017,6 +2327,43 @@
         "node": ">= 6"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2029,6 +2376,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2037,6 +2417,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -2113,6 +2507,13 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2131,6 +2532,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -2419,11 +2834,36 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/keytar": {
       "version": "7.9.0",
@@ -2441,6 +2881,16 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/leac": {
       "version": "0.6.0",
@@ -2512,6 +2962,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/mailparser": {
       "version": "3.7.5",
       "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.7.5.tgz",
@@ -2580,6 +3040,20 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2856,6 +3330,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/npmlog": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
@@ -2888,6 +3375,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -2976,6 +3474,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/parseley": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
@@ -3033,6 +3541,13 @@
       "funding": {
         "url": "https://ko-fi.com/killymxi"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3135,6 +3650,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3194,6 +3719,19 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -3295,6 +3833,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3303,6 +3848,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -3335,6 +3893,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/router": {
@@ -3424,6 +4001,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/send": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
@@ -3444,6 +4029,23 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serve-static": {
@@ -3678,6 +4280,14 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3747,6 +4357,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
       }
     },
     "node_modules/supports-color": {
@@ -3901,6 +4524,20 @@
         "node": "*"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -3943,10 +4580,20 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -4079,6 +4726,17 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {
@@ -63,6 +63,7 @@
     "@types/mailparser": "^3.4.6",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^24.0.14",
+    "electron": "^41.3.0",
     "nodemon": "^3.1.10",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3"
@@ -71,9 +72,7 @@
     "@iarna/toml": "^2.2.5",
     "@journeyapps/sqlcipher": "^5.3.1",
     "@modelcontextprotocol/sdk": "^1.22.0",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/nodemailer": "^6.4.17",
-    "better-sqlite3": "^12.8.0",
     "body-parser": "^2.2.0",
     "chalk": "^5.4.1",
     "commander": "^14.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ const {
 
     // 2. Construct McpServer with explicit capabilities (closes #80)
     const server = new McpServer(
-      { name: 'imap-mcp-pro', version: '2.15.0' },
+      { name: 'imap-mcp-pro', version: '2.16.0' },
       { capabilities: SERVER_CAPABILITIES }
     );
 
@@ -175,7 +175,7 @@ async function buildToolsManifest(): Promise<unknown> {
 
   // Construct the same server object but never call server.connect().
   const tmpServer = new McpServer(
-    { name: 'imap-mcp-pro', version: '2.15.0' },
+    { name: 'imap-mcp-pro', version: '2.16.0' },
     { capabilities: SERVER_CAPABILITIES }
   );
   const tmpDb = new DatabaseService();

--- a/src/services/append-retry-service.ts
+++ b/src/services/append-retry-service.ts
@@ -131,9 +131,11 @@ export class AppendRetryService {
     const now = Date.now();
 
     // Drop expired entries first.
-    const expired = this.db.getDb()
-      .prepare('DELETE FROM append_retry_queue WHERE expires_at <= ?')
-      .run(now).changes;
+    const expired = Number(
+      this.db.getDb()
+        .prepare('DELETE FROM append_retry_queue WHERE expires_at <= ?')
+        .run(now).changes
+    );
 
     const due = this.db.getDb()
       .prepare(`
@@ -149,8 +151,14 @@ export class AppendRetryService {
     let failed = 0;
     for (const row of due) {
       try {
+        // node:sqlite returns BLOB columns as Uint8Array (not Buffer); wrap
+        // so .toString('hex') uses Buffer's encoding-aware impl, not the
+        // generic Object.prototype.toString.
+        const blob = Buffer.isBuffer(row.message_bytes)
+          ? row.message_bytes
+          : Buffer.from(row.message_bytes as Uint8Array);
         const plain = this.db.decryptString(
-          (row.message_bytes as Buffer).toString('hex'),
+          blob.toString('hex'),
           row.message_iv
         );
         const flags = JSON.parse(row.flags);

--- a/src/services/attachment-staging-service.ts
+++ b/src/services/attachment-staging-service.ts
@@ -346,7 +346,7 @@ export class AttachmentStagingService {
     }
     const rows = this.db.getDb()
       .prepare(`SELECT * FROM attachment_staging ${where} ORDER BY created_at DESC LIMIT ?`)
-      .all(...params, limit) as StagingRow[];
+      .all(...params, limit) as unknown as StagingRow[];
     return rows;
   }
 

--- a/src/services/database-service.ts
+++ b/src/services/database-service.ts
@@ -10,7 +10,7 @@
  * Date: 2025-11-05
  */
 
-import Database from 'better-sqlite3';
+import { DatabaseSync } from 'node:sqlite';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
@@ -39,7 +39,7 @@ import {
 import { MigrationService } from './migration-service.js';
 
 export class DatabaseService {
-  private db: Database.Database;
+  private db: DatabaseSync;
   private encryptionKey: Buffer;
   private algorithm = 'aes-256-gcm';
 
@@ -52,10 +52,12 @@ export class DatabaseService {
       fs.mkdirSync(dbDir, { recursive: true });
     }
 
-    // Initialize database
-    this.db = new Database(dbPath, {
-      verbose: config?.verbose ? console.log : undefined
-    });
+    // node:sqlite — same SQLite file format as better-sqlite3, so the
+    // existing DB at dbPath opens transparently. Native module ships with
+    // Node and inherits the host process's code signature, so it loads
+    // inside macOS-hardened apps like Claude Desktop where third-party
+    // .node binaries get rejected by library-validation.
+    this.db = new DatabaseSync(dbPath);
 
     // Set up encryption key
     this.encryptionKey = this.getOrCreateEncryptionKey(dbDir);
@@ -109,7 +111,7 @@ export class DatabaseService {
    * Public access to underlying Database (used by adjacent services that
    * need to share the connection — e.g. ResultsService).
    */
-  getDb(): Database.Database {
+  getDb(): DatabaseSync {
     return this.db;
   }
 
@@ -251,7 +253,7 @@ export class DatabaseService {
   createUser(user: Omit<User, 'created_at' | 'updated_at'>): User {
     const stmt = this.db.prepare(`
       INSERT INTO users (user_id, username, email, organization, is_active, metadata)
-      VALUES (@user_id, @username, @email, @organization, @is_active, @metadata)
+      VALUES ($user_id, $username, $email, $organization, $is_active, $metadata)
     `);
 
     stmt.run({
@@ -280,7 +282,7 @@ export class DatabaseService {
 
   listUsers(): User[] {
     const stmt = this.db.prepare('SELECT * FROM users WHERE is_active = 1 ORDER BY username');
-    return stmt.all() as User[];
+    return stmt.all() as unknown as User[];
   }
 
   updateUser(userId: string, updates: Partial<User>): void {
@@ -288,30 +290,30 @@ export class DatabaseService {
     const values: any = { user_id: userId };
 
     if (updates.username !== undefined) {
-      fields.push('username = @username');
+      fields.push('username = $username');
       values.username = updates.username;
     }
     if (updates.email !== undefined) {
-      fields.push('email = @email');
+      fields.push('email = $email');
       values.email = updates.email;
     }
     if (updates.organization !== undefined) {
-      fields.push('organization = @organization');
+      fields.push('organization = $organization');
       values.organization = updates.organization;
     }
     if (updates.is_active !== undefined) {
-      fields.push('is_active = @is_active');
+      fields.push('is_active = $is_active');
       values.is_active = updates.is_active ? 1 : 0;
     }
     if (updates.metadata !== undefined) {
-      fields.push('metadata = @metadata');
+      fields.push('metadata = $metadata');
       values.metadata = updates.metadata;
     }
 
     fields.push('updated_at = CURRENT_TIMESTAMP');
 
     const stmt = this.db.prepare(`
-      UPDATE users SET ${fields.join(', ')} WHERE user_id = @user_id
+      UPDATE users SET ${fields.join(', ')} WHERE user_id = $user_id
     `);
 
     stmt.run(values);
@@ -345,10 +347,10 @@ export class DatabaseService {
         smtp_host, smtp_port, smtp_secure, smtp_username,
         smtp_password_encrypted, smtp_encryption_iv, is_active
       ) VALUES (
-        @account_id, @user_id, @name, @host, @port, @username,
-        @password_encrypted, @encryption_iv, @tls,
-        @smtp_host, @smtp_port, @smtp_secure, @smtp_username,
-        @smtp_password_encrypted, @smtp_encryption_iv, @is_active
+        $account_id, $user_id, $name, $host, $port, $username,
+        $password_encrypted, $encryption_iv, $tls,
+        $smtp_host, $smtp_port, $smtp_secure, $smtp_username,
+        $smtp_password_encrypted, $smtp_encryption_iv, $is_active
       )
     `);
 
@@ -425,7 +427,7 @@ export class DatabaseService {
       ORDER BY a.name
     `);
 
-    return stmt.all(userId) as Account[];
+    return stmt.all(userId) as unknown as Account[];
   }
 
   listDecryptedAccountsForUser(userId: string): DecryptedAccount[] {
@@ -438,46 +440,46 @@ export class DatabaseService {
     const values: any = { account_id: accountId };
 
     if (updates.name !== undefined) {
-      fields.push('name = @name');
+      fields.push('name = $name');
       values.name = updates.name;
     }
     if (updates.host !== undefined) {
-      fields.push('host = @host');
+      fields.push('host = $host');
       values.host = updates.host;
     }
     if (updates.port !== undefined) {
-      fields.push('port = @port');
+      fields.push('port = $port');
       values.port = updates.port;
     }
     if (updates.username !== undefined) {
-      fields.push('username = @username');
+      fields.push('username = $username');
       values.username = updates.username;
     }
     if (updates.password !== undefined) {
       const passwordData = this.encrypt(updates.password);
-      fields.push('password_encrypted = @password_encrypted');
-      fields.push('encryption_iv = @encryption_iv');
+      fields.push('password_encrypted = $password_encrypted');
+      fields.push('encryption_iv = $encryption_iv');
       values.password_encrypted = passwordData.encrypted;
       values.encryption_iv = passwordData.iv;
     }
     if (updates.tls !== undefined) {
-      fields.push('tls = @tls');
+      fields.push('tls = $tls');
       values.tls = updates.tls ? 1 : 0;
     }
     if (updates.smtp_host !== undefined) {
-      fields.push('smtp_host = @smtp_host');
+      fields.push('smtp_host = $smtp_host');
       values.smtp_host = updates.smtp_host;
     }
     if (updates.smtp_port !== undefined) {
-      fields.push('smtp_port = @smtp_port');
+      fields.push('smtp_port = $smtp_port');
       values.smtp_port = updates.smtp_port;
     }
     if (updates.smtp_username !== undefined) {
-      fields.push('smtp_username = @smtp_username');
+      fields.push('smtp_username = $smtp_username');
       values.smtp_username = updates.smtp_username;
     }
     if (updates.smtp_secure !== undefined) {
-      fields.push('smtp_secure = @smtp_secure');
+      fields.push('smtp_secure = $smtp_secure');
       values.smtp_secure = updates.smtp_secure ? 1 : 0;
     }
     if (updates.smtp_password !== undefined) {
@@ -488,21 +490,21 @@ export class DatabaseService {
       } else {
         // Update SMTP password
         const smtpPasswordData = this.encrypt(updates.smtp_password);
-        fields.push('smtp_password_encrypted = @smtp_password_encrypted');
-        fields.push('smtp_encryption_iv = @smtp_encryption_iv');
+        fields.push('smtp_password_encrypted = $smtp_password_encrypted');
+        fields.push('smtp_encryption_iv = $smtp_encryption_iv');
         values.smtp_password_encrypted = smtpPasswordData.encrypted;
         values.smtp_encryption_iv = smtpPasswordData.iv;
       }
     }
     if (updates.is_active !== undefined) {
-      fields.push('is_active = @is_active');
+      fields.push('is_active = $is_active');
       values.is_active = updates.is_active ? 1 : 0;
     }
 
     fields.push('updated_at = CURRENT_TIMESTAMP');
 
     const stmt = this.db.prepare(`
-      UPDATE accounts SET ${fields.join(', ')} WHERE account_id = @account_id
+      UPDATE accounts SET ${fields.join(', ')} WHERE account_id = $account_id
     `);
 
     stmt.run(values);
@@ -584,7 +586,7 @@ export class DatabaseService {
     const stmt = this.db.prepare(`
       INSERT OR REPLACE INTO unsubscribe_links
       (user_id, account_id, folder, uid, sender_email, subject, unsubscribe_link, list_unsubscribe_header, message_date)
-      VALUES (@user_id, @account_id, @folder, @uid, @sender_email, @subject, @unsubscribe_link, @list_unsubscribe_header, @message_date)
+      VALUES ($user_id, $account_id, $folder, $uid, $sender_email, $subject, $unsubscribe_link, $list_unsubscribe_header, $message_date)
     `);
 
     stmt.run({
@@ -617,7 +619,7 @@ export class DatabaseService {
     query += ' ORDER BY extracted_at DESC';
 
     const stmt = this.db.prepare(query);
-    return stmt.all(...params) as UnsubscribeLink[];
+    return stmt.all(...params) as unknown as UnsubscribeLink[];
   }
 
   // ===================
@@ -636,14 +638,14 @@ export class DatabaseService {
     const stmt = this.db.prepare(`
       INSERT INTO subscription_summary
       (user_id, sender_email, sender_domain, sender_name, unsubscribe_link, unsubscribe_method, category, total_emails, first_seen, last_seen)
-      VALUES (@user_id, @sender_email, @sender_domain, @sender_name, @unsubscribe_link, @unsubscribe_method, @category, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      VALUES ($user_id, $sender_email, $sender_domain, $sender_name, $unsubscribe_link, $unsubscribe_method, $category, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
       ON CONFLICT(user_id, sender_email) DO UPDATE SET
         total_emails = total_emails + 1,
         last_seen = CURRENT_TIMESTAMP,
-        sender_name = COALESCE(@sender_name, sender_name),
-        unsubscribe_link = COALESCE(@unsubscribe_link, unsubscribe_link),
-        unsubscribe_method = COALESCE(@unsubscribe_method, unsubscribe_method),
-        category = @category
+        sender_name = COALESCE($sender_name, sender_name),
+        unsubscribe_link = COALESCE($unsubscribe_link, unsubscribe_link),
+        unsubscribe_method = COALESCE($unsubscribe_method, unsubscribe_method),
+        category = $category
     `);
 
     stmt.run({
@@ -912,7 +914,7 @@ export class DatabaseService {
   createCategory(category: Omit<Category, 'category_id' | 'created_at' | 'updated_at' | 'match_count' | 'last_matched'>): Category {
     const stmt = this.db.prepare(`
       INSERT INTO categories (user_id, account_id, category_name, keywords, target_folder, enabled)
-      VALUES (@user_id, @account_id, @category_name, @keywords, @target_folder, @enabled)
+      VALUES ($user_id, $account_id, $category_name, $keywords, $target_folder, $enabled)
     `);
 
     const result = stmt.run({

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -320,9 +320,16 @@ export class ImapService {
         console.error(`[IMAP] Connection error for account ${accountId}:`, err.message);
         this.updateConnectionState(accountId, ConnectionState.ERROR);
 
-        // Capture failure reason for circuit breaker
-        const errorReason = err.message || 'Connection error';
-        this.recordCircuitBreakerFailure(accountId, errorReason);
+        // Note: we deliberately do NOT trip the circuit breaker on transient
+        // socket events. Idle disconnects are normal for many IMAP servers
+        // (Hostinger, Yahoo, some Dovecot configs drop connections aggressively),
+        // and the auto-reconnect path absorbs them. Tripping the breaker here
+        // produced a false-positive OPEN state with `failedOperations: 0`
+        // because connection-level errors bypass recordOperationMetric.
+        //
+        // Hard failures during connection establishment (auth, IMAP-disabled,
+        // DNS, etc.) still trip the breaker via the catch-block in connect()
+        // below, and so do operations that exhaust withRetry.
 
         // Attempt reconnect
         this.scheduleReconnect(accountId);
@@ -1470,6 +1477,16 @@ export class ImapService {
     cb.lastFailureTime = new Date();
     cb.successCount = 0;
 
+    // Keep operation metrics in sync with the breaker so users can correlate
+    // a tripped breaker with a non-zero failedOperations count. (Previously
+    // connect()-time terminal failures bumped only the breaker, leaving the
+    // metric stuck at 0 — confusing during diagnosis.)
+    if (metadata.metrics) {
+      metadata.metrics.failedOperations++;
+      metadata.metrics.totalOperations++;
+      metadata.metrics.lastOperationTime = new Date();
+    }
+
     // Store the failure reason for better diagnostics
     if (!cb.lastFailureReason) {
       (cb as any).lastFailureReason = reason;
@@ -1510,6 +1527,65 @@ export class ImapService {
       cb.lastStateChange = new Date();
       console.error(`[CircuitBreaker] CLOSED for account ${accountId} (${cb.successCount} successes)`);
     }
+  }
+
+  /**
+   * Manually reset the circuit breaker for an account back to CLOSED with
+   * zero counters. Used by the imap_reset_circuit_breaker tool when a user
+   * wants immediate recovery rather than waiting on the timeout.
+   * Returns the previous state for diagnostics.
+   */
+  resetCircuitBreaker(accountId: string): {
+    previousState: string;
+    failureCountBefore: number;
+    lastFailureReason?: string;
+  } | null {
+    const metadata = this.connectionMetadata.get(accountId);
+    if (!metadata?.circuitBreaker) return null;
+    const cb = metadata.circuitBreaker;
+    const previous = {
+      previousState: cb.state,
+      failureCountBefore: cb.failureCount,
+      lastFailureReason: (cb as any).lastFailureReason as string | undefined,
+    };
+    cb.state = CircuitState.CLOSED;
+    cb.failureCount = 0;
+    cb.successCount = 0;
+    cb.lastStateChange = new Date();
+    delete (cb as any).lastFailureReason;
+    console.error(
+      `[CircuitBreaker] manually reset for account ${accountId} ` +
+      `(was ${previous.previousState}, ${previous.failureCountBefore} failures)`
+    );
+    return previous;
+  }
+
+  /** Read-only snapshot of breaker state (for the metrics/diagnostic tool). */
+  getCircuitBreakerState(accountId: string): {
+    state: string;
+    failureCount: number;
+    successCount: number;
+    failureThreshold: number;
+    successThreshold: number;
+    timeoutMs: number;
+    lastFailureTime: string | null;
+    lastFailureReason: string | null;
+    lastStateChange: string | null;
+  } | null {
+    const metadata = this.connectionMetadata.get(accountId);
+    if (!metadata?.circuitBreaker) return null;
+    const cb = metadata.circuitBreaker;
+    return {
+      state: cb.state,
+      failureCount: cb.failureCount,
+      successCount: cb.successCount,
+      failureThreshold: cb.config.failureThreshold,
+      successThreshold: cb.config.successThreshold,
+      timeoutMs: cb.config.timeout,
+      lastFailureTime: cb.lastFailureTime ? cb.lastFailureTime.toISOString() : null,
+      lastFailureReason: (cb as any).lastFailureReason ?? null,
+      lastStateChange: cb.lastStateChange ? cb.lastStateChange.toISOString() : null,
+    };
   }
 
   // ==================

--- a/src/services/migration-service.ts
+++ b/src/services/migration-service.ts
@@ -26,7 +26,21 @@
 
 import fs from 'fs';
 import path from 'path';
-import type Database from 'better-sqlite3';
+import type { DatabaseSync } from 'node:sqlite';
+
+/** Run `body` inside a SQLite transaction. node:sqlite has no built-in
+ * transaction wrapper (better-sqlite3 had `db.transaction(fn)`), so we
+ * roll our own: BEGIN -> body() -> COMMIT, or ROLLBACK on throw. */
+function runInTransaction(db: DatabaseSync, body: () => void): void {
+  db.exec('BEGIN');
+  try {
+    body();
+    db.exec('COMMIT');
+  } catch (e) {
+    try { db.exec('ROLLBACK'); } catch { /* ignore — original error wins */ }
+    throw e;
+  }
+}
 
 export interface MigrationStep {
   file: string;          // Absolute path to the .sql file
@@ -65,7 +79,7 @@ function compareSemver(a: string, b: string): number {
 
 export class MigrationService {
   constructor(
-    private db: Database.Database,
+    private db: DatabaseSync,
     private migrationsDir: string
   ) {}
 
@@ -154,8 +168,7 @@ export class MigrationService {
 
       const sql = fs.readFileSync(step.file, 'utf-8');
       try {
-        // better-sqlite3 exposes `transaction()` that wraps a function in BEGIN/COMMIT.
-        const run = this.db.transaction(() => {
+        runInTransaction(this.db, () => {
           this.db.exec(sql);
           this.db
             .prepare(
@@ -167,7 +180,6 @@ export class MigrationService {
               `Auto-applied from ${step.fileName}`
             );
         });
-        run();
         result.applied.push({
           fromVersion: step.fromVersion,
           toVersion: step.toVersion,
@@ -220,13 +232,12 @@ export class MigrationService {
       }
       const sql = fs.readFileSync(step.rollbackFile, 'utf-8');
       try {
-        const run = this.db.transaction(() => {
+        runInTransaction(this.db, () => {
           this.db.exec(sql);
           this.db
             .prepare('DELETE FROM schema_version WHERE version = ?')
             .run(step.toVersion);
         });
-        run();
         out.rolledBack.push({
           toVersion: step.toVersion,
           file: path.basename(step.rollbackFile),

--- a/src/services/results-service.ts
+++ b/src/services/results-service.ts
@@ -193,9 +193,9 @@ export class ResultsService {
         storage_mode, storage_type, rows_json, rows_iv, file_path, file_size_bytes,
         row_count, schema_version, created_at, expires_at, last_accessed_at, access_count
       ) VALUES (
-        @result_id, @user_id, @account_id, @tool_name, @folder, @params_json, @summary_json,
-        @storage_mode, @storage_type, @rows_json, @rows_iv, @file_path, @file_size_bytes,
-        @row_count, @schema_version, @created_at, @expires_at, @last_accessed_at, @access_count
+        $result_id, $user_id, $account_id, $tool_name, $folder, $params_json, $summary_json,
+        $storage_mode, $storage_type, $rows_json, $rows_iv, $file_path, $file_size_bytes,
+        $row_count, $schema_version, $created_at, $expires_at, $last_accessed_at, $access_count
       )
     `);
 
@@ -257,8 +257,12 @@ export class ResultsService {
       if (!row.rows_json || !row.rows_iv) {
         throw new Error(`Result ${resultId} marked inline but missing rows_json/iv`);
       }
-      const encryptedHex = (row.rows_json as Buffer).toString('hex');
-      const plain = this.db.decryptString(encryptedHex, row.rows_iv);
+      // node:sqlite returns BLOB as Uint8Array (not Node Buffer); coerce so
+      // .toString('hex') uses Buffer's encoding-aware impl.
+      const blob = Buffer.isBuffer(row.rows_json)
+        ? row.rows_json
+        : Buffer.from(row.rows_json as Uint8Array);
+      const plain = this.db.decryptString(blob.toString('hex'), row.rows_iv);
       const all = JSON.parse(plain) as StoredResultRowSummary[];
       rows = all.slice(offset, offset + limit);
     }

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -1,0 +1,190 @@
+/**
+ * Tool annotations — drives Claude Desktop's "Tool Permissions" UI.
+ *
+ * MCP tool annotations (per the MCP spec) carry hints that clients use
+ * to group tools by side-effect category and to apply per-group default
+ * policies. Claude Desktop's settings panel groups by:
+ *   - Read-only tools          (readOnlyHint: true)
+ *   - Write/delete tools       (destructiveHint: true)
+ *   - Other / neutral          (no hint set)
+ *
+ * Conventions used in this table:
+ *   - readOnlyHint: tool only reads server-side state; safe to call repeatedly
+ *   - destructiveHint: tool modifies server-side state in a way users would
+ *     want approval for (send, delete, move, write to mailbox, mutate config)
+ *   - idempotentHint: repeated calls converge to the same state
+ *   - openWorldHint: tool interacts with external systems (IMAP/SMTP servers,
+ *     UserCheck API, DNS lookups). Helps clients reason about latency.
+ *
+ * NB: a tool can be both readOnly + openWorld (e.g. imap_search_emails:
+ * reads remote mailbox without modifying it).
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-04-30
+ * Version: 0.1.0
+ */
+
+export interface ToolAnnotations {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+/** Read-only hints for tools that only read state. Most don't mutate the
+ *  remote IMAP server or local DB; the ones that hit IMAP/SMTP/etc. also
+ *  carry openWorldHint:true. */
+const READ_ONLY: ToolAnnotations = { readOnlyHint: true, destructiveHint: false };
+const READ_REMOTE: ToolAnnotations = { readOnlyHint: true, destructiveHint: false, openWorldHint: true };
+
+/** Destructive hints for tools that mutate state — local DB, remote
+ *  mailbox flags, sent SMTP, etc. */
+const WRITE_LOCAL: ToolAnnotations = { readOnlyHint: false, destructiveHint: true };
+const WRITE_REMOTE: ToolAnnotations = { readOnlyHint: false, destructiveHint: true, openWorldHint: true };
+
+/** Connect/disconnect: not really destructive (idempotent), not really
+ *  read-only (state changes, but transient and recoverable). */
+const NEUTRAL_IDEMPOTENT: ToolAnnotations = { idempotentHint: true, openWorldHint: true };
+
+export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
+  // ---- account-tools (8) ----
+  'imap_add_account':                  WRITE_LOCAL,
+  'imap_add_account_auto':             WRITE_LOCAL,
+  'imap_add_account_with_provider':    WRITE_LOCAL,
+  'imap_remove_account':               WRITE_LOCAL,
+  'imap_list_accounts':                READ_ONLY,
+  'imap_list_providers':               READ_ONLY,
+  'imap_share_account':                WRITE_LOCAL,
+  'imap_unshare_account':              WRITE_LOCAL,
+
+  // ---- email-tools — search/get/list (read-remote) ----
+  'imap_search_emails':                READ_REMOTE,
+  'imap_get_email':                    READ_REMOTE,
+  'imap_get_latest_emails':            READ_REMOTE,
+  'imap_get_unread_count':             READ_REMOTE,
+  'imap_bulk_get_emails':              READ_REMOTE,
+  'imap_bulk_get_emails_chunked':      READ_REMOTE,
+  'imap_extract_unsubscribe_links':    READ_REMOTE,
+
+  // ---- email-tools — write/destructive ----
+  'imap_mark_as_read':                 WRITE_REMOTE,
+  'imap_mark_as_unread':               WRITE_REMOTE,
+  'imap_delete_email':                 WRITE_REMOTE,
+  'imap_move_email':                   WRITE_REMOTE,
+  'imap_copy_email':                   WRITE_REMOTE,
+  'imap_send_email':                   WRITE_REMOTE,
+  'imap_reply_to_email':               WRITE_REMOTE,
+  'imap_forward_email':                WRITE_REMOTE,
+  'imap_append_message':               WRITE_REMOTE,
+  'imap_bulk_delete_emails':           WRITE_REMOTE,
+  'imap_bulk_delete_emails_chunked':   WRITE_REMOTE,
+  'imap_bulk_mark_emails':             WRITE_REMOTE,
+  'imap_bulk_mark_emails_chunked':     WRITE_REMOTE,
+  'imap_bulk_move_emails':             WRITE_REMOTE,
+  'imap_bulk_copy_emails':             WRITE_REMOTE,
+
+  // ---- email-tools — diagnostics + metrics (read) ----
+  'imap_test_smtp':                    READ_REMOTE,
+  'imap_test_sent_folder':             READ_REMOTE,
+  'imap_get_smtp_metrics':             READ_ONLY,
+  'imap_reset_smtp_metrics':           WRITE_LOCAL,
+  'imap_list_unarchived_sends':        READ_ONLY,
+
+  // ---- WP2 attachment staging (writes server-local state) ----
+  'imap_attachment_stage_init':        WRITE_LOCAL,
+  'imap_attachment_stage_append':      WRITE_LOCAL,
+  'imap_attachment_stage_finalize':    WRITE_LOCAL,
+  'imap_attachment_stage_cancel':      WRITE_LOCAL,
+  'imap_list_staged_attachments':      READ_ONLY,
+
+  // ---- folder-tools (6) ----
+  'imap_list_folders':                 READ_REMOTE,
+  'imap_folder_status':                READ_REMOTE,
+  'imap_get_mailbox_status':           READ_REMOTE,
+  'imap_create_folder':                WRITE_REMOTE,
+  'imap_delete_folder':                WRITE_REMOTE,
+  'imap_rename_folder':                WRITE_REMOTE,
+
+  // ---- meta-tools (7) ----
+  'imap_about':                        READ_ONLY,
+  'imap_list_tools':                   READ_ONLY,
+  'imap_connect':                      NEUTRAL_IDEMPOTENT,
+  'imap_disconnect':                   NEUTRAL_IDEMPOTENT,
+  'imap_get_metrics':                  READ_ONLY,
+  'imap_get_operation_metrics':        READ_ONLY,
+  'imap_reset_metrics':                WRITE_LOCAL,
+  'imap_get_circuit_breaker':          READ_ONLY,
+  'imap_reset_circuit_breaker':        WRITE_LOCAL,
+
+  // ---- capability-tools (1) ----
+  'imap_get_capabilities':             READ_REMOTE,
+
+  // ---- category-tools (5) ----
+  'imap_list_categories':              READ_ONLY,
+  'imap_apply_categories':             WRITE_REMOTE,        // sets keyword flags on messages
+  'imap_add_keyword':                  WRITE_REMOTE,
+  'imap_remove_keyword':               WRITE_REMOTE,
+  'imap_analyze_folder_confidence':    READ_REMOTE,
+
+  // ---- result-tools (1, mixed actions) ----
+  // get/list are read; delete/persist are write. Treat as not-read-only
+  // so the user defaults to "needs approval" — safer for the destructive
+  // sub-actions.
+  'imap_results':                      WRITE_LOCAL,
+
+  // ---- scoring-tools (2) ----
+  'imap_score_email_confidence':       READ_REMOTE,
+  'imap_bulk_score_emails':            READ_REMOTE,
+
+  // ---- subscription-tools (10) ----
+  'imap_get_subscription_summary':     READ_ONLY,
+  'imap_list_subscribed_mailboxes':    READ_REMOTE,
+  'imap_subscribe_mailbox':            WRITE_REMOTE,
+  'imap_unsubscribe_mailbox':          WRITE_REMOTE,
+  'imap_list_unsubscribe_candidates':  READ_ONLY,
+  'imap_mark_subscription_unsubscribed': WRITE_LOCAL,
+  'imap_update_subscription_category': WRITE_LOCAL,
+  'imap_update_subscription_notes':    WRITE_LOCAL,
+  'imap_get_unsubscribe_links':        READ_ONLY,
+  'imap_execute_unsubscribe':          WRITE_REMOTE,        // hits external HTTP/mailto
+
+  // ---- user-tools (3) ----
+  'imap_create_user':                  WRITE_LOCAL,
+  'imap_get_user':                     READ_ONLY,
+  'imap_list_users':                   READ_ONLY,
+
+  // ---- usercheck-tools (7) ----
+  'imap_add_usercheck_key':            WRITE_LOCAL,
+  'imap_get_usercheck_key':            READ_ONLY,
+  'imap_delete_usercheck_key':         WRITE_LOCAL,
+  'imap_check_email_spam':             READ_REMOTE,
+  'imap_check_emails_spam_bulk':       READ_REMOTE,
+  'imap_check_folder_spam':            READ_REMOTE,
+  'imap_scan_account_spam':            READ_REMOTE,
+
+  // ---- dns-firewall-tools (5) ----
+  'imap_check_domain':                 READ_REMOTE,
+  'imap_bulk_check_domains':           READ_REMOTE,
+  'imap_check_domain_dns_firewall':    READ_REMOTE,
+  'imap_scan_message_domains':         READ_REMOTE,
+  'imap_bulk_scan_messages':           READ_REMOTE,
+};
+
+/**
+ * Heuristic fallback for a tool name we forgot to register above.
+ * Keeps the worst-case policy (treat as destructive — needs approval)
+ * unless the name clearly maps to a read-only verb prefix.
+ */
+function fallbackFromName(name: string): ToolAnnotations {
+  const n = name.replace(/^imap_/, '').toLowerCase();
+  const READ_VERBS = ['get_', 'list_', 'search_', 'check_', 'scan_', 'test_', 'analyze_', 'score_', 'about'];
+  if (READ_VERBS.some(v => n.startsWith(v))) return READ_ONLY;
+  // Default to "destructive" so unknown tools land in "Write/delete" group.
+  return WRITE_LOCAL;
+}
+
+export function getAnnotations(toolName: string): ToolAnnotations {
+  return TOOL_ANNOTATIONS[toolName] ?? fallbackFromName(toolName);
+}

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -1566,6 +1566,52 @@ export function emailTools(
     };
   }));
 
+  // Circuit-breaker diagnostic + manual reset
+  server.registerTool('imap_get_circuit_breaker', {
+    description:
+      'Inspect the per-account circuit breaker state (CLOSED / OPEN / HALF_OPEN), ' +
+      'failure count, last failure reason, and configured thresholds/timeout. Use this to ' +
+      'understand why operations are being blocked when imap_get_metrics shows zero failures.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+    }
+  }, withErrorHandling(async ({ accountId }) => {
+    const state = imapService.getCircuitBreakerState(accountId);
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(
+          state ?? { error: `No circuit breaker state for account ${accountId}` },
+          null, 2
+        )
+      }]
+    };
+  }));
+
+  server.registerTool('imap_reset_circuit_breaker', {
+    description:
+      'Manually reset the circuit breaker for an account back to CLOSED with zero failure ' +
+      "count. Use when the breaker has tripped due to transient errors and you don't want " +
+      "to wait for the timeout-based HALF_OPEN transition. Returns the breaker's previous " +
+      'state for diagnostics.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+    }
+  }, withErrorHandling(async ({ accountId }) => {
+    const previous = imapService.resetCircuitBreaker(accountId);
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(
+          previous
+            ? { success: true, accountId, previous }
+            : { success: false, error: `No circuit breaker state for account ${accountId}` },
+          null, 2
+        )
+      }]
+    };
+  }));
+
   // Level 3: Reset metrics
   server.registerTool('imap_reset_metrics', {
     description: 'Reset connection metrics for an account',

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,28 @@ import { capabilityTools } from './capability-tools.js';
 import { dnsFirewallTools } from './dns-firewall-tools.js';
 import { categoryTools } from './category-tools.js';
 import { resultTools } from './result-tools.js';
+import { getAnnotations } from './annotations.js';
+
+/**
+ * Wrap server.registerTool so every call gets MCP annotations injected
+ * from our central table. Drives Claude Desktop's "Tool permissions" UI
+ * (Read-only / Write-delete groups). Restored on every registerTools()
+ * invocation so we don't leak the wrapper across re-registrations.
+ *
+ * Caller-supplied annotations (if any) win on a per-key basis — the
+ * central table only fills in keys the call site didn't already set.
+ */
+function withAnnotations<T extends McpServer>(server: T): () => void {
+  const original = (server as any).registerTool.bind(server);
+  (server as any).registerTool = (name: string, config: any, handler: any) => {
+    const merged = {
+      ...config,
+      annotations: { ...getAnnotations(name), ...(config?.annotations ?? {}) },
+    };
+    return original(name, merged, handler);
+  };
+  return () => { (server as any).registerTool = original; };
+}
 
 export function registerTools(
   server: McpServer,
@@ -31,6 +53,11 @@ export function registerTools(
   appendRetry?: AppendRetryService,
   staging?: AttachmentStagingService
 ): void {
+  // Inject MCP annotations on every registerTool call (drives Claude
+  // Desktop's Tool Permissions UI). Restored after the registration phase
+  // so re-entrant calls (e.g. from buildToolsManifest) start fresh.
+  const restoreRegisterTool = withAnnotations(server);
+
   // Register user & database management tools (v2.6.0 - SQLite3 integration)
   userTools(server, db);
 
@@ -69,4 +96,6 @@ export function registerTools(
 
   // Register meta/discovery tools
   metaTools(server);
+
+  restoreRegisterTool();
 }


### PR DESCRIPTION
## Summary

v2.16.0 — three threads bundled into one release because they all blocked actually shipping the `.mcpb` extension to end users on macOS:

1. **`better-sqlite3` → `node:sqlite`** — the third-party native binding was blocked by macOS library validation in Claude Desktop (different Apple Team ID from Anthropic's). `node:sqlite` ships inside Node, inherits Claude Desktop's process signature, loads cleanly.
2. **DXT manifest spec compliance** — the v2.15.0 `.mcpb` failed at the preview stage with `Invalid manifest` errors. Fixed.
3. **MCP tool annotations** — Claude Desktop's "Tool Permissions" UI was empty for our extension. Now populated for all 93 tools.

Plus one real bug fix surfaced by live use:

4. **Circuit breaker false-positive OPEN state** (closes #116) — Hostinger's idle disconnects were tripping the breaker without any operation actually failing.

## Tool count: 91 → 93

Two new diagnostic tools: `imap_get_circuit_breaker` (read-only) and `imap_reset_circuit_breaker` (destructive). Both annotated.

## Test plan

- [x] `npm run build` clean at v2.16.0
- [x] All 4 WP harnesses pass against live IMAP (WP1: 15/15, WP3: 7/7, WP4: 4/4, WP2: 8/8)
- [x] Server starts at v2.16.0 with 93 tools registered, pre-handshake 12 ms
- [x] Existing `~/.imap-mcp/data.db` opens transparently with `node:sqlite` — no schema changes, all 4 accounts visible
- [x] `.mcpb` install end-to-end on macOS arm64 — confirmed loaded, `tools/list` returns 93 tools, `imap_about` / `imap_list_accounts` / `imap_connect` succeed
- [x] DXT manifest passes Claude Desktop's preview validation (no `dxt_version`, `inputSchema`, or `enum` errors)
- [x] Tool Permissions UI groups tools correctly: ~50 read-only, ~40 write/delete, 2 idempotent (connect/disconnect)
- [x] Circuit-breaker reset path verified — `imap_reset_circuit_breaker` clears state, subsequent operations succeed

## Bundle size

40 MB → **33 MB** (no `better_sqlite3.node`, no Electron rebuild step).

## Schema

Unchanged. Database stays at v1.10.0. No migration runs on this release.

## Backward compatibility

No breaking changes. Every env var from v2.15.0 continues to work. All 91 prior tool surfaces unchanged. The `.mcpb` install path is now the recommended distribution channel — still works alongside the manual install.

## Caveats

- The dead-code path in `src/services/encryption/` still references `@journeyapps/sqlcipher` and `keytar`. Those deps stay in the bundle but are never loaded at runtime. Cleanup tracked separately.
- Tested only on macOS arm64. The `.mcpb` build pipeline for windows-x64, macos-x64, linux-x64 in the existing GH Actions workflow needs the v2.15.0 `.mcpb` build failure investigated separately (windows-x64 step failed in the v2.15.0 CI run).

## Issues

- Closes #116 (circuit breaker bug)
- Drives forward #117 (long-running bulk-op persistence) — depends on `node:sqlite` as the canonical DB driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)
