### PR TITLE
ci: force JavaScript actions onto Node.js 24 (deprecation prep)

### DIFF
--- a/.github/workflows/build-dxt.yml
+++ b/.github/workflows/build-dxt.yml
@@ -16,6 +16,13 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+# Force JavaScript actions onto Node.js 24. GitHub deprecated Node 20 in
+# their action runtime — without this opt-in, every run logs the deprecation
+# warning, and Node 20 will be removed entirely on 2026-09-16. See
+# https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: write  # needed for release upload
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Force JavaScript actions (actions/checkout, actions/setup-node, etc.) onto
+# Node.js 24. GitHub deprecated Node 20 in their action runtime — without
+# this opt-in, every run logs the deprecation warning, and Node 20 will be
+# removed entirely on 2026-09-16. Setting this env var now buys us safe
+# forward compatibility without bumping individual action SHAs.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build:
     name: Build (linux-x64, node 22)


### PR DESCRIPTION
Opts all v4-pinned JavaScript actions into Node 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the workflow level. Eliminates the Node 20 deprecation warning that surfaces on every run and future-proofs the build before Sept 16, 2026 (Node 20 removal date).

## Why this and not action-SHA bumps?
The deprecation message itself documents this env-var path. It's a one-line opt-in that doesn't require validating new action versions. We can still bump SHAs as v5 actions stabilize.

## Changes
- `.github/workflows/ci.yml` — workflow-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`
- `.github/workflows/build-dxt.yml` — same

## Reference
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)