### PR TITLE
v2.17.2: fix userId resolution in subscription tools (closes #130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.2] - 2026-05-02
+
+### Patch — fix subscription tools' silent FK failure on `userId` (#130)
+
+The v2.17.1 `failedLinks` diagnostic worked exactly as designed and surfaced the actual underlying bug: `imap_extract_unsubscribe_links` was failing 100% of stores with `FOREIGN KEY constraint failed` because the tool layer accepted the caller-supplied `userId` (often a username like `"colin"`) and inserted it directly into tables whose FK references `users.user_id` (a UUID like `cabcbc4f-…`). Every insert violated the FK; every error was caught and reported in `failedLinks` but no row was ever stored. Downstream `imap_get_unsubscribe_links`, `imap_list_unsubscribe_candidates`, `imap_get_subscription_summary`, and the entire `unsubscribe-cleanup` skill workflow returned empty.
+
+This bug has been latent since v2.6 — pre-v2.17.1 the errors were swallowed to stderr and were invisible. v2.17.1's `failedLinks` made it diagnosable.
+
+#### 🐛 Fixed
+
+- **`db.resolveUserId(input)` helper** — accepts either a canonical `user_id` (UUID) or a `username`, returns the canonical UUID. Single point of truth for caller-supplied user identifiers.
+- **All 8 subscription tools now resolve `userId` at the tool boundary** before any DB write or read:
+  - `imap_extract_unsubscribe_links`
+  - `imap_get_subscription_summary`
+  - `imap_mark_subscription_unsubscribed`
+  - `imap_update_subscription_category`
+  - `imap_update_subscription_notes`
+  - `imap_get_unsubscribe_links`
+  - `imap_list_unsubscribe_candidates`
+  - `imap_execute_unsubscribe`
+- **Unknown user → structured error** — passing a `userId` that matches neither a UUID nor a username throws `UnknownUserError`, which `withErrorHandling` converts to a clean error envelope with the actionable hint *"Pass a valid user_id (UUID) or a username that exists in the users table. Call imap_list_users to see valid values."*
+- **Tool descriptions updated** — all subscription tools now document that `userId` accepts either form.
+
+#### 🧪 Acceptance criteria (per #130)
+
+After installing 2.17.2, the same reproduction that produced the bug report should succeed:
+
+```
+imap_extract_unsubscribe_links(folder="INBOX", limit=200)
+  → linksFound: 17, linksStored: 17, errors: 0   (no failedLinks field)
+imap_get_unsubscribe_links(userId="colin")
+  → 17 rows returned
+imap_list_unsubscribe_candidates(userId="colin")
+  → 5 candidates (one per distinct sender)
+```
+
+#### 🛡️ Backward compatibility
+
+- No schema changes (DB stays at 1.11.0).
+- `userId` parameter accepts a strict superset of what it did before — any UUID that worked previously still works; usernames now also work.
+- All other tool surfaces unchanged.
+
 ## [2.17.1] - 2026-05-01
 
 ### Patch — fix stale hardcoded version strings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/database-service.ts
+++ b/src/services/database-service.ts
@@ -285,6 +285,25 @@ export class DatabaseService {
     return stmt.all() as unknown as User[];
   }
 
+  /**
+   * Resolve a caller-supplied user identifier to the canonical `users.user_id`
+   * (UUID). Accepts either form:
+   *
+   *   - canonical user_id UUID  → returned as-is if it exists
+   *   - username (e.g. "colin") → looked up; returns the matched user_id
+   *
+   * Returns null if neither resolution succeeds — caller must surface a
+   * clear "unknown user" error rather than letting an FK constraint fail
+   * deep in an unrelated insert path (issue #130).
+   */
+  resolveUserId(input: string): string | null {
+    if (!input) return null;
+    const byId = this.getUser(input);
+    if (byId) return byId.user_id;
+    const byName = this.getUserByUsername(input);
+    return byName ? byName.user_id : null;
+  }
+
   updateUser(userId: string, updates: Partial<User>): void {
     const fields: string[] = [];
     const values: any = { user_id: userId };

--- a/src/tools/subscription-tools.ts
+++ b/src/tools/subscription-tools.ts
@@ -19,6 +19,33 @@ import { UnsubscribeService } from '../services/unsubscribe-service.js';
 import { UnsubscribeExecutorService } from '../services/unsubscribe-executor-service.js';
 import { withErrorHandling } from '../utils/error-handler.js';
 
+/**
+ * Thrown when the caller-supplied `userId` doesn't match any row in the
+ * users table by UUID or by username. `withErrorHandling` converts this
+ * into a structured error response back to the LLM with a clear hint.
+ */
+class UnknownUserError extends Error {
+  constructor(provided: string) {
+    super(
+      `Unknown user: "${provided}". Pass a valid user_id (UUID) or a username ` +
+      `that exists in the users table. Call imap_list_users to see valid values.`
+    );
+    this.name = 'UnknownUserError';
+  }
+}
+
+/**
+ * Resolve `userId` input (UUID or username) → canonical UUID. Throws
+ * UnknownUserError if neither match — this stops FK constraint failures
+ * deep in INSERT paths (issue #130) by failing fast at the tool boundary
+ * with a clear, actionable error.
+ */
+function resolveUserOrThrow(db: DatabaseService, input: string): string {
+  const resolved = db.resolveUserId(input);
+  if (!resolved) throw new UnknownUserError(input);
+  return resolved;
+}
+
 export function registerSubscriptionTools(
   server: McpServer,
   imapService: ImapService,
@@ -34,15 +61,16 @@ export function registerSubscriptionTools(
   server.registerTool('imap_extract_unsubscribe_links', {
     description: 'Scan folder for unsubscribe links in emails. Extracts List-Unsubscribe headers and body links. Stores to database for subscription management. Processes 100+ emails efficiently.',
     inputSchema: {
-      userId: z.string().describe('User ID'),
+      userId: z.string().describe('User ID (either canonical user_id UUID or username from the users table). Call imap_list_users for valid values.'),
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name'),
       limit: z.number().optional().default(100).describe('Max emails to process (default: 100)'),
       olderThan: z.number().optional().describe('Optional: Only process emails older than N days')
     }
-  }, withErrorHandling(async ({ userId, accountId, folder, limit, olderThan }: {
+  }, withErrorHandling(async ({ userId: userIdRaw, accountId, folder, limit, olderThan }: {
     userId: string; accountId: string; folder: string; limit?: number; olderThan?: number
   }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     const startTime = Date.now();
 
     // Build search criteria
@@ -154,14 +182,15 @@ export function registerSubscriptionTools(
   server.registerTool('imap_get_subscription_summary', {
     description: 'Get aggregated subscription summary. Shows all senders with unsubscribe links, email counts, categories, and unsubscribe status. Filter by category or unsubscribed status.',
     inputSchema: {
-      userId: z.string().describe('User ID'),
+      userId: z.string().describe('User ID (either canonical user_id UUID or username from the users table). Call imap_list_users for valid values.'),
       category: z.enum(['marketing', 'newsletter', 'promotional', 'transactional', 'other']).optional().describe('Filter by category'),
       unsubscribed: z.boolean().optional().describe('Filter by unsubscribe status'),
       sortBy: z.enum(['last_seen', 'total_emails', 'sender_email']).optional().default('last_seen').describe('Sort by field')
     }
-  }, withErrorHandling(async ({ userId, category, unsubscribed, sortBy }: {
+  }, withErrorHandling(async ({ userId: userIdRaw, category, unsubscribed, sortBy }: {
     userId: string; category?: string; unsubscribed?: boolean; sortBy?: string
   }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     let subscriptions = unsubscribeService.getSubscriptionSummary(userId, { category, unsubscribed });
 
     // Sort results
@@ -214,10 +243,11 @@ export function registerSubscriptionTools(
   server.registerTool('imap_mark_subscription_unsubscribed', {
     description: 'Mark a sender as unsubscribed in the database. Records timestamp. Useful for tracking which lists you have already unsubscribed from.',
     inputSchema: {
-      userId: z.string().describe('User ID'),
+      userId: z.string().describe('User ID (either canonical user_id UUID or username from the users table). Call imap_list_users for valid values.'),
       senderEmail: z.string().describe('Sender email address to mark as unsubscribed')
     }
-  }, withErrorHandling(async ({ userId, senderEmail }: { userId: string; senderEmail: string }) => {
+  }, withErrorHandling(async ({ userId: userIdRaw, senderEmail }: { userId: string; senderEmail: string }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     unsubscribeService.markAsUnsubscribed(userId, senderEmail);
 
     return {
@@ -239,13 +269,14 @@ export function registerSubscriptionTools(
   server.registerTool('imap_update_subscription_category', {
     description: 'Update the category of a subscription (marketing, newsletter, promotional, transactional, other). Helps organize subscriptions.',
     inputSchema: {
-      userId: z.string().describe('User ID'),
+      userId: z.string().describe('User ID (either canonical user_id UUID or username from the users table). Call imap_list_users for valid values.'),
       senderEmail: z.string().describe('Sender email address'),
       category: z.enum(['marketing', 'newsletter', 'promotional', 'transactional', 'other']).describe('New category')
     }
-  }, withErrorHandling(async ({ userId, senderEmail, category }: {
+  }, withErrorHandling(async ({ userId: userIdRaw, senderEmail, category }: {
     userId: string; senderEmail: string; category: 'marketing' | 'newsletter' | 'promotional' | 'transactional' | 'other'
   }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     db.updateSubscriptionCategory(userId, senderEmail, category);
 
     return {
@@ -268,13 +299,14 @@ export function registerSubscriptionTools(
   server.registerTool('imap_update_subscription_notes', {
     description: 'Add or update notes for a subscription. Useful for tracking why you subscribed, unsubscribe difficulty, etc.',
     inputSchema: {
-      userId: z.string().describe('User ID'),
+      userId: z.string().describe('User ID (either canonical user_id UUID or username from the users table). Call imap_list_users for valid values.'),
       senderEmail: z.string().describe('Sender email address'),
       notes: z.string().describe('Notes text')
     }
-  }, withErrorHandling(async ({ userId, senderEmail, notes }: {
+  }, withErrorHandling(async ({ userId: userIdRaw, senderEmail, notes }: {
     userId: string; senderEmail: string; notes: string
   }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     db.updateSubscriptionNotes(userId, senderEmail, notes);
 
     return {
@@ -296,13 +328,14 @@ export function registerSubscriptionTools(
   server.registerTool('imap_get_unsubscribe_links', {
     description: 'Get all extracted unsubscribe links from emails. Filter by account or sender. Shows individual email details with unsubscribe links.',
     inputSchema: {
-      userId: z.string().describe('User ID'),
+      userId: z.string().describe('User ID (either canonical user_id UUID or username from the users table). Call imap_list_users for valid values.'),
       accountId: z.string().optional().describe('Filter by account ID'),
       senderEmail: z.string().optional().describe('Filter by sender email')
     }
-  }, withErrorHandling(async ({ userId, accountId, senderEmail }: {
+  }, withErrorHandling(async ({ userId: userIdRaw, accountId, senderEmail }: {
     userId: string; accountId?: string; senderEmail?: string
   }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     const links = unsubscribeService.getUnsubscribeLinks(userId, { account_id: accountId, sender_email: senderEmail });
 
     return {
@@ -334,14 +367,15 @@ export function registerSubscriptionTools(
   server.registerTool('imap_list_unsubscribe_candidates', {
     description: 'List all subscriptions with unsubscribe links. Shows sender, subject, link, method, and email count. Filter by category or unsubscribed status. Perfect for reviewing before executing unsubscribes.',
     inputSchema: {
-      userId: z.string().describe('User ID'),
+      userId: z.string().describe('User ID (either canonical user_id UUID or username from the users table). Call imap_list_users for valid values.'),
       category: z.enum(['marketing', 'newsletter', 'promotional', 'transactional', 'other']).optional().describe('Filter by category'),
       unsubscribed: z.boolean().optional().describe('Filter by unsubscribe status (default: show all)'),
       sortBy: z.enum(['last_seen', 'total_emails', 'sender_email']).optional().default('total_emails').describe('Sort by field')
     }
-  }, withErrorHandling(async ({ userId, category, unsubscribed, sortBy }: {
+  }, withErrorHandling(async ({ userId: userIdRaw, category, unsubscribed, sortBy }: {
     userId: string; category?: string; unsubscribed?: boolean; sortBy?: string
   }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     let subscriptions = unsubscribeService.getSubscriptionSummary(userId, { category, unsubscribed });
 
     // Only show subscriptions with unsubscribe links
@@ -388,19 +422,20 @@ export function registerSubscriptionTools(
   server.registerTool('imap_execute_unsubscribe', {
     description: 'Execute unsubscribe request for one or more senders. Supports HTTP GET/POST and mailto methods. Optional dry-run mode for testing. Updates database with execution results.',
     inputSchema: {
-      userId: z.string().describe('User ID'),
+      userId: z.string().describe('User ID (either canonical user_id UUID or username from the users table). Call imap_list_users for valid values.'),
       senderEmails: z.array(z.string()).describe('Array of sender email addresses to unsubscribe from'),
       accountId: z.string().optional().describe('Account ID (required for mailto unsubscribe)'),
       dryRun: z.boolean().optional().default(false).describe('Dry run mode - validate but do not execute'),
       method: z.enum(['auto', 'http-get', 'http-post', 'mailto']).optional().default('auto').describe('Unsubscribe method (auto detects from link)')
     }
-  }, withErrorHandling(async ({ userId, senderEmails, accountId, dryRun, method }: {
+  }, withErrorHandling(async ({ userId: userIdRaw, senderEmails, accountId, dryRun, method }: {
     userId: string;
     senderEmails: string[];
     accountId?: string;
     dryRun?: boolean;
     method?: 'auto' | 'http-get' | 'http-post' | 'mailto'
   }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     const results: any[] = [];
 
     for (const senderEmail of senderEmails) {


### PR DESCRIPTION
## Summary

Closes #130. Fixes the silent `FOREIGN KEY constraint failed` that v2.17.1's `failedLinks` diagnostic surfaced. Subscription tools now resolve caller-supplied `userId` (UUID or username) → canonical UUID at the tool boundary, before any DB read/write.

## What broke

The bug had been latent since v2.6. `imap_extract_unsubscribe_links` accepted whatever `userId` string the caller provided and inserted it directly into `unsubscribe_links` and `subscription_summary`, both of which have FK constraints on `users.user_id` (a UUID). Claude Desktop's natural call passed the username `"colin"` instead of the UUID `cabcbc4f-…`. Every insert violated the FK; zero rows ever stored. Pre-v2.17.1 the error went only to stderr; v2.17.1's `failedLinks` array exposed it on the tool surface.

End-to-end the entire `unsubscribe-cleanup` skill workflow returned empty downstream queries.

## Fix

- **`db.resolveUserId(input)`** — single helper, accepts UUID or username, returns canonical UUID or `null`.
- **`UnknownUserError` + `resolveUserOrThrow(db, input)`** in `subscription-tools.ts` — fail fast at the boundary with a clear hint.
- **All 8 subscription tools** call the resolver before any DB call:
  - `imap_extract_unsubscribe_links`
  - `imap_get_subscription_summary`
  - `imap_mark_subscription_unsubscribed`
  - `imap_update_subscription_category`
  - `imap_update_subscription_notes`
  - `imap_get_unsubscribe_links`
  - `imap_list_unsubscribe_candidates`
  - `imap_execute_unsubscribe`
- **Tool descriptions updated** — `userId` now documented as accepting either UUID or username.

## Acceptance criteria (from #130)

After installing v2.17.2 `.mcpb`, the exact reproduction in #130 should produce:

```
imap_extract_unsubscribe_links(folder="INBOX", limit=200, userId="colin")
  → { linksFound: 17, linksStored: 17, errors: 0 }    (no failedLinks)
imap_get_unsubscribe_links(userId="colin")            → 17 rows
imap_list_unsubscribe_candidates(userId="colin")      → 5 candidates
```

## Test plan

- [x] `npm run build` clean (tsc + postbuild)
- [x] `npm test` — 28/28 pass
- [ ] CI on this PR: `npm test` passes
- [ ] Manual end-to-end against Hostinger Legal account on the v2.17.2 `.mcpb`: `failedLinks` array empty, `imap_list_unsubscribe_candidates` returns 5 candidates

## Backward compatibility

- No schema changes (DB stays at 1.11.0)
- `userId` is now a strict superset — UUIDs still work; usernames now also work
- No other tool surfaces change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
