### PR TITLE
v2.17.3: fix stdout filter dropping large Buffer writes (closes #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.3] - 2026-05-02
+
+### Patch — fix stdout filter dropping large Buffer writes (#137)
+
+`imap_get_unsubscribe_links` (and any tool whose response payload exceeds Node's stdio highWaterMark, ~8KB on macOS/Linux) hung indefinitely in Claude Desktop. Sibling tools returning smaller payloads (`imap_get_subscription_summary`, `imap_list_unsubscribe_candidates`, `imap_about`) worked instantly. Local DB query for the same 17 rows completed in 1ms — confirming the hang was purely in the transport layer.
+
+Root cause: the stdout filter installed at server startup (originally to silence stray npm-style version banners that would corrupt the JSON-RPC stream) only allowed `string` writes starting with `{`. When Node's stdout switches to Buffer writes for larger payloads, those Buffers were silently discarded — the client kept waiting for bytes that never arrived.
+
+This bug has been latent since v2.6 (when the filter was first added). Pre-v2.17 nobody hit a tool whose response exceeded ~8KB; v2.17's `failedLinks` diagnostic and the row-level read tools finally pushed responses over the threshold.
+
+#### 🐛 Fixed
+
+- **`process.stdout.write` filter now passes Buffers and Uint8Arrays through unconditionally.** String writes still gate on JSON-RPC shape (`{…}` or bare newline) so the original anti-chatter intent is preserved. Library chatter (npm banners, dotenv config dumps) still gets dropped — only large structured responses are unblocked.
+- Added a comment block at the filter call site documenting the bug + fix history so the next person who touches it knows why the filter exists and what it does/doesn't allow.
+
+#### 🧪 Acceptance criteria (per #137)
+
+After installing 2.17.3:
+
+- `imap_get_unsubscribe_links(userId="colin")` returns 17 rows in under 1 second.
+- `imap_get_unsubscribe_links(senderEmail="citizenship@sableinternational.com", userId="colin")` returns exactly 1 row.
+- No regression in `imap_get_subscription_summary` or `imap_list_unsubscribe_candidates`.
+- No regression in `imap_extract_unsubscribe_links` (the `failedLinks` array on a real failure is now well above 8KB and previously may have hit the same bug).
+
+#### 🛡️ Backward compatibility
+
+- No schema, no API, no behavior changes for existing-working calls.
+- Pure transport-layer fix — strictly unblocks responses that were silently dropped.
+
 ## [2.17.2] - 2026-05-02
 
 ### Patch — fix subscription tools' silent FK failure on `userId` (#130)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,13 +23,31 @@ import { loadConfig, ConfigError } from './config/loader.js';
 import { logEvent, timeStage, SERVER_CAPABILITIES } from './startup.js';
 import { PACKAGE_VERSION } from './utils/package-info.js';
 
-// Silence any package version output to stdout
+// Filter stdout to keep stray library chatter (npm-style version banners,
+// dotenv config dumps, etc.) from corrupting the JSON-RPC stream that
+// Claude Desktop reads. The MCP transport is line-delimited JSON over
+// stdout — anything that isn't a JSON-RPC payload would parse as garbage.
+//
+// Bug history (v2.17.3, #137): the previous filter only allowed string
+// writes starting with `{`. Node's stdout switches from string writes to
+// Buffer writes once a payload exceeds the default highWaterMark (~8KB
+// on macOS/Linux). Any tool response over that threshold —
+// `imap_get_unsubscribe_links` with 17 rows being the canonical case —
+// got silently dropped, causing the MCP client to hang waiting for bytes
+// that never arrived. Fixed: pass Buffers through unconditionally; only
+// filter strings that don't look like JSON-RPC.
 const originalWrite = process.stdout.write.bind(process.stdout);
 (process.stdout.write as any) = function(chunk: any, encoding?: any, callback?: any): boolean {
-  // Only allow JSON-RPC messages through
+  // Buffers always pass through. They're either MCP SDK fragments (any
+  // non-trivial response will be a Buffer) or already-validated bytes.
+  if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+    return originalWrite(chunk, encoding, callback);
+  }
+  // Strings: allow JSON-RPC payloads (`{…}`) and bare newlines (delimiters).
   if (typeof chunk === 'string' && (chunk.startsWith('{') || chunk === '\n')) {
     return originalWrite(chunk, encoding, callback);
   }
+  // Anything else is library chatter — drop, preserving the v2.17.2 intent.
   return true;
 };
 


### PR DESCRIPTION
## Summary

Closes the hang on `imap_get_unsubscribe_links` reported in the v2.17.2 acceptance test. Root cause: an over-aggressive stdout filter from the v2.6 era was silently dropping Buffer writes, which Node uses for stdout payloads above the highWaterMark (~8KB on macOS/Linux). Result: large tool responses never reached Claude Desktop and the client hung waiting for bytes that never arrived.

## Diagnosis

| Tool | Response size | stdout write type | Filter result |
|---|---|---|---|
| `imap_about` | ~4KB | string `{…}` | passes ✅ |
| `imap_get_subscription_summary` | ~1–2KB (5 senders) | string `{…}` | passes ✅ |
| `imap_list_unsubscribe_candidates` | ~2–3KB (5 candidates) | string `{…}` | passes ✅ |
| **`imap_get_unsubscribe_links`** | **~8–10KB (17 row-level links)** | **Buffer** | **dropped → client hangs** ❌ |

Local DB-layer reproducer returned the same 17 rows in 1ms — confirming the data path is fine, the bug is purely transport.

## Fix

`src/index.ts` filter now:
- Passes Buffers and Uint8Arrays through **unconditionally** (transport correctness wins).
- Still gates string writes on JSON-RPC shape (`{…}` or bare newline) so npm-style version banners still get suppressed (the original v2.6 intent).
- Comments the filter so the next person to touch it knows the trade-off.

## Acceptance criteria (from the bug report)

- [ ] `imap_get_unsubscribe_links(userId="colin")` returns 17 rows in under 1 second
- [ ] `imap_get_unsubscribe_links(senderEmail="citizenship@sableinternational.com", userId="colin")` returns exactly 1 row
- [ ] `imap_get_subscription_summary` and `imap_list_unsubscribe_candidates` still work (regression check)
- [ ] `imap_extract_unsubscribe_links` still works on both clean and erroring runs

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 28/28 pass
- [ ] CI on this PR
- [ ] Manual: install v2.17.3 `.mcpb`, run reproduction from the bug report, confirm `imap_get_unsubscribe_links` returns 17 rows

## Backward compatibility

Pure transport-layer fix — anything that worked under v2.17.2 still works. Strictly unblocks responses that were silently dropped before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
