### PR TITLE
v2.17.0 MVP: local message cache + new tools (in progress)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,75 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.0] - 2026-05-01
+
+### Local message cache + first auto-installed skill
+
+This release lands the first piece of the v3.0 bulk-operations effort: a local SQLite header cache that makes sender enumeration, domain lookups, and "top N senders" queries return in milliseconds against folders with thousands of messages, plus the auto-install mechanism that delivers a Claude skill alongside the MCP server. Together they enable the `unsubscribe-cleanup` workflow without needing the user to hand-copy any skill files.
+
+Tool count: 93 → 95.
+
+#### ✨ Added
+
+- **`imap_sync_folder_cache`** — populate the local `messages_cache` table for one folder. Idempotent: subsequent calls fetch only UIDs since the last sync. UIDVALIDITY change triggers a full resync automatically. Returns `{ rowsAdded, rowsAfter, durationMs, uidValidity, uidValidityChanged }`. Reads remote (IMAP) and writes the local cache; annotated `READ_REMOTE` because the user-facing effect is reading messages — the cache is an implementation detail.
+- **`imap_search_cache`** — fast SQL-backed search against the local cache. Three modes:
+  - `by_domain` — rows where `from_domain` matches (case-insensitive).
+  - `by_address` — rows where `from_address` matches exactly.
+  - `group_by_sender` — top-N senders ranked by message count, with `list_unsubscribe_present` flag for quick newsletter identification.
+  - Optional `since` filter accepts relative ("90d", "24h") or ISO date.
+  - Cache miss returns an explicit structured `cache_miss` error — no silent IMAP fallback. The skill orchestrates the order.
+- **Auto-installed skills** (`SkillsInstallerService`). On startup, the server copies bundled skills from inside its package to `~/.claude/skills/imap-mcp-pro/<skill-name>/`. Idempotent: skips when versions match, updates when the bundle is newer, preserves on-disk content when its version is ahead of the bundle. Disable via `IMAP_MCP_SKIP_SKILLS_INSTALL=1`.
+- **`unsubscribe-cleanup` skill** (v0.1.0) bundled inside the `.mcpb`. Wraps `imap_sync_folder_cache` + `imap_search_cache` + the existing PR #45 unsubscribe pipeline (`imap_list_unsubscribe_candidates`, `imap_get_unsubscribe_links`, `imap_execute_unsubscribe`, `imap_mark_subscription_unsubscribed`) into a confirmation-gated workflow. Source of truth lives in `Temple-of-Epiphany/claude-skills-library`; this `.mcpb` ships a vendored snapshot.
+
+#### 🛠️ Changed
+
+- **Schema migration `1.10.0 → 1.11.0`** — adds `messages_cache` table with indexes on `(account_id, from_domain)`, `(account_id, from_address)`, and `(account_id, date_received)`. Reversible via the matching `.down.sql`. FK to `accounts` cascades on account delete.
+- **`scripts/postbuild.mjs`** — now also copies `skills/` → `dist/skills/` so the bundle ends up inside the `.mcpb` archive (no `dxt/build.mjs` change needed; existing `dist/` staging carries the skills along).
+- **`ImapService.fetchHeadersForCache`** — new public method used by the cache. Opens the folder, reads UIDVALIDITY/UIDNEXT, optionally fetches an envelope + flags + `List-Unsubscribe` header for a UID range. Pass `uidRange = null` to skip the fetch and just inspect mailbox status.
+
+#### 🐛 Fixed
+
+- **Windows `.mcpb` build** (Issue #122). The `npm run build` script used a Unix shell chain (`mkdir -p && cp ...`) that errored on Windows `cmd.exe` with "The syntax of the command is incorrect." `tsc` compiled fine but schema files never copied to `dist/database/`, then `DatabaseService` threw `Schema file not found`. Replaced with `scripts/postbuild.mjs` — small Node script using `node:fs/promises` for cross-platform file ops. Every Windows `.mcpb` artifact build had failed since the workflow was added.
+
+#### 🧪 Validated
+
+- **Cache primitive** verified against `colin@bitterfield.com` INBOX (1537 messages):
+  - Cold sync: 1537 rows in 1.72s (target < 60s — beat by 35×)
+  - Warm re-sync: 0 new rows in 196ms (UIDVALIDITY + delta logic confirmed)
+  - `group_by_sender` warm: 20 ranked rows in 4ms (target < 200ms — beat by 50×)
+  - `by_domain` lookup: 5 rows in 1ms
+- **Cache primitive** verified against `cbitterfield@gmail.com` INBOX with same 5/5 pass — top senders correctly enumerated across 100+ msg/sender clusters.
+- **Skills installer** smoke test: fresh install / no-op re-install / update on older / preserve on newer / skip env-var — 5/5 pass.
+
+#### 📦 Distribution
+
+- Build matrix dropped `macos-x64` (macos-13 runner pool queue-starved through 2026; Apple Silicon transition complete). Future tagged releases produce 3 `.mcpb` artifacts: `macos-arm64`, `windows-x64`, `linux-x64`. macOS Intel users: run the `linux-x64` `.mcpb` under Rosetta or build from source.
+- Node ≥ 22.5 still required (`node:sqlite` baseline from v2.16.0).
+
+#### 🛡️ Backward compatibility
+
+- Existing tools untouched. **No transparent cache rewrite of `imap_search_emails` / `imap_get_email`** in this release — those still go straight to IMAP. The skill orchestrates the order: call `imap_sync_folder_cache` first, then use `imap_search_cache`. Transparent integration is deferred to a future release once cache-staleness behavior is fully understood.
+- All env vars from v2.16.0 continue to work.
+- Schema migration `1.11.0` is purely additive (one new table); existing tables unchanged.
+
+#### 🚧 MVP cuts (deferred to v2.18.0+)
+
+These were intentionally scoped out of v2.17.0 to ship the cache thesis end-to-end:
+
+- Cross-folder participants index, attachments table, FTS5, threading columns (full Track B / #119)
+- Cache mutation write-through on `imap_mark_as_read` etc. (cache silently goes stale until next `imap_sync_folder_cache` call)
+- Multi-folder sync (`imap_sync_account_cache` — currently one folder per call)
+- Full skill installer per #120: SHA-based user-edit preservation, periodic 1–4 hr TTL re-sync, configurable install path, `imap_get_skills_manifest` tool for remote consumers
+
+#### 🔗 Issues / PRs
+
+- #122 (Windows build fix) → PR #123 — merged
+- #124 (v2.17.0 MVP umbrella) — closed by this release
+- #125 (cache scaffold + implementation + skill installer) — merged
+- #126 (drop macos-x64 from matrix) — merged
+- claude-skills-library #7 (`unsubscribe-cleanup` skill content) → PR #10 — merged
+- #117, #119, #120, #121 — remain open as v3.0 roadmap
+
 ## [2.16.0] - 2026-04-30
 
 ### Hardened Claude Desktop install path

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -1,55 +1,88 @@
 #!/usr/bin/env node
 /**
- * postbuild.mjs — copy schema artifacts from src/database into dist/database
- * after `tsc` runs. Cross-platform replacement for the previous
- * `mkdir -p && cp` shell chain that broke on Windows cmd.exe (issue #122).
+ * postbuild.mjs — stage runtime artifacts from source dirs into dist/ after
+ * `tsc` runs. Cross-platform replacement for the previous `mkdir -p && cp`
+ * shell chain that broke on Windows cmd.exe (issue #122).
  *
- * Files copied:
- *   - schema.sql                       (required; hard error if missing)
- *   - schema_update_*.sql              (versioned migrations)
- *   - schema_update_*.down.sql         (rollback companions)
- *   - migrations-manifest.json         (optional; non-fatal if absent)
+ * What gets copied:
  *
- * NOT copied:
- *   - migrations/ subdirectory         (legacy SQL not loaded by src/)
+ *   src/database/                  → dist/database/
+ *     schema.sql                   (required; hard error if missing)
+ *     schema_update_*.sql          (versioned migrations + .down rollbacks)
+ *     migrations-manifest.json     (optional; non-fatal if absent)
+ *
+ *   skills/                        → dist/skills/   (v2.17.0 MVP, issue #124)
+ *     manifest.json                (skill bundle manifest)
+ *     <skill-name>/SKILL.md        (skill content)
+ *     <skill-name>/version.json    (per-skill version metadata)
+ *
+ * Excluded:
+ *   src/database/migrations/       (legacy SQL not loaded by src/)
  *
  * Author: Colin Bitterfield
  * Email: colin.bitterfield@templeofepiphany.com
  * Date Created: 2026-04-30
- * Version: 1.0.0
+ * Date Updated: 2026-05-01
+ * Version: 1.1.0
  */
 
-import { mkdir, copyFile, readdir } from 'node:fs/promises';
+import { mkdir, copyFile, readdir, cp, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 
-const SRC = 'src/database';
-const DST = 'dist/database';
+// ---------------------------------------------------------------------------
+// Schema migrations: src/database -> dist/database
+// ---------------------------------------------------------------------------
 
-await mkdir(DST, { recursive: true });
+const SCHEMA_SRC = 'src/database';
+const SCHEMA_DST = 'dist/database';
+
+await mkdir(SCHEMA_DST, { recursive: true });
 
 // Required: base schema
-await copyFile(join(SRC, 'schema.sql'), join(DST, 'schema.sql'));
+await copyFile(join(SCHEMA_SRC, 'schema.sql'), join(SCHEMA_DST, 'schema.sql'));
 
 // All schema_update_*.sql files (forward + .down.sql rollbacks)
-const entries = await readdir(SRC);
-const migrations = entries.filter((f) => /^schema_update_.*\.sql$/i.test(f));
+const schemaEntries = await readdir(SCHEMA_SRC);
+const migrations = schemaEntries.filter((f) => /^schema_update_.*\.sql$/i.test(f));
 for (const f of migrations) {
-  await copyFile(join(SRC, f), join(DST, f));
+  await copyFile(join(SCHEMA_SRC, f), join(SCHEMA_DST, f));
 }
 
 // Optional: manifest
 let manifestCopied = false;
 try {
   await copyFile(
-    join(SRC, 'migrations-manifest.json'),
-    join(DST, 'migrations-manifest.json'),
+    join(SCHEMA_SRC, 'migrations-manifest.json'),
+    join(SCHEMA_DST, 'migrations-manifest.json'),
   );
   manifestCopied = true;
 } catch (e) {
   if (e.code !== 'ENOENT') throw e;
 }
 
-console.log(
-  `[postbuild] copied schema.sql + ${migrations.length} migration file${migrations.length === 1 ? '' : 's'}` +
-    (manifestCopied ? ' + migrations-manifest.json' : ''),
-);
+// ---------------------------------------------------------------------------
+// Skills bundle: skills/ -> dist/skills (only if skills/ exists at repo root)
+// ---------------------------------------------------------------------------
+
+let skillsCopied = 0;
+try {
+  await stat('skills');
+  await cp('skills', 'dist/skills', { recursive: true });
+  const skillDirs = await readdir('dist/skills', { withFileTypes: true });
+  skillsCopied = skillDirs.filter((d) => d.isDirectory()).length;
+} catch (e) {
+  if (e.code !== 'ENOENT') throw e;
+  // No skills/ directory at repo root — nothing to bundle.
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+const parts = [
+  `schema.sql + ${migrations.length} migration file${migrations.length === 1 ? '' : 's'}`,
+];
+if (manifestCopied) parts.push('migrations-manifest.json');
+if (skillsCopied > 0) parts.push(`${skillsCopied} bundled skill${skillsCopied === 1 ? '' : 's'}`);
+
+console.log(`[postbuild] copied ${parts.join(' + ')}`);

--- a/scripts/smoke-test-cache.ts
+++ b/scripts/smoke-test-cache.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env tsx
+/**
+ * smoke-test-cache.ts — end-to-end exercise of v2.17.0 MVP cache against a live
+ * IMAP account. Runs the full success-criterion workflow from issue #124:
+ *
+ *   1. Connect to the account
+ *   2. Sync INBOX cache (cold)
+ *   3. group_by_sender top 20
+ *   4. by_domain spot check
+ *   5. Re-sync (warm — should be near-zero ops)
+ *   6. group_by_sender again (warm — should be < 200ms)
+ *
+ * Usage:
+ *   npx tsx scripts/smoke-test-cache.ts <accountId> [folder]
+ *
+ * Default folder is INBOX. Account ID can be looked up via:
+ *   sqlite3 ~/.imap-mcp/data.db "SELECT account_id, name, username FROM accounts;"
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-04-30
+ * Version: 0.1.0
+ */
+
+import { DatabaseService } from '../src/services/database-service.js';
+import { ImapService } from '../src/services/imap-service.js';
+import { MessageCacheService } from '../src/services/message-cache-service.js';
+
+const accountId = process.argv[2];
+const folder = process.argv[3] ?? 'INBOX';
+
+if (!accountId) {
+  console.error('Usage: npx tsx scripts/smoke-test-cache.ts <accountId> [folder]');
+  console.error('');
+  console.error('List accounts:');
+  console.error('  sqlite3 ~/.imap-mcp/data.db "SELECT account_id, name, username FROM accounts;"');
+  process.exit(2);
+}
+
+function fmt(ms: number): string {
+  if (ms < 1000) return `${ms.toFixed(0)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + ' '.repeat(n - s.length);
+}
+
+async function main() {
+  console.log(`\n=== v2.17.0 MVP cache smoke test ===`);
+  console.log(`Account:  ${accountId}`);
+  console.log(`Folder:   ${folder}`);
+  console.log('');
+
+  const db = new DatabaseService();
+  const imap = new ImapService(db);
+  const cache = new MessageCacheService(db, imap);
+
+  // ---- Step 1: Connect ----
+  const account = db.getDecryptedAccount(accountId);
+  if (!account) {
+    console.error(`Account not found: ${accountId}`);
+    process.exit(2);
+  }
+  const t1 = Date.now();
+  await imap.connect({
+    id: account.account_id,
+    name: account.name,
+    host: account.host,
+    port: account.port,
+    user: account.username,
+    password: account.password,
+    tls: account.tls,
+  });
+  console.log(`[1] connect (${account.name} @ ${account.host}): ${fmt(Date.now() - t1)}`);
+
+  // ---- Step 2: Cold sync ----
+  console.log(`[2] sync (cold) ...`);
+  const sync1 = await cache.syncFolder(accountId, folder);
+  console.log(`    rows added:   ${sync1.rowsAdded}`);
+  console.log(`    rows after:   ${sync1.rowsAfter}`);
+  console.log(`    duration:     ${fmt(sync1.durationMs)}`);
+  console.log(`    UIDVALIDITY:  ${sync1.uidValidity}${sync1.uidValidityChanged ? ' (changed!)' : ''}`);
+
+  // ---- Step 3: group_by_sender top 20 (cold cache, but read is fast either way) ----
+  console.log(`\n[3] group_by_sender (top 20):`);
+  const t3 = Date.now();
+  const groups = await cache.groupBySender(accountId, folder, { limit: 20 });
+  const t3ms = Date.now() - t3;
+  console.log(`    duration: ${fmt(t3ms)}\n`);
+  console.log(`    ${pad('#', 3)} ${pad('count', 6)} ${pad('list_unsub', 11)} ${pad('sender', 50)}`);
+  console.log(`    ${'-'.repeat(3)} ${'-'.repeat(6)} ${'-'.repeat(11)} ${'-'.repeat(50)}`);
+  groups.forEach((g, i) => {
+    const sender = g.fromName ? `${g.fromName} <${g.fromAddress}>` : g.fromAddress;
+    const truncSender = sender.length > 50 ? sender.slice(0, 47) + '...' : sender;
+    console.log(
+      `    ${pad(String(i + 1), 3)} ${pad(String(g.count), 6)} ` +
+      `${pad(g.listUnsubscribePresent ? 'yes' : 'no', 11)} ${pad(truncSender, 50)}`
+    );
+  });
+
+  // ---- Step 4: by_domain spot check (use top sender's domain) ----
+  if (groups.length > 0) {
+    const topDomain = groups[0].fromDomain;
+    if (topDomain) {
+      console.log(`\n[4] by_domain "${topDomain}" (limit 5):`);
+      const t4 = Date.now();
+      const byDom = await cache.searchByFromDomain(accountId, folder, topDomain, { limit: 5 });
+      const t4ms = Date.now() - t4;
+      console.log(`    duration: ${fmt(t4ms)}, rows: ${byDom.length}`);
+      byDom.slice(0, 3).forEach(r => {
+        const d = r.dateReceived ? new Date(r.dateReceived).toISOString().slice(0, 10) : '-';
+        console.log(`      ${d} | ${r.fromAddress} | ${r.subject?.slice(0, 60) ?? ''}`);
+      });
+    }
+  }
+
+  // ---- Step 5: Re-sync (warm — should be near-zero new) ----
+  console.log(`\n[5] sync (warm) ...`);
+  const sync2 = await cache.syncFolder(accountId, folder);
+  console.log(`    rows added:   ${sync2.rowsAdded}`);
+  console.log(`    duration:     ${fmt(sync2.durationMs)}`);
+
+  // ---- Step 6: group_by_sender again (warm, target < 200ms) ----
+  console.log(`\n[6] group_by_sender (warm):`);
+  const t6 = Date.now();
+  const groups2 = await cache.groupBySender(accountId, folder, { limit: 20 });
+  const t6ms = Date.now() - t6;
+  console.log(`    duration: ${fmt(t6ms)} ${t6ms < 200 ? '✓' : '✗ (target < 200ms)'}`);
+  console.log(`    rows: ${groups2.length}`);
+
+  // ---- Summary ----
+  console.log(`\n=== Summary ===`);
+  const checks = [
+    { name: 'Cold sync rows > 0',                  pass: sync1.rowsAfter > 0 },
+    { name: 'Cold sync < 60s',                     pass: sync1.durationMs < 60_000 },
+    { name: 'Warm sync near-zero new rows',        pass: sync2.rowsAdded === 0 },
+    { name: 'group_by_sender warm < 200ms',        pass: t6ms < 200 },
+    { name: 'group_by_sender returns >= 1 sender', pass: groups.length >= 1 },
+  ];
+  for (const c of checks) {
+    console.log(`  ${c.pass ? '✓' : '✗'} ${c.name}`);
+  }
+  const allPass = checks.every(c => c.pass);
+  console.log(`\nResult: ${allPass ? 'PASS' : 'FAIL'}`);
+
+  // ---- Cleanup ----
+  await imap.disconnect(accountId);
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error('\nFATAL:', err);
+  process.exit(1);
+});

--- a/scripts/smoke-test-skills-install.ts
+++ b/scripts/smoke-test-skills-install.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env tsx
+/**
+ * smoke-test-skills-install.ts — exercise SkillsInstallerService end-to-end.
+ *
+ * Verifies that the installer:
+ *   1. Reads the bundle manifest from dist/skills/manifest.json
+ *   2. Copies each skill to ~/.claude/skills/imap-mcp-pro/<name>/
+ *   3. Skips on second run (versions match)
+ *   4. Re-overwrites when version on disk is older than bundled
+ *   5. Honors IMAP_MCP_SKIP_SKILLS_INSTALL=1
+ *
+ * Usage:
+ *   npm run build && npx tsx scripts/smoke-test-skills-install.ts
+ *
+ * Author: Colin Bitterfield
+ * Date: 2026-05-01
+ * Version: 0.1.0
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SkillsInstallerService } from '../src/services/skills-installer-service.js';
+
+const bundleDir = path.resolve('dist/skills');
+const installDir = path.join(os.homedir(), '.claude', 'skills', 'imap-mcp-pro');
+
+async function exists(p: string): Promise<boolean> {
+  try { await fs.stat(p); return true; }
+  catch { return false; }
+}
+
+async function readVersion(p: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(path.join(p, 'version.json'), 'utf8');
+    return JSON.parse(raw).version ?? null;
+  } catch { return null; }
+}
+
+async function clean() {
+  if (await exists(installDir)) {
+    await fs.rm(installDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  console.log(`\n=== SkillsInstallerService smoke test ===`);
+  console.log(`Bundle:  ${bundleDir}`);
+  console.log(`Install: ${installDir}\n`);
+
+  // Sanity check: bundle exists
+  if (!await exists(path.join(bundleDir, 'manifest.json'))) {
+    console.error('FATAL: dist/skills/manifest.json not found. Run npm run build first.');
+    process.exit(2);
+  }
+
+  // ---- Test 1: Fresh install ----
+  console.log('[1] Fresh install (no existing skills)');
+  await clean();
+  const installer = new SkillsInstallerService(bundleDir);
+  const r1 = await installer.install();
+  console.log(`    installed: ${JSON.stringify(r1.installed)}, updated: ${JSON.stringify(r1.updated)}, skipped: ${r1.skipped}, durationMs: ${r1.durationMs}`);
+  const skillMd = path.join(installDir, 'unsubscribe-cleanup', 'SKILL.md');
+  const skillVer = path.join(installDir, 'unsubscribe-cleanup', 'version.json');
+  const t1ok = await exists(skillMd) && await exists(skillVer) && r1.installed.includes('unsubscribe-cleanup');
+  console.log(`    files exist + reported as installed: ${t1ok ? '✓' : '✗'}`);
+
+  // ---- Test 2: Idempotent re-install (no-op) ----
+  console.log('\n[2] Re-install (versions match, expect unchanged)');
+  const r2 = await installer.install();
+  console.log(`    installed: ${JSON.stringify(r2.installed)}, updated: ${JSON.stringify(r2.updated)}, unchanged: ${r2.unchanged.length}, durationMs: ${r2.durationMs}`);
+  const t2ok = r2.installed.length === 0 && r2.updated.length === 0 && r2.unchanged.includes('unsubscribe-cleanup');
+  console.log(`    no-op + reports unchanged: ${t2ok ? '✓' : '✗'}`);
+
+  // ---- Test 3: Older on-disk version triggers update ----
+  console.log('\n[3] Older on-disk version triggers update');
+  await fs.writeFile(skillVer, JSON.stringify({ name: 'unsubscribe-cleanup', version: '0.0.1' }, null, 2));
+  const r3 = await installer.install();
+  console.log(`    installed: ${JSON.stringify(r3.installed)}, updated: ${JSON.stringify(r3.updated)}, durationMs: ${r3.durationMs}`);
+  const restoredVersion = await readVersion(path.join(installDir, 'unsubscribe-cleanup'));
+  const t3ok = r3.updated.includes('unsubscribe-cleanup') && restoredVersion === '0.1.0';
+  console.log(`    updated + version restored to bundled (${restoredVersion}): ${t3ok ? '✓' : '✗'}`);
+
+  // ---- Test 4: Newer on-disk version preserved ----
+  console.log('\n[4] Newer on-disk version preserved');
+  await fs.writeFile(skillVer, JSON.stringify({ name: 'unsubscribe-cleanup', version: '99.0.0' }, null, 2));
+  const r4 = await installer.install();
+  console.log(`    installed: ${JSON.stringify(r4.installed)}, updated: ${JSON.stringify(r4.updated)}, preserved: ${JSON.stringify(r4.preserved)}, durationMs: ${r4.durationMs}`);
+  const stillNew = await readVersion(path.join(installDir, 'unsubscribe-cleanup'));
+  const t4ok = r4.preserved.includes('unsubscribe-cleanup') && stillNew === '99.0.0';
+  console.log(`    preserved + on-disk version untouched (${stillNew}): ${t4ok ? '✓' : '✗'}`);
+
+  // ---- Test 5: IMAP_MCP_SKIP_SKILLS_INSTALL=1 ----
+  console.log('\n[5] IMAP_MCP_SKIP_SKILLS_INSTALL=1 short-circuits');
+  process.env.IMAP_MCP_SKIP_SKILLS_INSTALL = '1';
+  const r5 = await installer.install();
+  delete process.env.IMAP_MCP_SKIP_SKILLS_INSTALL;
+  const t5ok = r5.skipped === true && r5.installed.length === 0 && r5.durationMs < 5;
+  console.log(`    skipped: ${r5.skipped}, durationMs: ${r5.durationMs} → ${t5ok ? '✓' : '✗'}`);
+
+  // ---- Cleanup: restore proper version on disk ----
+  await clean();
+  await installer.install();
+  console.log(`\nCleaned + reinstalled at proper version.`);
+
+  // ---- Summary ----
+  const all = [t1ok, t2ok, t3ok, t4ok, t5ok];
+  const passed = all.filter(Boolean).length;
+  console.log(`\n=== ${passed}/${all.length} pass ===`);
+  process.exit(passed === all.length ? 0 : 1);
+}
+
+main().catch(err => { console.error('FATAL:', err); process.exit(1); });

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": "1.0",
+  "publisher": "imap-mcp-pro",
+  "publisher_version": "2.17.0",
+  "description": "Skills bundled with imap-mcp-pro and auto-installed to the AI client's skills directory on startup. Source of truth lives in Temple-of-Epiphany/claude-skills-library; this bundle is a vendored snapshot at build time.",
+  "skills": [
+    {
+      "name": "unsubscribe-cleanup",
+      "version": "0.1.0",
+      "description": "Find and execute newsletter unsubscribes safely. Wraps imap_sync_folder_cache + imap_search_cache + the existing PR #45 unsubscribe pipeline into a confirmation-gated workflow.",
+      "content_path": "unsubscribe-cleanup/SKILL.md",
+      "content_format": "markdown",
+      "depends_on_tools": [
+        "imap_list_accounts",
+        "imap_sync_folder_cache",
+        "imap_search_cache",
+        "imap_list_unsubscribe_candidates",
+        "imap_get_unsubscribe_links",
+        "imap_execute_unsubscribe",
+        "imap_mark_subscription_unsubscribed"
+      ],
+      "min_mcp_server_version": "2.17.0"
+    }
+  ]
+}

--- a/skills/unsubscribe-cleanup/SKILL.md
+++ b/skills/unsubscribe-cleanup/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: unsubscribe-cleanup
+version: "0.1.0"
+description: "Find and execute newsletter unsubscribes safely using imap-mcp-pro. Enumerates senders ranked by message count, filters to genuine bulk-mail (List-Unsubscribe header present, never replied to), presents candidates for user confirmation, and executes selected unsubscribes via the existing imap_execute_unsubscribe pipeline. Use when the user wants to reduce newsletter clutter, stop receiving promotional mail, or clean up subscription noise."
+date_created: 2026-04-30
+date_updated: 2026-04-30
+---
+
+# Unsubscribe Cleanup
+
+## Overview
+
+This skill drives a safe, user-confirmed newsletter cleanup workflow against a single IMAP account using the `imap-mcp-pro` MCP server. It's designed for the daily-pain case where an inbox accumulates hundreds of newsletter senders and the user wants to reduce clutter without accidentally unsubscribing from anything important.
+
+The skill does **not** auto-execute. Every unsubscribe is explicitly confirmed by the user. The workflow is read-heavy (cache enumeration), mutation-light (only the chosen unsubscribes fire). It never deletes existing messages from the unsubscribed sender — unsubscribing only stops *future* mail.
+
+## When to Use
+
+**User phrases that trigger this skill:**
+
+- "clean up newsletters"
+- "unsubscribe from spam"
+- "stop these promotional emails"
+- "reduce newsletter clutter"
+- "find newsletters I never read"
+
+**Don't use this skill when:**
+
+- The user wants to *delete* existing messages (use `imap_bulk_delete_emails` directly)
+- The user wants to triage critical-vs-noise mail (defer to `email-triage` skill once available)
+- The user wants to search or research correspondence (defer to `correspondence-research` skill)
+
+## Required MCP Tools
+
+This skill depends on the `imap-mcp-pro` MCP server being installed and connected. Required tools:
+
+**Cache primitives (imap-mcp-pro v2.17.0+):**
+- `imap_sync_folder_cache` — populate the local cache for a folder
+- `imap_search_cache` — fast SQL-backed search; modes include `group_by_sender`, `by_domain`, `by_address`
+
+**Unsubscribe primitives (imap-mcp-pro PR #45+):**
+- `imap_list_unsubscribe_candidates` — read-only candidate list with subscription metadata
+- `imap_get_unsubscribe_links` — extract URLs/mailtos from a specific message
+- `imap_execute_unsubscribe` — fire the unsubscribe action (HTTP GET, POST, or mailto)
+- `imap_mark_subscription_unsubscribed` — record the action in the local subscription DB
+
+**Account discovery:**
+- `imap_list_accounts` — confirm the target account exists
+
+If any required tool is missing, stop and tell the user the MCP server needs upgrading to v2.17.0 or later.
+
+## Workflow
+
+### Step 1 — Confirm scope
+
+Ask the user (or infer from context):
+
+1. **Account** — which IMAP account? Use `imap_list_accounts` to show options if unclear. Default to the user's primary account.
+2. **Folder** — default `INBOX`. Don't operate on `Sent`, `Trash`, `Junk`, or `_Pending_Cleanup`.
+3. **Date range** — default last 90 days. The user might say "last 6 months" or "all of 2025" — convert to a since-date.
+
+Confirm scope back to the user in one sentence before proceeding: *"I'll look at INBOX in your Gmail account for newsletters received in the last 90 days."*
+
+### Step 2 — Sync the folder cache
+
+```
+imap_sync_folder_cache accountId="<id>" folder="INBOX"
+```
+
+This populates the local SQLite cache with header data. First run on a 5–10K-message folder takes 30–60 seconds. Subsequent runs are incremental (typically < 5 seconds).
+
+If the sync fails or times out, report the error and stop — don't try to proceed without the cache.
+
+### Step 3 — Enumerate sender candidates
+
+```
+imap_search_cache accountId="<id>" folder="INBOX" mode="group_by_sender" since="90d" limit=50
+```
+
+Returns rows like:
+```
+{ from_address, from_domain, from_name, count, last_seen, list_unsubscribe_present }
+```
+
+### Step 4 — Filter to high-confidence newsletter candidates
+
+Apply these filters to the result:
+
+1. `list_unsubscribe_present = true` — sender self-declared as bulk mail (RFC 2369). Highest-confidence signal.
+2. `count >= 3` — at least 3 messages in the date range. One-offs aren't newsletters.
+3. **(Optional)** Exclude senders the user has replied to. Cross-check against the Sent folder if cached (out of scope for v0.1; defer to a future enhancement).
+
+If the filter yields fewer than 5 candidates, broaden the date range and retry once. If still empty, report "no newsletter candidates found" and stop.
+
+### Step 5 — Present top 20 candidates
+
+Render as a numbered list. For each:
+
+- Sender name + address
+- Message count in range
+- Subject of most recent message (call `imap_search_cache` per-sender if needed)
+- Subscription status from the local DB (use `imap_list_unsubscribe_candidates` to enrich)
+
+Format:
+```
+ 1. Promo Daily <noreply@promodaily.com>
+    23 messages · last: "20% Off Everything Today!" (Apr 28)
+    Status: not previously unsubscribed
+
+ 2. The Verge Newsletter <newsletter@theverge.com>
+    18 messages · last: "Today in tech" (Apr 30)
+    Status: previously unsubscribed (still receiving — link may have expired)
+
+ ...
+```
+
+### Step 6 — Get user selections
+
+Ask the user to pick which to unsubscribe — by number, by sender name, or "all but #X." Never assume "do everything." If the user says "all 20," **explicitly confirm** before proceeding: *"That's 20 unsubscribes. Confirm before I proceed?"*
+
+### Step 7 — Execute with safety throttle
+
+For each selected sender:
+
+1. Get a representative message UID from cached results
+2. `imap_get_unsubscribe_links uid=<uid>` — extract the unsubscribe URL/mailto
+3. `imap_execute_unsubscribe` with the link — fire the action
+4. `imap_mark_subscription_unsubscribed` — record locally
+5. Report per-sender outcome inline: ✓ success, ✗ failed (with reason), ⚠ partial (e.g., mailto sent but unclear if processed)
+
+**Safety throttle:** if the user selected more than 5 unsubscribes, pause every 5 and ask: *"5 done so far. Continue with the next 5?"* This prevents runaway execution and gives the user a chance to bail if outcomes look wrong.
+
+### Step 8 — Final summary
+
+Report the outcome:
+
+```
+Unsubscribe summary for INBOX (Gmail):
+  ✓ Successful: 4 senders
+  ✗ Failed:     1 sender (broken unsubscribe link — recommend manual)
+  ⚠ Partial:    0 senders
+  ⏭ Skipped:    16 candidates not selected
+
+Existing messages from these senders are still in your inbox.
+Want me to also delete or archive their existing messages? (separate workflow)
+```
+
+The closing question is intentional — many users will want a follow-up cleanup of the existing mail, but that's a separate skill (`email-triage` once available) and a separate confirmation.
+
+## Safety Rules
+
+1. **Never auto-execute the full candidate list.** Always require explicit per-sender or per-batch confirmation.
+2. **Throttle at 5.** No more than 5 unsubscribes without re-confirmation.
+3. **Never delete messages.** This skill only stops *future* mail. Existing messages stay.
+4. **Never operate on Sent / Trash / Junk / Drafts.** Default folder is `INBOX`; reject other folder choices unless the user explicitly insists with reasoning.
+5. **Stop on cache failure.** Don't try to enumerate without the cache — falling back to direct IMAP would be slow and miss the `list_unsubscribe` filter.
+6. **Report failures clearly.** Broken unsubscribe links, mailto bounces, or HTTP errors should be surfaced with the sender name so the user can manually clean up.
+7. **No retry on failure.** If `imap_execute_unsubscribe` fails, report and continue. Retrying might double-process if the first attempt actually worked.
+
+## Output Format
+
+The skill emits structured Markdown for Claude Desktop's chat UI:
+
+- Scope confirmation: one sentence
+- Candidate list: numbered, with metadata indented
+- Outcome per sender: inline ✓/✗/⚠ glyph + reason
+- Final summary: counts + closing question
+
+Internal tool call structure (for the LLM's reference):
+
+```
+1. imap_list_accounts             → confirm account
+2. imap_sync_folder_cache         → populate cache
+3. imap_search_cache (group_by_sender) → enumerate
+4. imap_list_unsubscribe_candidates → enrich with subscription DB
+5. (per selection):
+   - imap_search_cache (by_address) → get a message UID
+   - imap_get_unsubscribe_links     → extract link
+   - imap_execute_unsubscribe       → fire
+   - imap_mark_subscription_unsubscribed → record
+```
+
+## Examples
+
+### Example 1 — Happy path
+
+**User:** "Clean up newsletters in my Gmail."
+
+**Claude (via skill):**
+
+> I'll look at INBOX in your Gmail account for newsletters received in the last 90 days. Syncing the local cache first…
+>
+> Cache sync complete: 8,240 messages indexed in 41 seconds.
+>
+> Top 20 newsletter candidates by message count:
+>
+> ```
+>  1. Promo Daily <noreply@promodaily.com>          — 23 msgs
+>  2. The Verge Newsletter <newsletter@theverge.com> — 18 msgs
+>  ...
+> ```
+>
+> Which to unsubscribe? (numbers, names, or "all")
+
+**User:** "1, 2, 5, 8, 11"
+
+**Claude:**
+
+> 5 selected. Executing:
+>
+> ```
+>  1. Promo Daily              ✓ Unsubscribed
+>  2. The Verge Newsletter     ✓ Unsubscribed
+>  5. RetailMeNot              ✓ Unsubscribed
+>  8. Quora Digest             ✗ Failed: unsubscribe link returned 404
+> 11. Medium Daily             ✓ Unsubscribed
+> ```
+>
+> Summary: 4 successful, 1 failed (Quora — recommend manual unsubscribe via the email itself).
+>
+> Existing messages from these senders are still in your inbox. Want me to clean them up too? (separate workflow)
+
+### Example 2 — Bail-out at the throttle
+
+**User:** "Unsubscribe from all 20."
+
+**Claude:**
+
+> That's 20 unsubscribes. Confirm before I proceed?
+
+**User:** "Yes."
+
+**Claude:** *(after first 5)*
+
+> 5 done — 4 successful, 1 failed (Quora 404). Continue with the next 5?
+
+**User:** "Stop, the Quora one worries me."
+
+**Claude:**
+
+> Stopped after 5. Final summary: 4 successful, 1 failed, 15 candidates skipped. Want me to investigate the Quora failure?
+
+### Example 3 — No candidates
+
+**User:** "Unsubscribe me from newsletters in my work account from last week."
+
+**Claude:**
+
+> I'll look at INBOX in your work account for newsletters received in the last 7 days.
+>
+> Cache sync complete: 47 messages indexed.
+>
+> No newsletter candidates found in that date range (no senders with `List-Unsubscribe` headers and ≥ 3 messages). Want me to broaden the search to the last 90 days?
+
+## Error Handling
+
+| Error | Action |
+|---|---|
+| `cache_miss` from `imap_search_cache` | Run `imap_sync_folder_cache` first; if user already requested sync and it failed, surface the underlying error |
+| `imap_sync_folder_cache` times out | Report and stop. Don't fall back to direct IMAP — the workflow assumes cache is present |
+| `imap_get_unsubscribe_links` returns empty | Skip this sender, mark "no unsubscribe link found" in summary |
+| `imap_execute_unsubscribe` HTTP 4xx/5xx | Mark ✗ with status code, continue with next |
+| `imap_execute_unsubscribe` mailto bounce | Mark ⚠ "mailto sent but bounce reported" — outcome unclear |
+| User says "stop" mid-workflow | Halt immediately; report what's been done so far |
+
+## Out of Scope (this skill version)
+
+- Cross-account unsubscribe in one workflow — single account at a time
+- Auto-deleting existing messages from unsubscribed senders (defer to `email-triage` skill)
+- Re-subscribing — this skill is one-way
+- Whitelist management ("never unsubscribe from sender X")
+- Subscription analytics / engagement scoring
+
+These can land in v0.2+ once the v0.1 workflow is validated against real usage.
+
+## Related Skills
+
+- `email-triage` (placeholder, claude-skills-library #8) — broader inbox cleanup with safe quarantine workflow
+- `correspondence-research` (placeholder, claude-skills-library #9) — search and analyze correspondence
+
+## Author
+
+- Author: Colin Bitterfield
+- Email: colin.bitterfield@templeofepiphany.com
+- Project: imap-mcp-pro
+- License: SEE LICENSE in the imap-mcp-pro repository

--- a/skills/unsubscribe-cleanup/version.json
+++ b/skills/unsubscribe-cleanup/version.json
@@ -1,0 +1,18 @@
+{
+  "name": "unsubscribe-cleanup",
+  "version": "0.1.0",
+  "date_created": "2026-04-30",
+  "date_updated": "2026-04-30",
+  "depends_on": {
+    "mcp_server": "imap-mcp-pro@>=2.17.0",
+    "tools": [
+      "imap_list_accounts",
+      "imap_sync_folder_cache",
+      "imap_search_cache",
+      "imap_list_unsubscribe_candidates",
+      "imap_get_unsubscribe_links",
+      "imap_execute_unsubscribe",
+      "imap_mark_subscription_unsubscribed"
+    ]
+  }
+}

--- a/src/database/migrations-manifest.json
+++ b/src/database/migrations-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.10.0",
+  "schemaVersion": "1.11.0",
   "description": "Release-indexed manifest of schema migrations. Each entry is applied in order via the `schema_version` ledger. A migration is complete when its `to` version is present in the ledger.",
   "migrations": [
     {
@@ -65,6 +65,13 @@
       "file": "schema_update_1.9.0_TO_1.10.0.sql",
       "rollbackFile": "schema_update_1.9.0_TO_1.10.0.down.sql",
       "description": "Add attachment_staging table for WP2 Attachment Staging API (Issue #101)"
+    },
+    {
+      "from": "1.10.0",
+      "to": "1.11.0",
+      "file": "schema_update_1.10.0_TO_1.11.0.sql",
+      "rollbackFile": "schema_update_1.10.0_TO_1.11.0.down.sql",
+      "description": "Add messages_cache table for v2.17.0 MVP local message header cache (Issue #124)"
     }
   ]
 }

--- a/src/database/schema_update_1.10.0_TO_1.11.0.down.sql
+++ b/src/database/schema_update_1.10.0_TO_1.11.0.down.sql
@@ -1,0 +1,5 @@
+-- Rollback for schema 1.10.0 → 1.11.0 (v2.17.0 MVP: messages_cache table)
+DROP INDEX IF EXISTS idx_messages_cache_date;
+DROP INDEX IF EXISTS idx_messages_cache_from_address;
+DROP INDEX IF EXISTS idx_messages_cache_from_domain;
+DROP TABLE IF EXISTS messages_cache;

--- a/src/database/schema_update_1.10.0_TO_1.11.0.sql
+++ b/src/database/schema_update_1.10.0_TO_1.11.0.sql
@@ -1,0 +1,46 @@
+-- Schema migration 1.10.0 → 1.11.0
+-- v2.17.0 MVP: local message header cache (Issue #124, Track B thin slice of #119)
+--
+-- Adds:
+--   messages_cache    Per-message header cache for fast sender enumeration
+--                     and SQL-backed search. Powers imap_sync_folder_cache
+--                     and imap_search_cache tools introduced in v2.17.0.
+--                     One row per (account_id, folder, uid). The cache is
+--                     populated explicitly by imap_sync_folder_cache; existing
+--                     read tools (imap_search_emails, imap_get_email) are NOT
+--                     transparently rewritten to consult it in v2.17.0.
+--
+-- Author: Colin Bitterfield
+-- Email: colin.bitterfield@templeofepiphany.com
+-- Date: 2026-04-30
+
+CREATE TABLE IF NOT EXISTS messages_cache (
+  account_id        TEXT NOT NULL,
+  folder            TEXT NOT NULL,
+  uid               INTEGER NOT NULL,
+  uid_validity      INTEGER NOT NULL,        -- detect mailbox renumbering
+  message_id        TEXT,                    -- RFC 5322 Message-ID
+  date_received     INTEGER,                 -- unix milliseconds
+  subject           TEXT,
+  from_address      TEXT,                    -- normalized lowercase
+  from_domain       TEXT,                    -- denormalized for GROUP BY
+  from_name         TEXT,                    -- "John Smith" — searchable display name
+  list_unsubscribe  TEXT,                    -- raw List-Unsubscribe header (RFC 2369)
+  flags_json        TEXT,                    -- JSON array of flags ['\\Seen', '\\Flagged']
+  cached_at         INTEGER NOT NULL,        -- unix ms when this row was last refreshed
+  PRIMARY KEY (account_id, folder, uid),
+  FOREIGN KEY (account_id) REFERENCES accounts(account_id) ON DELETE CASCADE
+);
+
+-- Sender domain GROUP BY (top-N senders by count) — primary search path.
+CREATE INDEX IF NOT EXISTS idx_messages_cache_from_domain
+  ON messages_cache(account_id, from_domain);
+
+-- Sender address lookup (specific sender's mail).
+CREATE INDEX IF NOT EXISTS idx_messages_cache_from_address
+  ON messages_cache(account_id, from_address);
+
+-- Date range filtering ("last 90 days") — combined with from_domain in the
+-- compound index above, this carries a wide range of triage queries.
+CREATE INDEX IF NOT EXISTS idx_messages_cache_date
+  ON messages_cache(account_id, date_received);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { ResultsService } from './services/results-service.js';
 import { SentFolderService } from './services/sent-folder-service.js';
 import { AppendRetryService } from './services/append-retry-service.js';
 import { AttachmentStagingService, DEFAULT_STAGING_CONFIG } from './services/attachment-staging-service.js';
+import { MessageCacheService } from './services/message-cache-service.js';
 import os from 'os';
 import { WorkerPool } from './utils/worker-pool.js';
 import { registerTools } from './tools/index.js';
@@ -51,7 +52,7 @@ await dispatchCli({
 
 const {
   server, imapService, smtpService, db, fileExport, results, workerPool,
-  sentFolderService, appendRetryService, attachmentStaging,
+  sentFolderService, appendRetryService, attachmentStaging, messageCache,
 } = await timeStage('pre-handshake', async () => {
     // 1. Load + validate config
     let config;
@@ -108,10 +109,13 @@ const {
       perUserMaxBytes: Number(process.env.IMAP_MCP_MAX_STAGING_BYTES_PER_USER ?? 500 * 1024 * 1024),
     });
 
+    // 6d. v2.17.0 MVP: local message header cache (no I/O at construction time)
+    const messageCache = new MessageCacheService(db, imapService);
+
     // 7. Tool schema registration
     registerTools(
       server, imapService, db, smtpService, results, workerPool,
-      sentFolderService, appendRetryService, attachmentStaging
+      sentFolderService, appendRetryService, attachmentStaging, messageCache
     );
 
     // Mark unused config field as intentional for now
@@ -119,7 +123,7 @@ const {
 
     return {
       server, imapService, smtpService, db, fileExport, results, workerPool,
-      sentFolderService, appendRetryService, attachmentStaging,
+      sentFolderService, appendRetryService, attachmentStaging, messageCache,
     };
   });
 
@@ -194,9 +198,10 @@ async function buildToolsManifest(): Promise<unknown> {
     ...DEFAULT_STAGING_CONFIG,
     stagingDir: path.join(os.homedir(), '.imap-mcp', 'staging'),
   });
+  const tmpMessageCache = new MessageCacheService(tmpDb, tmpImap);
   registerTools(
     tmpServer, tmpImap, tmpDb, tmpSmtp, tmpResults, tmpWorkerPool,
-    tmpSentFolder, tmpAppendRetry, tmpStaging
+    tmpSentFolder, tmpAppendRetry, tmpStaging, tmpMessageCache
   );
 
   // Pull the registered tools out of McpServer's internal map. This is
@@ -262,3 +267,4 @@ process.on('SIGTERM', () => shutdown('SIGTERM'));
 
 // keep refs alive
 void imapService; void smtpService; void db; void sentFolderService;
+void messageCache;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { SentFolderService } from './services/sent-folder-service.js';
 import { AppendRetryService } from './services/append-retry-service.js';
 import { AttachmentStagingService, DEFAULT_STAGING_CONFIG } from './services/attachment-staging-service.js';
 import { MessageCacheService } from './services/message-cache-service.js';
+import { SkillsInstallerService } from './services/skills-installer-service.js';
 import os from 'os';
 import { WorkerPool } from './utils/worker-pool.js';
 import { registerTools } from './tools/index.js';
@@ -163,6 +164,29 @@ void timeStage('post-handshake', async () => {
     logEvent('[startup]', { component: 'staging-gc', msg: 'GC timer started' });
   } catch (e: any) {
     logEvent('[startup]', { component: 'staging-gc', outcome: 'error', error: e?.message });
+  }
+
+  // v2.17.0 MVP (#124): copy bundled skills to ~/.claude/skills/imap-mcp-pro/.
+  // Idempotent — skips skills already at the bundled version. Best-effort:
+  // a failure here is logged but never blocks tool availability.
+  try {
+    const bundleDir = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      'skills',
+    );
+    const installer = new SkillsInstallerService(bundleDir);
+    const r = await installer.install();
+    logEvent('[startup]', {
+      component: 'skills-install',
+      installed: r.installed,
+      updated: r.updated,
+      unchanged: r.unchanged.length,
+      preserved: r.preserved,
+      skipped: r.skipped,
+      durationMs: r.durationMs,
+    });
+  } catch (e: any) {
+    logEvent('[startup]', { component: 'skills-install', outcome: 'error', error: e?.message });
   }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ const {
 
     // 2. Construct McpServer with explicit capabilities (closes #80)
     const server = new McpServer(
-      { name: 'imap-mcp-pro', version: '2.16.0' },
+      { name: 'imap-mcp-pro', version: '2.17.0' },
       { capabilities: SERVER_CAPABILITIES }
     );
 
@@ -203,7 +203,7 @@ async function buildToolsManifest(): Promise<unknown> {
 
   // Construct the same server object but never call server.connect().
   const tmpServer = new McpServer(
-    { name: 'imap-mcp-pro', version: '2.16.0' },
+    { name: 'imap-mcp-pro', version: '2.17.0' },
     { capabilities: SERVER_CAPABILITIES }
   );
   const tmpDb = new DatabaseService();

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -1140,6 +1140,52 @@ export class ImapService {
     }, `bulkRemoveKeyword(${folderName}, ${keyword}, ${uids.length} messages)`);
   }
 
+  // ============================================================================
+  // v2.17.0 MVP: header fetch for MessageCacheService (Issue #124)
+  // ============================================================================
+
+  /**
+   * Open a folder and fetch envelope + flags + raw headers for a UID range.
+   * Returns the folder's current UIDVALIDITY/UIDNEXT alongside the messages
+   * so the caller can detect mailbox renumbering and decide whether to wipe
+   * the local cache.
+   *
+   * Pass `uidRange = null` to skip the fetch entirely (useful when the caller
+   * only needs the UIDVALIDITY/UIDNEXT to decide there's nothing new to fetch).
+   */
+  async fetchHeadersForCache(
+    accountId: string,
+    folderName: string,
+    uidRange: string | null,
+    options?: { headers?: string[] }
+  ): Promise<{
+    uidValidity: number;
+    uidNext: number;
+    messages: FetchMessageObject[];
+  }> {
+    return this.withRetry(accountId, async () => {
+      const client = this.getConnection(accountId);
+      const mailbox = await client.mailboxOpen(folderName);
+      const uidValidity = Number(mailbox.uidValidity ?? 0);
+      const uidNext = Number(mailbox.uidNext ?? 0);
+
+      const messages: FetchMessageObject[] = [];
+      if (uidRange !== null) {
+        const fetchOpts: any = {
+          uid: true,
+          flags: true,
+          envelope: true,
+          headers: options?.headers ?? ['list-unsubscribe'],
+        };
+        for await (const msg of client.fetch(uidRange, fetchOpts, { uid: true })) {
+          messages.push(msg);
+        }
+      }
+
+      return { uidValidity, uidNext, messages };
+    }, `fetchHeadersForCache(${folderName}, ${uidRange ?? 'status-only'})`);
+  }
+
   // RFC 9051: APPEND command (Issue #52)
   async appendMessage(
     accountId: string,

--- a/src/services/message-cache-service.ts
+++ b/src/services/message-cache-service.ts
@@ -1,0 +1,186 @@
+/**
+ * MessageCacheService — local SQLite header cache for fast sender enumeration.
+ *
+ * v2.17.0 MVP scope (Issue #124, thin slice of Track B / #119):
+ *   - One table: messages_cache (account_id, folder, uid, header fields)
+ *   - Explicit sync (no transparent rewrite of existing tools)
+ *   - Three search modes: by_domain, by_address, group_by_sender
+ *   - Cache miss returns an explicit error — no silent IMAP fallback
+ *
+ * Out of scope for v2.17.0 (deferred to full B.1 in #119):
+ *   - Participants table, attachments table, threading columns
+ *   - Cache mutation write-through on flag changes
+ *   - Multi-folder sync (one folder per call)
+ *   - Body cache, FTS5 index
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-04-30
+ * Date Updated: 2026-04-30
+ * Version: 0.1.0
+ */
+
+import { DatabaseService } from './database-service.js';
+import { ImapService } from './imap-service.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Row shape persisted in the messages_cache table. */
+export interface CachedMessageRow {
+  accountId: string;
+  folder: string;
+  uid: number;
+  uidValidity: number;
+  messageId: string | null;
+  dateReceived: number | null;          // unix ms
+  subject: string | null;
+  fromAddress: string | null;           // normalized lowercase
+  fromDomain: string | null;
+  fromName: string | null;
+  listUnsubscribe: string | null;
+  flags: string[];
+  cachedAt: number;                     // unix ms
+}
+
+export interface SyncFolderOptions {
+  /** Force full resync regardless of UIDVALIDITY. */
+  fullResync?: boolean;
+}
+
+export interface SyncFolderReport {
+  accountId: string;
+  folder: string;
+  uidValidity: number;
+  /** True if UIDVALIDITY changed and cache was wiped before this sync. */
+  uidValidityChanged: boolean;
+  rowsBefore: number;
+  rowsAfter: number;
+  rowsAdded: number;
+  rowsUpdated: number;
+  durationMs: number;
+}
+
+export interface SearchOptions {
+  /** Lower bound for date_received (unix ms). Optional. */
+  since?: number;
+  /** Upper bound for date_received (unix ms). Optional. */
+  until?: number;
+  /** Cap on returned rows. Default 50. */
+  limit?: number;
+}
+
+export interface SenderGroupRow {
+  fromAddress: string;
+  fromDomain: string;
+  fromName: string | null;
+  count: number;
+  lastSeen: number;                     // most recent date_received in the group
+  listUnsubscribePresent: boolean;      // any row in the group has the header
+}
+
+/** Cache miss is an explicit error — caller (tool layer) translates it to a
+ *  structured response rather than silently falling back to IMAP. */
+export class CacheMissError extends Error {
+  readonly accountId: string;
+  readonly folder: string;
+  constructor(accountId: string, folder: string) {
+    super(`Cache miss: folder "${folder}" on account "${accountId}" has not been synced. ` +
+          `Call imap_sync_folder_cache first.`);
+    this.name = 'CacheMissError';
+    this.accountId = accountId;
+    this.folder = folder;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class MessageCacheService {
+  constructor(
+    private db: DatabaseService,
+    private imap: ImapService,
+  ) {}
+
+  /**
+   * Sync a folder's headers into the local cache. Idempotent.
+   *
+   * Behavior:
+   *   1. Resolve current UIDVALIDITY from IMAP.
+   *   2. If the cache holds rows for this (accountId, folder) at a different
+   *      UIDVALIDITY (or fullResync=true), drop those rows.
+   *   3. UID FETCH headers for every UID not already in the cache at the
+   *      current UIDVALIDITY. Insert rows.
+   *   4. Return a report with row counts + duration.
+   *
+   * @throws AccountNotFoundError, FolderNotFoundError, ImapConnectionError
+   */
+  async syncFolder(
+    _accountId: string,
+    _folder: string,
+    _options: SyncFolderOptions = {},
+  ): Promise<SyncFolderReport> {
+    throw new Error('MessageCacheService.syncFolder: not yet implemented (v2.17.0 MVP.1)');
+  }
+
+  /**
+   * Return cached rows where from_domain matches `domain` (case-insensitive).
+   * Throws CacheMissError if the folder has never been synced.
+   */
+  async searchByFromDomain(
+    _accountId: string,
+    _folder: string,
+    _domain: string,
+    _options: SearchOptions = {},
+  ): Promise<CachedMessageRow[]> {
+    throw new Error('MessageCacheService.searchByFromDomain: not yet implemented (v2.17.0 MVP.1)');
+  }
+
+  /**
+   * Return cached rows where from_address matches `address` exactly
+   * (case-insensitive). Throws CacheMissError if the folder has never been synced.
+   */
+  async searchByFromAddress(
+    _accountId: string,
+    _folder: string,
+    _address: string,
+    _options: SearchOptions = {},
+  ): Promise<CachedMessageRow[]> {
+    throw new Error('MessageCacheService.searchByFromAddress: not yet implemented (v2.17.0 MVP.1)');
+  }
+
+  /**
+   * Group cached rows by from_address, return top N senders by message count.
+   * Throws CacheMissError if the folder has never been synced.
+   */
+  async groupBySender(
+    _accountId: string,
+    _folder: string,
+    _options: SearchOptions = {},
+  ): Promise<SenderGroupRow[]> {
+    throw new Error('MessageCacheService.groupBySender: not yet implemented (v2.17.0 MVP.1)');
+  }
+
+  /**
+   * Drop cache rows for one folder (folder=string) or an entire account
+   * (folder=undefined). Returns the number of rows removed.
+   */
+  async invalidate(_accountId: string, _folder?: string): Promise<number> {
+    throw new Error('MessageCacheService.invalidate: not yet implemented (v2.17.0 MVP.1)');
+  }
+
+  /**
+   * Diagnostic: per-folder cached row count + last sync time.
+   * Read-only; safe to call before any sync has happened (returns []).
+   */
+  async getStatus(_accountId: string): Promise<Array<{
+    folder: string;
+    rowCount: number;
+    uidValidity: number;
+    lastCachedAt: number;
+  }>> {
+    throw new Error('MessageCacheService.getStatus: not yet implemented (v2.17.0 MVP.1)');
+  }
+}

--- a/src/services/message-cache-service.ts
+++ b/src/services/message-cache-service.ts
@@ -13,15 +13,21 @@
  *   - Multi-folder sync (one folder per call)
  *   - Body cache, FTS5 index
  *
+ * Cache-miss heuristic: a folder is considered "synced" when at least one row
+ * exists for (account_id, folder). MVP limitation — an empty folder that was
+ * legitimately synced will look like a cache miss. Acceptable for v2.17.0;
+ * v2.18.0 may add a folder_cache_state table to track sync without rows.
+ *
  * Author: Colin Bitterfield
  * Email: colin.bitterfield@templeofepiphany.com
  * Date Created: 2026-04-30
  * Date Updated: 2026-04-30
- * Version: 0.1.0
+ * Version: 0.2.0
  */
 
 import { DatabaseService } from './database-service.js';
 import { ImapService } from './imap-service.js';
+import type { FetchMessageObject } from 'imapflow';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -95,6 +101,105 @@ export class CacheMissError extends Error {
 }
 
 // ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Pull domain off "user@host" → "host" (lowercase). */
+function extractDomain(address: string | null): string | null {
+  if (!address) return null;
+  const at = address.lastIndexOf('@');
+  if (at < 0 || at === address.length - 1) return null;
+  return address.slice(at + 1).toLowerCase();
+}
+
+/** Find a header in imapflow's raw-headers Buffer (case-insensitive,
+ *  handles folded continuation lines). */
+function extractHeader(headersBuf: Buffer | undefined, name: string): string | null {
+  if (!headersBuf || headersBuf.length === 0) return null;
+  const text = headersBuf.toString('utf8');
+  const lines = text.split(/\r?\n/);
+  const lowerName = name.toLowerCase() + ':';
+  let value: string | null = null;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.toLowerCase().startsWith(lowerName)) {
+      value = line.slice(lowerName.length).trim();
+      // Continuation lines start with whitespace; concatenate.
+      while (i + 1 < lines.length && /^[ \t]/.test(lines[i + 1])) {
+        i++;
+        value += ' ' + lines[i].trim();
+      }
+      return value;
+    }
+  }
+  return null;
+}
+
+/** Convert imapflow's FetchMessageObject into a CachedMessageRow. */
+function toCacheRow(
+  accountId: string,
+  folder: string,
+  uidValidity: number,
+  cachedAt: number,
+  msg: FetchMessageObject,
+): CachedMessageRow | null {
+  if (!msg || typeof msg.uid !== 'number') return null;
+
+  const fromEntry = msg.envelope?.from?.[0];
+  const fromAddrRaw = fromEntry?.address ?? null;
+  const fromAddress = fromAddrRaw ? fromAddrRaw.toLowerCase() : null;
+  const fromDomain = extractDomain(fromAddress);
+  const fromName = fromEntry?.name ?? null;
+
+  // imapflow gives `headers` as a Buffer when fetched via `headers: [...]`.
+  const headersBuf = (msg as any).headers as Buffer | undefined;
+  const listUnsubscribe = extractHeader(headersBuf, 'List-Unsubscribe');
+
+  const date = msg.envelope?.date instanceof Date ? msg.envelope.date.getTime()
+             : msg.envelope?.date ? new Date(msg.envelope.date as any).getTime()
+             : null;
+
+  return {
+    accountId,
+    folder,
+    uid: msg.uid,
+    uidValidity,
+    messageId: msg.envelope?.messageId ?? null,
+    dateReceived: date,
+    subject: msg.envelope?.subject ?? null,
+    fromAddress,
+    fromDomain,
+    fromName,
+    listUnsubscribe,
+    flags: msg.flags ? Array.from(msg.flags) : [],
+    cachedAt,
+  };
+}
+
+/** Row coming back from SQLite → typed CachedMessageRow. */
+function rowFromDb(r: any): CachedMessageRow {
+  let flags: string[] = [];
+  try {
+    if (r.flags_json) flags = JSON.parse(r.flags_json);
+  } catch { /* swallow */ }
+  return {
+    accountId: r.account_id,
+    folder: r.folder,
+    uid: r.uid,
+    uidValidity: r.uid_validity,
+    messageId: r.message_id,
+    dateReceived: r.date_received,
+    subject: r.subject,
+    fromAddress: r.from_address,
+    fromDomain: r.from_domain,
+    fromName: r.from_name,
+    listUnsubscribe: r.list_unsubscribe,
+    flags,
+    cachedAt: r.cached_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
 
@@ -108,79 +213,270 @@ export class MessageCacheService {
    * Sync a folder's headers into the local cache. Idempotent.
    *
    * Behavior:
-   *   1. Resolve current UIDVALIDITY from IMAP.
-   *   2. If the cache holds rows for this (accountId, folder) at a different
-   *      UIDVALIDITY (or fullResync=true), drop those rows.
-   *   3. UID FETCH headers for every UID not already in the cache at the
-   *      current UIDVALIDITY. Insert rows.
-   *   4. Return a report with row counts + duration.
-   *
-   * @throws AccountNotFoundError, FolderNotFoundError, ImapConnectionError
+   *   1. Read existing cache state (count, max uid, uid_validity).
+   *   2. Open IMAP folder, read current UIDVALIDITY + UIDNEXT.
+   *   3. If cached UIDVALIDITY differs (or fullResync=true), wipe rows.
+   *   4. Fetch every UID > max-cached-UID (or 1:* on full resync).
+   *   5. INSERT OR REPLACE rows in a single transaction.
+   *   6. Return a SyncFolderReport.
    */
   async syncFolder(
-    _accountId: string,
-    _folder: string,
-    _options: SyncFolderOptions = {},
+    accountId: string,
+    folder: string,
+    options: SyncFolderOptions = {},
   ): Promise<SyncFolderReport> {
-    throw new Error('MessageCacheService.syncFolder: not yet implemented (v2.17.0 MVP.1)');
+    const start = Date.now();
+    const rawDb = this.db.getDb();
+
+    // 1. Existing cache state for this folder.
+    const existing = rawDb.prepare(
+      `SELECT
+         COUNT(*)          AS count,
+         MAX(uid)          AS max_uid,
+         MAX(uid_validity) AS uid_validity
+       FROM messages_cache
+       WHERE account_id = $a AND folder = $f`
+    ).get({ $a: accountId, $f: folder }) as
+      | { count: number; max_uid: number | null; uid_validity: number | null }
+      | undefined;
+
+    const rowsBefore = existing?.count ?? 0;
+    const cachedUidValidity = existing?.uid_validity ?? null;
+    const maxCachedUid = existing?.max_uid ?? 0;
+
+    // 2. Resolve current IMAP folder state (no fetch yet).
+    const head = await this.imap.fetchHeadersForCache(accountId, folder, null);
+    const currentUidValidity = head.uidValidity;
+    const currentUidNext = head.uidNext;
+
+    // 3. Decide: full resync or incremental?
+    const uidValidityChanged =
+      cachedUidValidity !== null && cachedUidValidity !== currentUidValidity;
+    const fullResync = options.fullResync === true || uidValidityChanged;
+
+    if (fullResync && rowsBefore > 0) {
+      rawDb.prepare(
+        `DELETE FROM messages_cache WHERE account_id = $a AND folder = $f`
+      ).run({ $a: accountId, $f: folder });
+    }
+
+    const baseRows = fullResync ? 0 : rowsBefore;
+
+    // 4. Compute UID range. Skip fetch entirely when there's nothing new.
+    const fetchFrom = fullResync ? 1 : maxCachedUid + 1;
+    const nothingNew = currentUidNext > 0 && fetchFrom >= currentUidNext;
+
+    let rowsAdded = 0;
+    if (!nothingNew) {
+      const uidRange = `${fetchFrom}:*`;
+      const fetched = await this.imap.fetchHeadersForCache(accountId, folder, uidRange);
+
+      // 5. Insert in a single transaction for performance.
+      const insert = rawDb.prepare(`
+        INSERT OR REPLACE INTO messages_cache (
+          account_id, folder, uid, uid_validity, message_id, date_received,
+          subject, from_address, from_domain, from_name, list_unsubscribe,
+          flags_json, cached_at
+        ) VALUES (
+          $accountId, $folder, $uid, $uidValidity, $messageId, $dateReceived,
+          $subject, $fromAddress, $fromDomain, $fromName, $listUnsubscribe,
+          $flagsJson, $cachedAt
+        )
+      `);
+
+      const cachedAt = Date.now();
+      rawDb.exec('BEGIN');
+      try {
+        for (const msg of fetched.messages) {
+          const row = toCacheRow(accountId, folder, currentUidValidity, cachedAt, msg);
+          if (!row) continue;
+          insert.run({
+            $accountId: row.accountId,
+            $folder: row.folder,
+            $uid: row.uid,
+            $uidValidity: row.uidValidity,
+            $messageId: row.messageId,
+            $dateReceived: row.dateReceived,
+            $subject: row.subject,
+            $fromAddress: row.fromAddress,
+            $fromDomain: row.fromDomain,
+            $fromName: row.fromName,
+            $listUnsubscribe: row.listUnsubscribe,
+            $flagsJson: JSON.stringify(row.flags),
+            $cachedAt: row.cachedAt,
+          });
+          rowsAdded++;
+        }
+        rawDb.exec('COMMIT');
+      } catch (e) {
+        try { rawDb.exec('ROLLBACK'); } catch { /* swallow */ }
+        throw e;
+      }
+    }
+
+    return {
+      accountId,
+      folder,
+      uidValidity: currentUidValidity,
+      uidValidityChanged,
+      rowsBefore,
+      rowsAfter: baseRows + rowsAdded,
+      rowsAdded,
+      rowsUpdated: 0,                   // INSERT OR REPLACE doesn't distinguish
+      durationMs: Date.now() - start,
+    };
   }
 
-  /**
-   * Return cached rows where from_domain matches `domain` (case-insensitive).
-   * Throws CacheMissError if the folder has never been synced.
-   */
+  /** Throw CacheMissError if the folder has no cached rows. */
+  private assertSynced(accountId: string, folder: string): void {
+    const row = this.db.getDb().prepare(
+      `SELECT 1 FROM messages_cache WHERE account_id = $a AND folder = $f LIMIT 1`
+    ).get({ $a: accountId, $f: folder });
+    if (!row) throw new CacheMissError(accountId, folder);
+  }
+
   async searchByFromDomain(
-    _accountId: string,
-    _folder: string,
-    _domain: string,
-    _options: SearchOptions = {},
+    accountId: string,
+    folder: string,
+    domain: string,
+    options: SearchOptions = {},
   ): Promise<CachedMessageRow[]> {
-    throw new Error('MessageCacheService.searchByFromDomain: not yet implemented (v2.17.0 MVP.1)');
+    this.assertSynced(accountId, folder);
+    const limit = Math.min(options.limit ?? 50, 1000);
+    const params: Record<string, unknown> = {
+      $a: accountId,
+      $f: folder,
+      $d: domain.toLowerCase(),
+      $limit: limit,
+    };
+    let where = `account_id = $a AND folder = $f AND from_domain = $d`;
+    if (options.since !== undefined) { where += ` AND date_received >= $since`; params.$since = options.since; }
+    if (options.until !== undefined) { where += ` AND date_received <= $until`; params.$until = options.until; }
+
+    const rows = this.db.getDb().prepare(
+      `SELECT * FROM messages_cache WHERE ${where}
+       ORDER BY date_received DESC LIMIT $limit`
+    ).all(params as any) as any[];
+
+    return rows.map(rowFromDb);
   }
 
-  /**
-   * Return cached rows where from_address matches `address` exactly
-   * (case-insensitive). Throws CacheMissError if the folder has never been synced.
-   */
   async searchByFromAddress(
-    _accountId: string,
-    _folder: string,
-    _address: string,
-    _options: SearchOptions = {},
+    accountId: string,
+    folder: string,
+    address: string,
+    options: SearchOptions = {},
   ): Promise<CachedMessageRow[]> {
-    throw new Error('MessageCacheService.searchByFromAddress: not yet implemented (v2.17.0 MVP.1)');
+    this.assertSynced(accountId, folder);
+    const limit = Math.min(options.limit ?? 50, 1000);
+    const params: Record<string, unknown> = {
+      $a: accountId,
+      $f: folder,
+      $addr: address.toLowerCase(),
+      $limit: limit,
+    };
+    let where = `account_id = $a AND folder = $f AND from_address = $addr`;
+    if (options.since !== undefined) { where += ` AND date_received >= $since`; params.$since = options.since; }
+    if (options.until !== undefined) { where += ` AND date_received <= $until`; params.$until = options.until; }
+
+    const rows = this.db.getDb().prepare(
+      `SELECT * FROM messages_cache WHERE ${where}
+       ORDER BY date_received DESC LIMIT $limit`
+    ).all(params as any) as any[];
+
+    return rows.map(rowFromDb);
   }
 
-  /**
-   * Group cached rows by from_address, return top N senders by message count.
-   * Throws CacheMissError if the folder has never been synced.
-   */
   async groupBySender(
-    _accountId: string,
-    _folder: string,
-    _options: SearchOptions = {},
+    accountId: string,
+    folder: string,
+    options: SearchOptions = {},
   ): Promise<SenderGroupRow[]> {
-    throw new Error('MessageCacheService.groupBySender: not yet implemented (v2.17.0 MVP.1)');
+    this.assertSynced(accountId, folder);
+    const limit = Math.min(options.limit ?? 50, 1000);
+    const params: Record<string, unknown> = {
+      $a: accountId,
+      $f: folder,
+      $limit: limit,
+    };
+    let where = `account_id = $a AND folder = $f AND from_address IS NOT NULL`;
+    if (options.since !== undefined) { where += ` AND date_received >= $since`; params.$since = options.since; }
+    if (options.until !== undefined) { where += ` AND date_received <= $until`; params.$until = options.until; }
+
+    const rows = this.db.getDb().prepare(
+      `SELECT
+         from_address                                              AS from_address,
+         MIN(from_domain)                                          AS from_domain,
+         MIN(COALESCE(from_name, ''))                              AS from_name,
+         COUNT(*)                                                  AS count,
+         MAX(date_received)                                        AS last_seen,
+         MAX(CASE WHEN list_unsubscribe IS NOT NULL THEN 1 ELSE 0 END)
+                                                                   AS list_unsubscribe_present
+       FROM messages_cache
+       WHERE ${where}
+       GROUP BY from_address
+       ORDER BY count DESC, last_seen DESC
+       LIMIT $limit`
+    ).all(params as any) as Array<{
+      from_address: string;
+      from_domain: string | null;
+      from_name: string;
+      count: number;
+      last_seen: number | null;
+      list_unsubscribe_present: number;
+    }>;
+
+    return rows.map(r => ({
+      fromAddress: r.from_address,
+      fromDomain: r.from_domain ?? '',
+      fromName: r.from_name === '' ? null : r.from_name,
+      count: r.count,
+      lastSeen: r.last_seen ?? 0,
+      listUnsubscribePresent: r.list_unsubscribe_present === 1,
+    }));
   }
 
-  /**
-   * Drop cache rows for one folder (folder=string) or an entire account
-   * (folder=undefined). Returns the number of rows removed.
-   */
-  async invalidate(_accountId: string, _folder?: string): Promise<number> {
-    throw new Error('MessageCacheService.invalidate: not yet implemented (v2.17.0 MVP.1)');
+  /** Drop cache rows for one folder or an entire account. Returns rows removed. */
+  async invalidate(accountId: string, folder?: string): Promise<number> {
+    const rawDb = this.db.getDb();
+    const result = folder !== undefined
+      ? rawDb.prepare(
+          `DELETE FROM messages_cache WHERE account_id = $a AND folder = $f`
+        ).run({ $a: accountId, $f: folder })
+      : rawDb.prepare(
+          `DELETE FROM messages_cache WHERE account_id = $a`
+        ).run({ $a: accountId });
+    return Number(result.changes ?? 0);
   }
 
-  /**
-   * Diagnostic: per-folder cached row count + last sync time.
-   * Read-only; safe to call before any sync has happened (returns []).
-   */
-  async getStatus(_accountId: string): Promise<Array<{
+  /** Per-folder cached row count + last sync time. Read-only; safe before sync. */
+  async getStatus(accountId: string): Promise<Array<{
     folder: string;
     rowCount: number;
     uidValidity: number;
     lastCachedAt: number;
   }>> {
-    throw new Error('MessageCacheService.getStatus: not yet implemented (v2.17.0 MVP.1)');
+    const rows = this.db.getDb().prepare(
+      `SELECT folder,
+              COUNT(*)             AS row_count,
+              MIN(uid_validity)    AS uid_validity,
+              MAX(cached_at)       AS last_cached_at
+       FROM messages_cache
+       WHERE account_id = $a
+       GROUP BY folder
+       ORDER BY folder`
+    ).all({ $a: accountId }) as Array<{
+      folder: string;
+      row_count: number;
+      uid_validity: number;
+      last_cached_at: number;
+    }>;
+
+    return rows.map(r => ({
+      folder: r.folder,
+      rowCount: r.row_count,
+      uidValidity: r.uid_validity,
+      lastCachedAt: r.last_cached_at,
+    }));
   }
 }

--- a/src/services/skills-installer-service.ts
+++ b/src/services/skills-installer-service.ts
@@ -1,0 +1,187 @@
+/**
+ * SkillsInstallerService — copy bundled skills from dist/skills/ to the AI
+ * client's skills directory on startup.
+ *
+ * v2.17.0 MVP scope (Issue #124, thin slice of #120):
+ *   - Hardcoded install path: ~/.claude/skills/imap-mcp-pro/
+ *   - Startup-only install (no periodic refresh)
+ *   - Version-compare overwrite (no SHA-based user-edit preservation)
+ *   - Skip if disabled via IMAP_MCP_SKIP_SKILLS_INSTALL=1
+ *
+ * Out of scope (deferred to full #120 design):
+ *   - Configurable install path
+ *   - Periodic TTL-based re-sync
+ *   - SHA comparison to preserve user edits
+ *   - imap_get_skills_manifest tool for remote consumers
+ *
+ * Bundle layout (produced by scripts/postbuild.mjs):
+ *
+ *   dist/skills/
+ *     manifest.json
+ *     <skill-name>/SKILL.md
+ *     <skill-name>/version.json
+ *
+ * Install layout (created by this service):
+ *
+ *   ~/.claude/skills/imap-mcp-pro/
+ *     <skill-name>/SKILL.md
+ *     <skill-name>/version.json
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-05-01
+ * Version: 0.1.0
+ *
+ * Tracker: #124 (MVP umbrella). Full design: #120.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SkillsInstallReport {
+  /** Skills that didn't exist on disk and were freshly copied. */
+  installed: string[];
+  /** Skills present on disk with an older version that were overwritten. */
+  updated: string[];
+  /** Skills already at the bundled version (no-op). */
+  unchanged: string[];
+  /** Skills the user has modified or that have a newer on-disk version. */
+  preserved: string[];
+  /** Skipped entirely via IMAP_MCP_SKIP_SKILLS_INSTALL=1. */
+  skipped: boolean;
+  durationMs: number;
+}
+
+interface BundleManifest {
+  manifest_version: string;
+  publisher: string;
+  publisher_version?: string;
+  skills: Array<{
+    name: string;
+    version: string;
+    description?: string;
+    content_path?: string;
+    min_mcp_server_version?: string;
+  }>;
+}
+
+interface SkillVersionFile {
+  name: string;
+  version: string;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class SkillsInstallerService {
+  /**
+   * @param bundleDir  Absolute path to the bundle root (e.g. dist/skills/)
+   * @param installDir Absolute path to install root (default: ~/.claude/skills/imap-mcp-pro/)
+   */
+  constructor(
+    private bundleDir: string,
+    private installDir: string = path.join(os.homedir(), '.claude', 'skills', 'imap-mcp-pro'),
+  ) {}
+
+  /**
+   * Run the install. Idempotent. Safe to call on every startup.
+   */
+  async install(): Promise<SkillsInstallReport> {
+    const start = Date.now();
+    const report: SkillsInstallReport = {
+      installed: [],
+      updated: [],
+      unchanged: [],
+      preserved: [],
+      skipped: false,
+      durationMs: 0,
+    };
+
+    if (process.env.IMAP_MCP_SKIP_SKILLS_INSTALL === '1') {
+      report.skipped = true;
+      report.durationMs = Date.now() - start;
+      return report;
+    }
+
+    // 1. Read bundle manifest. If absent, no skills to install — return empty report.
+    let manifest: BundleManifest;
+    try {
+      const raw = await fs.readFile(path.join(this.bundleDir, 'manifest.json'), 'utf8');
+      manifest = JSON.parse(raw) as BundleManifest;
+    } catch (e: any) {
+      if (e?.code === 'ENOENT') {
+        report.durationMs = Date.now() - start;
+        return report;
+      }
+      throw e;
+    }
+
+    // 2. Ensure install root exists.
+    await fs.mkdir(this.installDir, { recursive: true });
+
+    // 3. Per-skill: compare versions, copy if needed.
+    for (const entry of manifest.skills) {
+      const bundleSkillDir = path.join(this.bundleDir, entry.name);
+      const installSkillDir = path.join(this.installDir, entry.name);
+
+      const installedVersion = await this.readInstalledVersion(installSkillDir);
+
+      if (installedVersion === null) {
+        await this.copySkill(bundleSkillDir, installSkillDir);
+        report.installed.push(entry.name);
+      } else if (compareSemver(entry.version, installedVersion) > 0) {
+        // Bundle is newer → overwrite. (MVP cut: no SHA-based user-edit
+        // preservation; documented limitation.)
+        await this.copySkill(bundleSkillDir, installSkillDir);
+        report.updated.push(entry.name);
+      } else if (compareSemver(entry.version, installedVersion) === 0) {
+        report.unchanged.push(entry.name);
+      } else {
+        // On-disk version is newer than bundle — leave it alone.
+        report.preserved.push(entry.name);
+      }
+    }
+
+    report.durationMs = Date.now() - start;
+    return report;
+  }
+
+  /** Read version.json from an installed skill, return its version or null. */
+  private async readInstalledVersion(skillDir: string): Promise<string | null> {
+    try {
+      const raw = await fs.readFile(path.join(skillDir, 'version.json'), 'utf8');
+      const parsed = JSON.parse(raw) as SkillVersionFile;
+      return typeof parsed.version === 'string' ? parsed.version : null;
+    } catch (e: any) {
+      if (e?.code === 'ENOENT') return null;
+      throw e;
+    }
+  }
+
+  /** Copy bundle skill dir → install location, replacing existing content. */
+  private async copySkill(srcDir: string, dstDir: string): Promise<void> {
+    await fs.mkdir(dstDir, { recursive: true });
+    await fs.cp(srcDir, dstDir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: trivial semver compare (MVP — no prerelease handling)
+// ---------------------------------------------------------------------------
+
+function compareSemver(a: string, b: string): number {
+  const partsA = a.split('.').map((n) => parseInt(n, 10) || 0);
+  const partsB = b.split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const x = partsA[i] ?? 0;
+    const y = partsB[i] ?? 0;
+    if (x !== y) return x - y;
+  }
+  return 0;
+}

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -99,6 +99,14 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_attachment_stage_cancel':      WRITE_LOCAL,
   'imap_list_staged_attachments':      READ_ONLY,
 
+  // ---- v2.17.0 MVP cache (Issue #124) ----
+  // sync_folder_cache: reads remote (IMAP) and writes local DB rows. Treat
+  // as READ_REMOTE because the user-facing effect is "I'm reading these
+  // messages" — the local cache is an implementation detail, not user state.
+  'imap_sync_folder_cache':            READ_REMOTE,
+  // search_cache: pure local DB read, no IMAP traffic.
+  'imap_search_cache':                 READ_ONLY,
+
   // ---- folder-tools (6) ----
   'imap_list_folders':                 READ_REMOTE,
   'imap_folder_status':                READ_REMOTE,

--- a/src/tools/cache-tools.ts
+++ b/src/tools/cache-tools.ts
@@ -1,0 +1,150 @@
+/**
+ * cache-tools.ts — MCP tools backed by MessageCacheService.
+ *
+ * v2.17.0 MVP — Issue #124. Two new tools:
+ *   - imap_sync_folder_cache : populate local cache for one folder
+ *   - imap_search_cache      : SQL-backed search; modes by_domain, by_address,
+ *                              group_by_sender. Cache miss returns an explicit
+ *                              structured error — no silent IMAP fallback.
+ *
+ * Existing read tools (imap_search_emails, imap_get_email) are NOT rewritten
+ * to consult the cache transparently in v2.17.0. The skill orchestrates the
+ * order: sync first, then search.
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-04-30
+ * Date Updated: 2026-04-30
+ * Version: 0.1.0
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { withErrorHandling } from '../utils/error-handler.js';
+import {
+  MessageCacheService,
+  CacheMissError,
+} from '../services/message-cache-service.js';
+
+const SearchModeSchema = z.enum(['by_domain', 'by_address', 'group_by_sender']);
+
+/**
+ * Convert a "since" string ("90d", "24h", ISO date) to a unix-ms lower bound.
+ * Returns undefined when input is undefined/empty.
+ */
+function parseSince(since: string | undefined): number | undefined {
+  if (!since) return undefined;
+  const m = /^(\d+)\s*([dhm])$/i.exec(since.trim());
+  if (m) {
+    const n = parseInt(m[1], 10);
+    const unit = m[2].toLowerCase();
+    const ms = unit === 'd' ? 86_400_000 : unit === 'h' ? 3_600_000 : 60_000;
+    return Date.now() - n * ms;
+  }
+  // Fall through: try ISO date parse.
+  const t = Date.parse(since);
+  return Number.isNaN(t) ? undefined : t;
+}
+
+export function cacheTools(
+  server: McpServer,
+  cache: MessageCacheService,
+): void {
+  // -------------------------------------------------------------------
+  // imap_sync_folder_cache — explicit cache populate for one folder.
+  // -------------------------------------------------------------------
+  server.registerTool('imap_sync_folder_cache', {
+    description:
+      'Populate the local message header cache for one folder. Idempotent: ' +
+      'subsequent calls only fetch new UIDs since the last sync. Returns ' +
+      'row counts + duration. UIDVALIDITY change triggers a full resync. ' +
+      'Required before imap_search_cache will return results.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().describe('Folder name (e.g. "INBOX")'),
+      fullResync: z.boolean().optional()
+        .describe('Force full resync (drops existing rows). Default false.'),
+    },
+  }, withErrorHandling(async ({ accountId, folder, fullResync }) => {
+    const report = await cache.syncFolder(accountId, folder, { fullResync });
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(report, null, 2),
+      }],
+    };
+  }));
+
+  // -------------------------------------------------------------------
+  // imap_search_cache — SQL-backed search; cache miss is explicit.
+  // -------------------------------------------------------------------
+  server.registerTool('imap_search_cache', {
+    description:
+      'Fast SQL-backed search against the local header cache. ' +
+      'Modes: by_domain (rows where from_domain matches), by_address (exact ' +
+      'from_address match), group_by_sender (top-N senders by message count). ' +
+      'Returns explicit cache_miss error if the folder has not been synced — ' +
+      'call imap_sync_folder_cache first.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().describe('Folder name'),
+      mode: SearchModeSchema.describe(
+        'by_domain: rows for one domain. ' +
+        'by_address: rows for one exact address. ' +
+        'group_by_sender: top-N senders by message count.'
+      ),
+      value: z.string().optional()
+        .describe('Domain or address (required for by_domain/by_address modes)'),
+      since: z.string().optional()
+        .describe('Lower bound: relative ("90d", "24h") or ISO date'),
+      limit: z.number().int().positive().optional()
+        .describe('Max rows. Default 50, hard cap 1000.'),
+    },
+  }, withErrorHandling(async ({ accountId, folder, mode, value, since, limit }) => {
+    const opts = {
+      since: parseSince(since),
+      limit: Math.min(limit ?? 50, 1000),
+    };
+
+    try {
+      let payload: unknown;
+      switch (mode) {
+        case 'by_domain':
+          if (!value) throw new Error('by_domain mode requires value (domain)');
+          payload = await cache.searchByFromDomain(accountId, folder, value, opts);
+          break;
+        case 'by_address':
+          if (!value) throw new Error('by_address mode requires value (address)');
+          payload = await cache.searchByFromAddress(accountId, folder, value, opts);
+          break;
+        case 'group_by_sender':
+          payload = await cache.groupBySender(accountId, folder, opts);
+          break;
+      }
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ mode, results: payload }, null, 2),
+        }],
+      };
+    } catch (e) {
+      // Cache miss is structured, not a generic error — the skill needs to
+      // recognize this and call imap_sync_folder_cache first.
+      if (e instanceof CacheMissError) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              error: 'cache_miss',
+              accountId: e.accountId,
+              folder: e.folder,
+              hint: 'Call imap_sync_folder_cache for this folder before retrying.',
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+      throw e;
+    }
+  }));
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,7 @@ import { WorkerPool } from '../utils/worker-pool.js';
 import { SentFolderService } from '../services/sent-folder-service.js';
 import { AppendRetryService } from '../services/append-retry-service.js';
 import { AttachmentStagingService } from '../services/attachment-staging-service.js';
+import { MessageCacheService } from '../services/message-cache-service.js';
 import { accountTools } from './account-tools.js';
 import { emailTools } from './email-tools.js';
 import { folderTools } from './folder-tools.js';
@@ -19,6 +20,7 @@ import { capabilityTools } from './capability-tools.js';
 import { dnsFirewallTools } from './dns-firewall-tools.js';
 import { categoryTools } from './category-tools.js';
 import { resultTools } from './result-tools.js';
+import { cacheTools } from './cache-tools.js';
 import { getAnnotations } from './annotations.js';
 
 /**
@@ -51,7 +53,8 @@ export function registerTools(
   workerPool?: WorkerPool,
   sentFolder?: SentFolderService,
   appendRetry?: AppendRetryService,
-  staging?: AttachmentStagingService
+  staging?: AttachmentStagingService,
+  messageCache?: MessageCacheService
 ): void {
   // Inject MCP annotations on every registerTool call (drives Claude
   // Desktop's Tool Permissions UI). Restored after the registration phase
@@ -92,6 +95,11 @@ export function registerTools(
   // Register consolidated imap_results tool (resource-handle pattern)
   if (results) {
     resultTools(server, db, results);
+  }
+
+  // Register v2.17.0 MVP cache tools (Issue #124)
+  if (messageCache) {
+    cacheTools(server, messageCache);
   }
 
   // Register meta/discovery tools


### PR DESCRIPTION
## ✅ All 5 MVP phases complete — ready to merge + tag

### Summary

| Phase | Status | Deliverable |
|---|---|---|
| **MVP.1** | ✅ | Schema migration `1.10.0 → 1.11.0` + `MessageCacheService` + `imap_sync_folder_cache` + `imap_search_cache` |
| **MVP.2** | ✅ | `SkillsInstallerService` + bundled `unsubscribe-cleanup` skill auto-installed to `~/.claude/skills/imap-mcp-pro/` |
| **MVP.3** | ✅ | Skill content delivered via claude-skills-library #10 (merged) — vendored snapshot bundled here |
| **MVP.4** | ✅ | Validated against `colin@bitterfield.com` (Hostinger, 1537 msgs) + `cbitterfield@gmail.com` (Gmail) |
| **MVP.5** | ✅ | Version bump 2.16.0 → 2.17.0 + CHANGELOG entry |

### Validation results

**Cache primitive — `colin@bitterfield.com` INBOX (1537 messages):**

| Metric | Result | Target |
|---|---|---|
| Cold sync | 1.72s | < 60s ✓ (35× faster) |
| Warm re-sync | 0 new rows in 196ms | UIDVALIDITY + delta verified ✓ |
| `group_by_sender` warm | 4ms for 20 rows | < 200ms ✓ (50× faster) |
| `by_domain` lookup | 1ms for 5 rows | n/a ✓ |

Output is real — legal e-filing notifications, VA messages, LinkedIn newsletters with `list_unsubscribe` correctly flagged.

**Cache primitive — `cbitterfield@gmail.com` INBOX:** same 5/5 pass at scale (top senders 100+ msgs each).

**Skills installer — 5/5 cases pass:**
- Fresh install when missing → ✓
- No-op when versions match → ✓
- Updates when bundled is newer → ✓
- Preserves when on-disk version is newer → ✓
- Skips entirely when `IMAP_MCP_SKIP_SKILLS_INSTALL=1` → ✓

### Tool surface (93 → 95)

- **`imap_sync_folder_cache`** — explicit cache populate. Idempotent, UIDVALIDITY-aware, returns row counts + duration.
- **`imap_search_cache`** — fast SQL search over the cache. Modes: `by_domain`, `by_address`, `group_by_sender`. Cache miss returns explicit structured error (no silent IMAP fallback).

### Out of scope for this release (deferred to v2.18.0+)

- Transparent cache rewrite of `imap_search_emails` / `imap_get_email`
- Cross-folder participants index, attachments table, FTS5, threading
- Full skill installer per #120 (configurable path, periodic TTL, SHA-based edit preservation)

### Merge plan

1. Merge this PR → main lands at v2.17.0-ready state
2. Tag `v2.17.0` on main → triggers build-dxt.yml → produces 3-platform `.mcpb` (macos-arm64, windows-x64, linux-x64)
3. Reinstall the new `.mcpb` in Claude Desktop
4. End-to-end demo: ask Claude to "clean up newsletters in Gmail" — skill should auto-install on first run, then drive the workflow

### Closes

- Closes #124 (v2.17.0 MVP umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
