### PR TITLE
v2.17.4: skill update from public GitHub (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.4] - 2026-05-02
+
+### Skill update from public GitHub (#138)
+
+Adds the ability to check for and apply skill updates from the canonical `Temple-of-Epiphany/claude-skills-library` repo without rebuilding or reinstalling the `.mcpb`. Trust model is preserved: nothing happens automatically. Two new tools, intentionally split: a read-only check that surfaces "what's available," and a write tool that requires explicit skill names to apply. Auto-fetch at startup is **not** wired — manual user confirmation only.
+
+#### ✨ Added
+
+- **`imap_check_skill_updates`** — read-only. Fetches `version.json` for each bundled skill from GitHub, compares against the installed version, returns `{ name, installed, bundled, available, hasUpdate, fetchError }` per skill plus a one-line summary. No on-disk changes. Default `ref: "main"`, configurable per-call.
+- **`imap_update_skills`** — write. Accepts an explicit `skills: string[]` (no "update everything" shortcut). Fetches `SKILL.md` + `version.json` from GitHub, version-compares, writes to `~/.claude/skills/imap-mcp-pro/<name>/`. Skills not in the bundled manifest are rejected (the manifest is the allowlist). `force: true` bypasses version compare; default behavior preserves on-disk versions ≥ remote.
+- **GitHub source configuration** via env vars:
+  - `IMAP_MCP_SKILL_GITHUB_OWNER` (default `Temple-of-Epiphany`)
+  - `IMAP_MCP_SKILL_GITHUB_REPO` (default `claude-skills-library`)
+  - `IMAP_MCP_SKILL_GITHUB_REF` (default `main`)
+  - `IMAP_MCP_GITHUB_TOKEN` — optional Personal Access Token. When set, fetches go through the GitHub Contents API with `Accept: application/vnd.github.raw` (works for private repos and forks). When absent, falls back to public `raw.githubusercontent.com` URLs (no rate-limit concerns at our volume).
+
+#### 🛡️ Trust model
+
+Skills are *instructions to Claude*. Whoever controls the source repo controls the LLM workflow. To preserve user agency:
+
+- Updates are **never** applied automatically. `imap_check_skill_updates` is read-only; `imap_update_skills` requires explicit skill names.
+- The bundled `manifest.json` acts as an allowlist — skills not in the bundle cannot be installed via this path.
+- User-modified on-disk skills are preserved unless `force: true` is passed.
+
+#### 🧪 Acceptance verification
+
+End-to-end smoke test on a downgraded local install:
+
+```
+Pre-state:  installed: 0.0.1, available: 0.1.1, hasUpdate: true
+Apply:      updated: ["unsubscribe-cleanup"] in 342ms
+Post-state: installed: 0.1.1, hasUpdate: false
+```
+
+Both raw.githubusercontent.com (public) and authenticated GitHub Contents API paths verified.
+
+#### 🛡️ Backward compatibility
+
+- No schema, no DB changes. New tools only.
+- Bundled-skill install on startup unchanged — still copies from `dist/skills/` regardless of these new tools.
+
 ## [2.17.3] - 2026-05-02
 
 ### Patch — fix stdout filter dropping large Buffer writes (#137)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ await dispatchCli({
 const {
   server, imapService, smtpService, db, fileExport, results, workerPool,
   sentFolderService, appendRetryService, attachmentStaging, messageCache,
+  skillsInstaller,
 } = await timeStage('pre-handshake', async () => {
     // 1. Load + validate config
     let config;
@@ -132,10 +133,17 @@ const {
     // 6d. v2.17.0 MVP: local message header cache (no I/O at construction time)
     const messageCache = new MessageCacheService(db, imapService);
 
+    // 6e. v2.17.4 (#138): skill installer — same instance used for the
+    //     post-handshake bundle install AND for the imap_check_skill_updates
+    //     / imap_update_skills tools. No network calls at construction time.
+    const bundleSkillsDir = path.join(__dirname, '..', 'skills');
+    const skillsInstaller = new SkillsInstallerService(bundleSkillsDir);
+
     // 7. Tool schema registration
     registerTools(
       server, imapService, db, smtpService, results, workerPool,
-      sentFolderService, appendRetryService, attachmentStaging, messageCache
+      sentFolderService, appendRetryService, attachmentStaging, messageCache,
+      skillsInstaller
     );
 
     // Mark unused config field as intentional for now
@@ -144,6 +152,7 @@ const {
     return {
       server, imapService, smtpService, db, fileExport, results, workerPool,
       sentFolderService, appendRetryService, attachmentStaging, messageCache,
+      skillsInstaller,
     };
   });
 
@@ -189,12 +198,10 @@ void timeStage('post-handshake', async () => {
   // Idempotent — skips skills already at the bundled version. Best-effort:
   // a failure here is logged but never blocks tool availability.
   try {
-    const bundleDir = path.join(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'skills',
-    );
-    const installer = new SkillsInstallerService(bundleDir);
-    const r = await installer.install();
+    // Reuse the singleton installer constructed in pre-handshake. It already
+    // points at the right bundle dir and will be reused by the
+    // imap_check_skill_updates / imap_update_skills tools.
+    const r = await skillsInstaller.install();
     logEvent('[startup]', {
       component: 'skills-install',
       installed: r.installed,
@@ -242,9 +249,11 @@ async function buildToolsManifest(): Promise<unknown> {
     stagingDir: path.join(os.homedir(), '.imap-mcp', 'staging'),
   });
   const tmpMessageCache = new MessageCacheService(tmpDb, tmpImap);
+  const tmpBundleSkillsDir = path.join(__dirname, '..', 'skills');
+  const tmpSkillsInstaller = new SkillsInstallerService(tmpBundleSkillsDir);
   registerTools(
     tmpServer, tmpImap, tmpDb, tmpSmtp, tmpResults, tmpWorkerPool,
-    tmpSentFolder, tmpAppendRetry, tmpStaging, tmpMessageCache
+    tmpSentFolder, tmpAppendRetry, tmpStaging, tmpMessageCache, tmpSkillsInstaller
   );
 
   // Pull the registered tools out of McpServer's internal map. This is

--- a/src/services/skills-installer-service.ts
+++ b/src/services/skills-installer-service.ts
@@ -75,6 +75,41 @@ interface SkillVersionFile {
   version: string;
 }
 
+/** GitHub source descriptor for skill updates. */
+export interface GitHubSource {
+  owner: string;
+  repo: string;
+  ref: string;
+}
+
+/** Default GitHub source — overridable via env vars or per-call options. */
+export function defaultGitHubSource(): GitHubSource {
+  return {
+    owner: process.env.IMAP_MCP_SKILL_GITHUB_OWNER ?? 'Temple-of-Epiphany',
+    repo: process.env.IMAP_MCP_SKILL_GITHUB_REPO ?? 'claude-skills-library',
+    ref: process.env.IMAP_MCP_SKILL_GITHUB_REF ?? 'main',
+  };
+}
+
+/** Per-skill availability status from a GitHub check. */
+export interface SkillUpdateStatus {
+  name: string;
+  installed: string | null;     // version.json on disk; null if not installed
+  bundled: string;              // version shipped with this MCP build
+  available: string | null;     // version on GitHub at the requested ref
+  hasUpdate: boolean;           // available > max(installed, bundled)
+  fetchError: string | null;    // network/parse error, if any
+}
+
+export interface SkillUpdateCheckReport {
+  checkedAt: string;            // ISO timestamp
+  source: GitHubSource;
+  baseUrl: string;              // raw.githubusercontent.com URL up to /skills/
+  skills: SkillUpdateStatus[];
+  summary: string;              // human-readable single-line summary
+  cached: boolean;              // whether this came from the in-memory TTL cache
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
@@ -168,6 +203,252 @@ export class SkillsInstallerService {
   private async copySkill(srcDir: string, dstDir: string): Promise<void> {
     await fs.mkdir(dstDir, { recursive: true });
     await fs.cp(srcDir, dstDir, { recursive: true, force: true });
+  }
+
+  // -------------------------------------------------------------------
+  // GitHub update check + apply (v2.17.4, #138)
+  //
+  // Trust model: skills are *instructions to Claude*. Whoever controls
+  // the GitHub repo controls the LLM workflow. The check tool is read-
+  // only and surfaces "what would change" for human review. The apply
+  // tool requires explicit `skills: string[]` — no "update everything"
+  // shortcut. Auto-fetch at startup is intentionally NOT wired; this
+  // ships in user-confirmed mode only.
+  // -------------------------------------------------------------------
+
+  /** Build the raw.githubusercontent.com base for a given source. */
+  private rawBaseUrl(source: GitHubSource): string {
+    return `https://raw.githubusercontent.com/${source.owner}/${source.repo}/${source.ref}/skills/`;
+  }
+
+  /**
+   * Fetch a single text file from GitHub. Uses two endpoints:
+   *
+   *   - `raw.githubusercontent.com` for public repos (unauthenticated;
+   *     ignores Authorization headers, no rate-limit concerns at our
+   *     volume).
+   *   - GitHub Contents API with `Accept: application/vnd.github.raw`
+   *     when `IMAP_MCP_GITHUB_TOKEN` is set — works for private repos
+   *     and forks. The token is read from env at call time so users
+   *     can rotate it without restarting the server.
+   *
+   * Pick raw.githubusercontent.com whenever no token is set so unauth
+   * public-repo users don't burn the API rate limit (60/hr unauth vs
+   * effectively unlimited on raw.).
+   */
+  private async fetchTextFromGitHub(
+    source: GitHubSource,
+    pathInRepo: string,
+    timeoutMs = 10_000,
+  ): Promise<string> {
+    const token = process.env.IMAP_MCP_GITHUB_TOKEN;
+
+    const url = token
+      ? `https://api.github.com/repos/${source.owner}/${source.repo}/contents/skills/${pathInRepo}?ref=${encodeURIComponent(source.ref)}`
+      : this.rawBaseUrl(source) + pathInRepo;
+
+    const headers: Record<string, string> = {
+      'User-Agent': 'imap-mcp-pro skill-updater',
+    };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+      headers['Accept'] = 'application/vnd.github.raw';
+      headers['X-GitHub-Api-Version'] = '2022-11-28';
+    }
+
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, { signal: ac.signal, headers });
+      if (!res.ok) {
+        throw new Error(`GitHub returned ${res.status} ${res.statusText} for ${url}`);
+      }
+      return await res.text();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Fetch the version string for one skill from GitHub. Returns null on
+   * any error (network, parse, missing) — caller decides how to surface.
+   */
+  private async fetchRemoteVersion(
+    source: GitHubSource,
+    skillName: string,
+    timeoutMs = 10_000,
+  ): Promise<{ version: string | null; error: string | null }> {
+    try {
+      const raw = await this.fetchTextFromGitHub(source, `${skillName}/version.json`, timeoutMs);
+      const parsed = JSON.parse(raw) as SkillVersionFile;
+      if (typeof parsed.version === 'string') {
+        return { version: parsed.version, error: null };
+      }
+      return { version: null, error: 'version.json missing "version" field' };
+    } catch (e: any) {
+      return { version: null, error: e?.message ?? String(e) };
+    }
+  }
+
+  /**
+   * Check GitHub for newer skill versions without changing on-disk state.
+   * Reads the bundled manifest as the source of truth for skill names,
+   * compares each against installed and remote versions.
+   */
+  async checkForUpdates(options?: {
+    source?: GitHubSource;
+    timeoutMs?: number;
+  }): Promise<SkillUpdateCheckReport> {
+    const source = options?.source ?? defaultGitHubSource();
+    const timeoutMs = options?.timeoutMs ?? 10_000;
+
+    let manifest: BundleManifest;
+    try {
+      const raw = await fs.readFile(path.join(this.bundleDir, 'manifest.json'), 'utf8');
+      manifest = JSON.parse(raw) as BundleManifest;
+    } catch (e: any) {
+      // No bundle = nothing to check
+      return {
+        checkedAt: new Date().toISOString(),
+        source,
+        baseUrl: this.rawBaseUrl(source),
+        skills: [],
+        summary: 'No bundled manifest found.',
+        cached: false,
+      };
+    }
+
+    const statuses = await Promise.all(
+      manifest.skills.map(async (entry): Promise<SkillUpdateStatus> => {
+        const installed = await this.readInstalledVersion(
+          path.join(this.installDir, entry.name),
+        );
+        const remote = await this.fetchRemoteVersion(source, entry.name, timeoutMs);
+
+        // hasUpdate compares remote against what's *on disk* (or, when nothing
+        // is installed, against what would land via the bundle). This matches
+        // user intuition: "does GitHub have something newer than my actual
+        // installed copy?" Not "newer than the best source available."
+        const baseline = installed ?? entry.version;
+        const hasUpdate = remote.version !== null && compareSemver(remote.version, baseline) > 0;
+
+        return {
+          name: entry.name,
+          installed,
+          bundled: entry.version,
+          available: remote.version,
+          hasUpdate,
+          fetchError: remote.error,
+        };
+      }),
+    );
+
+    const updates = statuses.filter(s => s.hasUpdate);
+    const summary = updates.length === 0
+      ? `All ${statuses.length} skill(s) up to date at ${source.owner}/${source.repo}@${source.ref}`
+      : updates.map(s => `${s.name}: ${s.installed ?? '(none)'} → ${s.available} available`).join('; ');
+
+    return {
+      checkedAt: new Date().toISOString(),
+      source,
+      baseUrl: this.rawBaseUrl(source),
+      skills: statuses,
+      summary,
+      cached: false,
+    };
+  }
+
+  /**
+   * Apply an update for the named skills. Fetches SKILL.md + version.json
+   * from GitHub, writes to the install dir, preserves user edits unless
+   * `force: true`. Skills not in the manifest are rejected.
+   */
+  async updateFromGitHub(options: {
+    skills: string[];
+    source?: GitHubSource;
+    force?: boolean;
+    timeoutMs?: number;
+  }): Promise<SkillsInstallReport> {
+    const start = Date.now();
+    const source = options.source ?? defaultGitHubSource();
+    const timeoutMs = options.timeoutMs ?? 10_000;
+
+    const report: SkillsInstallReport = {
+      installed: [],
+      updated: [],
+      unchanged: [],
+      preserved: [],
+      skipped: false,
+      durationMs: 0,
+    };
+
+    if (!options.skills || options.skills.length === 0) {
+      throw new Error('updateFromGitHub requires an explicit non-empty `skills` array.');
+    }
+
+    let manifest: BundleManifest;
+    try {
+      const raw = await fs.readFile(path.join(this.bundleDir, 'manifest.json'), 'utf8');
+      manifest = JSON.parse(raw) as BundleManifest;
+    } catch {
+      manifest = { manifest_version: '1.0', publisher: 'imap-mcp-pro', skills: [] };
+    }
+    const knownSkills = new Set(manifest.skills.map(s => s.name));
+
+    await fs.mkdir(this.installDir, { recursive: true });
+
+    for (const skillName of options.skills) {
+      if (!knownSkills.has(skillName)) {
+        // Reject unknown to prevent path-injection-like behavior. The
+        // bundled manifest is the allowlist.
+        report.preserved.push(`${skillName} (unknown — not in bundle manifest)`);
+        continue;
+      }
+
+      try {
+        const [skillMd, versionJson] = await Promise.all([
+          this.fetchTextFromGitHub(source, `${skillName}/SKILL.md`, timeoutMs),
+          this.fetchTextFromGitHub(source, `${skillName}/version.json`, timeoutMs),
+        ]);
+
+        const remoteVersion = (() => {
+          try {
+            const v = JSON.parse(versionJson) as SkillVersionFile;
+            return typeof v.version === 'string' ? v.version : null;
+          } catch {
+            return null;
+          }
+        })();
+        if (!remoteVersion) {
+          report.preserved.push(`${skillName} (remote version.json malformed)`);
+          continue;
+        }
+
+        const skillDir = path.join(this.installDir, skillName);
+        const installedVersion = await this.readInstalledVersion(skillDir);
+
+        if (installedVersion && !options.force && compareSemver(installedVersion, remoteVersion) >= 0) {
+          report.unchanged.push(skillName);
+          continue;
+        }
+
+        await fs.mkdir(skillDir, { recursive: true });
+        await fs.writeFile(path.join(skillDir, 'SKILL.md'), skillMd, 'utf8');
+        await fs.writeFile(path.join(skillDir, 'version.json'), versionJson, 'utf8');
+
+        if (installedVersion) {
+          report.updated.push(skillName);
+        } else {
+          report.installed.push(skillName);
+        }
+      } catch (e: any) {
+        // Surface as preserved with reason — caller decides whether to retry.
+        report.preserved.push(`${skillName} (fetch failed: ${e?.message ?? String(e)})`);
+      }
+    }
+
+    report.durationMs = Date.now() - start;
+    return report;
   }
 }
 

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -107,6 +107,12 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   // search_cache: pure local DB read, no IMAP traffic.
   'imap_search_cache':                 READ_ONLY,
 
+  // ---- v2.17.4 skill update from GitHub (#138) ----
+  // check: read-only network call to raw.githubusercontent.com.
+  'imap_check_skill_updates':          READ_REMOTE,
+  // update: writes to ~/.claude/skills/imap-mcp-pro/<name>/ from GitHub.
+  'imap_update_skills':                WRITE_LOCAL,
+
   // ---- folder-tools (6) ----
   'imap_list_folders':                 READ_REMOTE,
   'imap_folder_status':                READ_REMOTE,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,6 +8,7 @@ import { SentFolderService } from '../services/sent-folder-service.js';
 import { AppendRetryService } from '../services/append-retry-service.js';
 import { AttachmentStagingService } from '../services/attachment-staging-service.js';
 import { MessageCacheService } from '../services/message-cache-service.js';
+import { SkillsInstallerService } from '../services/skills-installer-service.js';
 import { accountTools } from './account-tools.js';
 import { emailTools } from './email-tools.js';
 import { folderTools } from './folder-tools.js';
@@ -21,6 +22,7 @@ import { dnsFirewallTools } from './dns-firewall-tools.js';
 import { categoryTools } from './category-tools.js';
 import { resultTools } from './result-tools.js';
 import { cacheTools } from './cache-tools.js';
+import { skillsTools } from './skills-tools.js';
 import { getAnnotations } from './annotations.js';
 
 /**
@@ -54,7 +56,8 @@ export function registerTools(
   sentFolder?: SentFolderService,
   appendRetry?: AppendRetryService,
   staging?: AttachmentStagingService,
-  messageCache?: MessageCacheService
+  messageCache?: MessageCacheService,
+  skillsInstaller?: SkillsInstallerService
 ): void {
   // Inject MCP annotations on every registerTool call (drives Claude
   // Desktop's Tool Permissions UI). Restored after the registration phase
@@ -100,6 +103,12 @@ export function registerTools(
   // Register v2.17.0 MVP cache tools (Issue #124)
   if (messageCache) {
     cacheTools(server, messageCache);
+  }
+
+  // Register v2.17.4 skill update tools (#138). Skips registration when no
+  // installer is wired (e.g. tests or environments without bundled skills).
+  if (skillsInstaller) {
+    skillsTools(server, skillsInstaller);
   }
 
   // Register meta/discovery tools

--- a/src/tools/skills-tools.ts
+++ b/src/tools/skills-tools.ts
@@ -1,0 +1,100 @@
+/**
+ * skills-tools.ts — MCP tools for checking + applying skill updates from
+ * the public claude-skills-library GitHub repo.
+ *
+ * v2.17.4 (#138). Two tools, intentionally split:
+ *
+ *   - imap_check_skill_updates : read-only — surfaces "what's available"
+ *   - imap_update_skills       : write — applies updates for explicitly
+ *                                named skills (no "update everything"
+ *                                shortcut)
+ *
+ * Trust model: skills are instructions to Claude. Whoever controls the
+ * source repo controls the LLM workflow. Updates are user-confirmed:
+ * `imap_update_skills` requires the caller to pass an explicit `skills`
+ * array. There is no automatic background fetch.
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-05-02
+ * Version: 0.1.0
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { withErrorHandling } from '../utils/error-handler.js';
+import {
+  SkillsInstallerService,
+  defaultGitHubSource,
+} from '../services/skills-installer-service.js';
+
+export function skillsTools(
+  server: McpServer,
+  installer: SkillsInstallerService,
+): void {
+  // -------------------------------------------------------------------
+  // imap_check_skill_updates — read-only check, surfaces availability.
+  // -------------------------------------------------------------------
+  server.registerTool('imap_check_skill_updates', {
+    description:
+      'Check public GitHub for newer skill versions without changing anything ' +
+      'on disk. Compares each skill in the bundled manifest against the ' +
+      'latest version.json on GitHub. Returns a per-skill status with ' +
+      'installed/bundled/available versions and a hasUpdate flag. Skills are ' +
+      'instructions to the LLM — review the diff before applying via ' +
+      'imap_update_skills.',
+    inputSchema: {
+      ref: z.string().optional()
+        .describe('GitHub ref to check against (branch, tag, or commit SHA). Default: "main".'),
+      timeoutMs: z.number().int().positive().optional()
+        .describe('Network timeout per file in milliseconds. Default: 10000.'),
+    },
+  }, withErrorHandling(async ({ ref, timeoutMs }) => {
+    const source = ref ? { ...defaultGitHubSource(), ref } : defaultGitHubSource();
+    const report = await installer.checkForUpdates({ source, timeoutMs });
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(report, null, 2),
+      }],
+    };
+  }));
+
+  // -------------------------------------------------------------------
+  // imap_update_skills — apply updates for explicitly named skills.
+  // -------------------------------------------------------------------
+  server.registerTool('imap_update_skills', {
+    description:
+      'Apply skill updates from public GitHub for explicitly named skills. ' +
+      'Fetches SKILL.md + version.json from raw.githubusercontent.com, writes ' +
+      'to ~/.claude/skills/imap-mcp-pro/<name>/, preserves files when the ' +
+      'on-disk version is already at or ahead of remote unless force=true. ' +
+      'Skills not present in the bundled manifest are rejected (the manifest ' +
+      'is the allowlist). Always pair with imap_check_skill_updates first to ' +
+      'see what would change.',
+    inputSchema: {
+      skills: z.array(z.string()).min(1)
+        .describe('Skill names to update (must be in the bundled manifest). Required and non-empty.'),
+      ref: z.string().optional()
+        .describe('GitHub ref (branch, tag, or commit SHA). Default: "main".'),
+      force: z.boolean().optional()
+        .describe('If true, overwrite even when on-disk version >= remote. Default: false.'),
+      timeoutMs: z.number().int().positive().optional()
+        .describe('Network timeout per file in milliseconds. Default: 10000.'),
+    },
+  }, withErrorHandling(async ({ skills, ref, force, timeoutMs }) => {
+    const source = ref ? { ...defaultGitHubSource(), ref } : defaultGitHubSource();
+    const report = await installer.updateFromGitHub({
+      skills,
+      source,
+      force,
+      timeoutMs,
+    });
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(report, null, 2),
+      }],
+    };
+  }));
+}


### PR DESCRIPTION
## Summary

Add the ability to update bundled skills (currently `unsubscribe-cleanup`) from the canonical `Temple-of-Epiphany/claude-skills-library` repo without rebuilding or reinstalling the `.mcpb`. Updates should never be automatic — the user (via Claude) must approve each one.

## Motivation

Bundled skills ship inside the `.mcpb`. Until now, the only way to push a skill fix to users was: edit skill in claude-skills-library → vendor copy into imap-mcp-pro → bump MCP version → rebuild → tag → install. That's 6 steps for a markdown change. Want to collapse to: edit upstream → user runs `imap_check_skill_updates` → user runs `imap_update_skills`.

## Trust model

Skills are *instructions to the LLM*. Whoever controls the source repo controls the workflow. To preserve user agency:

- Updates **never automatic**. Two tools, intentionally split.
- Bundled `manifest.json` acts as an allowlist — skills not in the bundle cannot be installed via this path (rejects path-injection-like behavior).
- User-modified on-disk skills preserved unless `force: true`.

## Tools (PR #139)

- **`imap_check_skill_updates`** (read-only) — fetches `version.json` from GitHub for each bundled skill, returns per-skill `{ installed, bundled, available, hasUpdate, fetchError }` plus a one-line summary.
- **`imap_update_skills`** (write) — requires explicit `skills: string[]`. Fetches `SKILL.md` + `version.json`, version-compares, writes to `~/.claude/skills/imap-mcp-pro/<name>/`.

## Configuration (env vars, all optional)

- `IMAP_MCP_SKILL_GITHUB_OWNER` (default `Temple-of-Epiphany`)
- `IMAP_MCP_SKILL_GITHUB_REPO` (default `claude-skills-library`)
- `IMAP_MCP_SKILL_GITHUB_REF` (default `main`)
- `IMAP_MCP_GITHUB_TOKEN` — optional PAT for private repos / forks. When set, uses Contents API with `Accept: application/vnd.github.raw`. When absent, falls back to `raw.githubusercontent.com` (public-only).

## Acceptance criteria

- [x] `imap_check_skill_updates` returns `available` versions from real GitHub
- [x] `hasUpdate` semantically correct (compares remote vs installed-or-bundled)
- [x] `imap_update_skills` with explicit skill names succeeds end-to-end
- [x] Skills not in bundle manifest rejected
- [x] Token-auth path works for private repos
- [x] Public raw.githubusercontent.com path works (when repo is public)
- [x] No automatic background fetch
- [x] Build clean, all 28 unit tests still pass

## Verified end-to-end

```
Pre-state:  installed=0.0.1, available=0.1.1, hasUpdate=true
Apply:      updated=["unsubscribe-cleanup"] in 342ms
Post-state: installed=0.1.1, hasUpdate=false
```

## Filed by

Colin Bitterfield, 2026-05-02
