### PR TITLE
v2.17.5: skill update source defaults to imap-mcp-pro itself (no PAT needed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.5] - 2026-05-02
+
+### Patch — skill update source defaults to imap-mcp-pro itself (no PAT needed)
+
+v2.17.4 shipped with the GitHub update source defaulting to `Temple-of-Epiphany/claude-skills-library`. That repo is private, so out-of-the-box `imap_check_skill_updates` and `imap_update_skills` returned `fetchError: 404` for any user who hadn't set `IMAP_MCP_GITHUB_TOKEN`.
+
+Architecturally, the cleaner answer is: **skills ship bundled with the MCP, so the MCP's own repo is the canonical update source**. imap-mcp-pro is public, so the raw.githubusercontent.com fetch path works for everyone with no token, no setup. claude-skills-library can stay private and serve as the cross-cutting / standalone-skill registry; imap-mcp-pro is now self-contained.
+
+#### 🐛 Fixed
+
+- **`defaultGitHubSource()` defaults `repo` to `imap-mcp-pro`** (was `claude-skills-library`). Skills are fetched from `https://raw.githubusercontent.com/Temple-of-Epiphany/imap-mcp-pro/main/skills/<name>/...` — the same paths where bundled skills already live in this repo.
+- **No PAT required** for the default public-update path.
+- **Override path intact:** users with skills in a different repo (fork, private library, etc.) can still set `IMAP_MCP_SKILL_GITHUB_REPO` / `IMAP_MCP_SKILL_GITHUB_OWNER` / `IMAP_MCP_SKILL_GITHUB_REF` and it works as before.
+- **Verified end-to-end** with the public path:
+  ```
+  GET https://raw.githubusercontent.com/Temple-of-Epiphany/imap-mcp-pro/main/skills/unsubscribe-cleanup/version.json
+    → 200 OK, returns {"name":"unsubscribe-cleanup","version":"0.1.1",...}
+  ```
+
+#### 🛡️ Backward compatibility
+
+- No schema, API, or behavior changes for already-working calls.
+- Users who explicitly set `IMAP_MCP_SKILL_GITHUB_REPO=claude-skills-library` (or any other repo) keep that behavior.
+- Pure default-flip — anyone running the previous v2.17.4 build can update via the new v2.17.5 `.mcpb` and immediately get the public-fetch path.
+
 ## [2.17.4] - 2026-05-02
 
 ### Skill update from public GitHub (#138)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/skills-installer-service.ts
+++ b/src/services/skills-installer-service.ts
@@ -82,11 +82,22 @@ export interface GitHubSource {
   ref: string;
 }
 
-/** Default GitHub source — overridable via env vars or per-call options. */
+/**
+ * Default GitHub source — overridable via env vars or per-call options.
+ *
+ * v2.17.5: defaults to the MCP's own repo (`Temple-of-Epiphany/imap-mcp-pro`)
+ * rather than the upstream `claude-skills-library`. Skills ship bundled with
+ * the MCP and live at `skills/<name>/` inside its repo, so the MCP repo IS
+ * the canonical update source. imap-mcp-pro is public, so the
+ * raw.githubusercontent.com fetch path works without a PAT.
+ *
+ * Override via `IMAP_MCP_SKILL_GITHUB_REPO` if you fork or maintain skills
+ * elsewhere; the back-compat env-var override path is intact.
+ */
 export function defaultGitHubSource(): GitHubSource {
   return {
     owner: process.env.IMAP_MCP_SKILL_GITHUB_OWNER ?? 'Temple-of-Epiphany',
-    repo: process.env.IMAP_MCP_SKILL_GITHUB_REPO ?? 'claude-skills-library',
+    repo: process.env.IMAP_MCP_SKILL_GITHUB_REPO ?? 'imap-mcp-pro',
     ref: process.env.IMAP_MCP_SKILL_GITHUB_REF ?? 'main',
   };
 }


### PR DESCRIPTION
## Summary

Default skill update source flips from the private `claude-skills-library` repo to **`imap-mcp-pro` itself** (which is public). Anyone running v2.17.5 can now run `imap_check_skill_updates` and `imap_update_skills` with **no PAT, no token, no setup**.

## What broke (v2.17.4)

v2.17.4 wired update functionality with `claude-skills-library` as the default repo. That repo is private, so the public `raw.githubusercontent.com` fetch returned 404 for any user without a token. The functionality was correct; the default endpoint was wrong.

## Fix

One-line default change in `src/services/skills-installer-service.ts::defaultGitHubSource()`:

```diff
- repo: process.env.IMAP_MCP_SKILL_GITHUB_REPO ?? 'claude-skills-library',
+ repo: process.env.IMAP_MCP_SKILL_GITHUB_REPO ?? 'imap-mcp-pro',
```

The path pattern (`<base>/skills/<name>/<file>`) is identical because `imap-mcp-pro/skills/unsubscribe-cleanup/{SKILL.md,version.json}` lives at the same paths. No installer changes, no manifest schema bump.

## Architectural rationale

Per the user's direction: skills ship bundled inside the MCP, no separate distribution. The MCP's own repo is the canonical source of truth — once it's public, the public-fetch path works without token management. claude-skills-library stays private as a cross-cutting / standalone-skill registry; imap-mcp-pro becomes self-contained for its embedded skills.

## Verification

```
GET https://raw.githubusercontent.com/Temple-of-Epiphany/imap-mcp-pro/main/skills/unsubscribe-cleanup/version.json
  → 200 OK, version "0.1.1"

imap_check_skill_updates (no PAT):
  summary: "All 1 skill(s) up to date at Temple-of-Epiphany/imap-mcp-pro@main"
  fetchError: null
```

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 28/28 pass
- [x] Smoke test against real GitHub without PAT succeeds
- [ ] CI on this PR
- [ ] Manual: install v2.17.5 `.mcpb`, run `imap_check_skill_updates` without setting any GitHub-related env var, confirm no `fetchError`

## Backward compatibility

- Pure default-flip — anyone running v2.17.4 can update via v2.17.5 `.mcpb` and immediately get the public-fetch path.
- `IMAP_MCP_SKILL_GITHUB_REPO` override still works — users with skills in a different repo (fork, private library) keep that behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
