### PR TITLE
ci: drop macos-x64 from build matrix

### DIFF
--- a/.github/workflows/build-dxt.yml
+++ b/.github/workflows/build-dxt.yml
@@ -26,14 +26,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14         # arm64
+          - os: macos-14         # Apple Silicon
             label: macos-arm64
-          - os: macos-13         # x86_64
-            label: macos-x64
           - os: windows-latest
             label: windows-x64
           - os: ubuntu-latest
             label: linux-x64
+          # macos-x64 (Intel) intentionally dropped — GitHub-hosted macos-13
+          # runners are queue-starved through 2026 (Apple Silicon transition).
+          # macOS Intel users can run the linux-x64 .mcpb under Rosetta or
+          # build from source. Tracked in commit history; revisit if a clean
+          # macos-x64 runner pool returns.
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Drops `macos-x64` (macos-13) from the `.github/workflows/build-dxt.yml` build matrix
- Future releases produce 3 `.mcpb` artifacts instead of 4: `macos-arm64`, `windows-x64`, `linux-x64`

## Why
The GitHub-hosted `macos-13` runner pool has been queue-starved through 2026 as the Apple Silicon transition consolidates GitHub Actions infrastructure. Every workflow run on this matrix has had the `macos-x64` job sit queued indefinitely:

- v2.15.0 release (run [25184094081](https://github.com/Temple-of-Epiphany/imap-mcp-pro/actions/runs/25184094081)): `Build (macos-x64)` queued 6+ hours, never assigned a runner. Other 3 platforms completed in seconds.
- v2.17.0 MVP `workflow_dispatch` verification (run [25198573430](https://github.com/Temple-of-Epiphany/imap-mcp-pro/actions/runs/25198573430)): same pattern, identical outcome.

Apple Silicon transition is complete. The remaining x86_64 macOS users can run the `linux-x64` `.mcpb` under Rosetta or build from source. Re-add if a clean `macos-x64` runner pool returns.

## Test plan
- [ ] Next tag (or `workflow_dispatch`) on this branch shows 3 jobs in the matrix, all completing successfully
- [ ] No `macos-x64` artifact uploaded to release (intentional)
- [ ] Existing 3 platforms (`macos-arm64`, `windows-x64`, `linux-x64`) still produce `.mcpb` + `.sha256` correctly

## Notes
This is a workflow-only change. No code changes, no tool changes, no schema changes. Safe to merge ahead of any other in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
