### PR TITLE
v2.17.9: attachment hardening (dotfile reject, 20 MiB default, filename basename)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,121 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.9] - 2026-05-06
+
+### Patch — attachment hardening: dotfile reject, 10 MB default cap, filename basename on all forms
+
+Closes the first batch of attachment-input security gaps surfaced while diagnosing the Claude Desktop Workspace attachment failure that motivated v2.17.8. v2.17.8 fixed *discoverability* (the inline form was buried as "legacy"). v2.17.9 fixes *enforcement* (the rules now apply to all three input forms — inline, path, staged — uniformly).
+
+#### 🛡️ New: dotfile / dotdir rejection (default-on, configurable)
+
+Any attachment whose path or filename contains a segment starting with `.` is now rejected by default. Catches the canonical exfiltration shapes (`~/.ssh/id_rsa`, `~/.aws/credentials`, `~/.config/...`, `~/.bashrc`, `~/.envrc`, etc.) without requiring the operator to enumerate every dotdir up front.
+
+- **Path form (`attachmentPaths`):** scans both the input path and the `realpath` (so a non-dotted symlink resolving into a dotdir is also rejected). Implemented via new `findDotSegment()` helper; `.` and `..` segments are skipped (they are caught by the pre-existing parent-traversal / realpath checks).
+- **Inline form (`attachments[].filename`):** filename is `path.basename`-ed and checked with `isDotfileBasename()` after sanitization.
+- **Staged form (`stagedAttachmentIds`):** stored filename from `imap_attachment_stage_init` is re-checked at send time.
+
+**Override:** set `IMAP_MCP_ALLOW_DOTFILES=true` in the server env to allow dotfile sends. Recommended only for narrow, audited use cases.
+
+**New `ValidationFailure` kinds:** `dotfile-or-dotdir-rejected` (with `path` and `component` fields), `invalid-filename` (when sanitization yields an empty basename).
+
+#### 🛡️ Default size caps now 20 MiB and enforced on every form
+
+Per-attachment and aggregate size caps now both default to **20 MiB** (20 971 520 bytes; was 25 MB / 50 MB respectively). Both are enforced against:
+
+- `attachmentPaths` — already enforced; default lowered.
+- `attachments[].content` — **was previously unbounded.** A caller could submit an arbitrarily large base64 blob and the server would buffer the decoded bytes in memory before nodemailer streamed to SMTP. Now decoded byte length is checked against the per-attachment cap, and the running aggregate spans inline + path + staged in a single budget.
+- `stagedAttachmentIds` — finalized session size from staging metadata is now checked at send time, in addition to the per-user disk quota that staging enforces at upload.
+
+**Overrides (env vars, applied before defaults):**
+- `IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES` — per-attachment ceiling.
+- `IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES` — aggregate ceiling for one send.
+
+The aggregate budget is shared across all three input forms, so mixing inline + path + staged in a single send still respects the total cap.
+
+**Claude Desktop UI surfaces:** the `.mcpb` extension manifest now exposes both ceilings as `user_config` entries (*"Maximum Attachment Size — per file (bytes)"* and *"Maximum Attachment Size — aggregate per send (bytes)"*), each defaulting to 20 MiB with sliders bounded at 1 MiB / 100 MiB and 1 MiB / 200 MiB respectively. The dotfile policy is exposed as a *"Allow Dotfile / Dotdir Attachments"* boolean defaulting to off.
+
+#### 🐛 Fixed manifest env-var name mismatch (latent since manifest first shipped)
+
+The `.mcpb` manifest's `max_attachment_size_bytes` user_config entry was wired to the env var name `IMAP_MCP_ATTACHMENT_MAX_BYTES`, but the server has always read `IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES`. The Claude Desktop UI control was therefore inert — a user could move the slider all day without the server cap changing. Renamed the manifest's env wiring to the canonical name so the user_config now actually drives the runtime cap. New `max_total_attachment_size_bytes` and `allow_dotfiles` entries were added with the correct names from the start.
+
+#### 🛡️ Filename basename on every form ("sanitize the path from the filename")
+
+`sanitizeFilename()` now uses `path.basename()` as its first step (previously it merely replaced `/` and `\` with `_`, preserving path-like noise in the filename). After basename, control characters are stripped and the result is capped at 255 bytes per RFC 2183. **Leading dots are no longer auto-stripped** — that was a silent renaming policy; the explicit `denyDotfiles` knob replaces it.
+
+Applied uniformly to:
+- Path-based attachments (filename derived from `realpath` basename or the `attachmentFilenames[]` override).
+- Inline attachments (`attachments[].filename`).
+- Staged attachments (filename stored from `imap_attachment_stage_init`).
+
+A filename that sanitizes to an empty string (e.g., input was just `/` or all control chars) is rejected with `invalid-filename` instead of silently being passed to the MIME composer.
+
+#### 🧪 New tests
+
+`src/services/attachment-validator.test.ts` (21 tests) covers:
+- `sanitizeFilename` basename behavior, control-char strip, length cap, leading-dot preservation.
+- `isDotfileBasename` and `findDotSegment` happy + edge cases.
+- `validateAttachmentPaths` dotfile rejection (default and `denyDotfiles=false` override) with real tmpdir filesystem fixtures.
+- Per-attachment and aggregate size cap enforcement.
+
+Total test count: **71/71 pass** (was 50).
+
+#### Backward compatibility
+
+- **Default size caps changed.** Per-attachment cap drops 25 MB → 20 MiB (a smaller change than first drafted at 10 MiB). Aggregate cap drops 50 MB → 20 MiB. Sends with attachments between 20 MiB and 25 MB that previously succeeded will now fail with `attachment_validation_failed` / `size-exceeds-per-attachment`. Raise either ceiling via the Claude Desktop user_config sliders or by setting `IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES` / `IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES` directly.
+- **Dotfile sends now refused by default.** Sends targeting `.bashrc`, `.envrc`, etc. will fail unless `IMAP_MCP_ALLOW_DOTFILES=true`. This is the intended safe default; the override exists for the narrow case where a user genuinely wants to email a dotfile.
+- **`sanitizeFilename` semantics changed.** Internal helper; the only external caller is `validateAttachmentPaths`, which now produces basename-only filenames instead of underscore-substituted full paths. Callers passing absolute paths as the *filename override* (`attachmentFilenames[i]`) will get the basename rather than a mangled long string.
+- **Validator no longer auto-strips leading dots from filenames.** Combined with the new `denyDotfiles` policy, the security posture is equivalent — and now explicit.
+- No tool-surface, no schema, no env-var rename. New env vars (`IMAP_MCP_ALLOW_DOTFILES`, lowered `IMAP_MCP_MAX_*` defaults) are additive / refined.
+
+#### Still open — tracked for follow-up
+
+- **Inline `attachments[].path` allow-list bypass.** The inline form's `path` field still forwards directly to nodemailer without going through `validateAttachmentPaths`. Flagged DEPRECATED in v2.17.8's schema description; routing it through the validator (or removing it) is the next iteration of attachment-input hardening.
+- **Per-user outbox dir** (auto-created, auto-allowlisted at `~/.imap-mcp/users/<userId>/outbox/`). Eliminates the "no allowed dirs configured" first-run friction without widening the attack surface beyond a server-managed dir. Tracked separately.
+
+## [2.17.8] - 2026-05-06
+
+### Patch — attachment-form discoverability + steering error messages (no behavior change)
+
+`imap_send_email` exposes three attachment input forms (inline base64 `attachments`, host-path `attachmentPaths`, chunked-upload `stagedAttachmentIds`). Schema descriptions did not communicate when each one applies, so callers driving the tool from a sandboxed environment (Claude Desktop Workspace, Claude.ai code sandbox where files live at `/mnt/user-data/outputs/`) reached for `attachmentPaths` first, hit `attachment_validation_failed`, retried with the staging API (multi-call dance), and still failed when the sandbox path remained unreadable to the server. The inline form — which has worked since v1, completes in one round-trip, and bypasses the allow-list because no path is involved — was buried as `(legacy form: ...)` in the description.
+
+This patch is documentation/error-text only. No behavior changes, no new code paths, no schema migrations.
+
+#### 📝 Schema descriptions rewritten on `imap_send_email`
+
+- **Tool top-level description** now ends with a one-line decision rule listing the three forms and when each one applies.
+- **`attachments`** (inline base64) is presented as **INLINE FORM (preferred when the file is not on the server host)** with explicit guidance pointing at Claude Desktop Workspace and Claude.ai sandbox cases. Mentions the ~10 MB MCP transport ceiling.
+- **`attachmentPaths`** is presented as **PATH FORM (preferred when the file is on the same host as this server)** with a steer to inline when the file lives in a sandbox.
+- **`stagedAttachmentIds`** is presented as **STAGED FORM (for large files or streaming uploads)**, explicitly de-recommended for small-file Workspace cases.
+- **`attachments[].path`** is now flagged DEPRECATED in its description: it is forwarded directly to the SMTP composer and bypasses the WP1 allow-list. Callers wanting host-path attachments should use the top-level `attachmentPaths` field, which goes through `validateAttachmentPaths`. (No code change yet — flagged for a follow-up issue. See *Known issue* below.)
+
+#### 🪧 Validation error messages now steer to the right form
+
+`formatValidationErrors` in `src/services/attachment-validator.ts` was rewriting two failure kinds in a way that told the caller *what* was wrong but not *what to do next*. Both now include an explicit recommendation:
+
+- **`no-allowed-dirs-configured`** — instead of just *"Set IMAP_MCP_ALLOWED_ATTACHMENT_DIRS"*, the message now offers two paths forward: (a) if the file is in a sandbox the server cannot read, retry with the inline form; (b) if the file is on the host, here is how to configure the allow-list.
+- **`outside-allowed-dirs`** — now includes the same inline-form fallback recommendation for the sandbox case.
+
+#### 📝 Staging tool description tightened
+
+`imap_attachment_stage_init` now opens with *"Use only when the file exceeds the ~10 MB inline ceiling… For small files in a sandbox, prefer the inline `attachments` form."* This stops the tool from being chosen as a first-line answer for cases where one inline call would suffice.
+
+#### Known issue — flagged for follow-up
+
+Surfaced while writing this patch, **not fixed here**: the inline `attachments[].path` field is forwarded directly to the SMTP composer (`src/tools/email-tools.ts` ~660) without going through `validateAttachmentPaths`. A caller can therefore pass `{ filename: 'x', path: '/etc/passwd' }` and bypass the WP1 allow-list. The `attachmentPaths` top-level field is the correctly-gated path-based input. This patch only flags the inline `path` field as DEPRECATED in the schema description — it does not remove or block the field, because that would be a breaking change for any external caller relying on the v1 shape. Tracking issue and removal will follow in a separate release.
+
+#### Verified
+
+- `npm run build`: clean.
+- `npm test`: existing 50/50 still pass (no test changes — these are description-text edits).
+- Manual: error envelope text confirmed via local stdio run.
+
+#### Backward compatibility
+
+- No tool surface change. Same arguments, same return shape, same env vars.
+- No schema migration. DB stays at 1.10.0.
+- Error envelopes for `attachment_validation_failed` keep the same `result` and `errorDetails[].kind` codes; only the human-readable `errors[]` strings grew longer.
+
 ## [2.17.7] - 2026-05-03
 
 ### Patch — userId resolution on usercheck tools + skill-update response sanitization (#145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.7] - 2026-05-03
+
+### Patch — userId resolution on usercheck tools + skill-update response sanitization (#145)
+
+Two issues surfaced while expanding the v2.17.x acceptance test plan with UserCheck (Phase 6) and skill-update (Phase 8) coverage. Both are now fixed:
+
+#### 🐛 Fixed — userId on usercheck tools accepts username (matches subscription-tools behavior)
+
+`imap_add_usercheck_key` and the other 6 usercheck tools that accept `userId` were not running it through the v2.17.2 `resolveUserOrThrow` helper. Passing the username form (e.g., `"colin"`) returned `FOREIGN KEY constraint failed` deep in the INSERT path — same failure shape as #130 before that fix landed. The subscription tools were updated in v2.17.2; the usercheck tools were missed.
+
+- **Extracted** `resolveUserOrThrow` and `UnknownUserError` into `src/utils/user-resolver.ts` (was a private helper inside `subscription-tools.ts`).
+- **Applied** the resolver to all 7 usercheck tools that accept `userId`:
+  - `imap_add_usercheck_key`
+  - `imap_get_usercheck_key`
+  - `imap_check_email_spam`
+  - `imap_check_domain`
+  - `imap_check_emails_spam_bulk`
+  - `imap_check_folder_spam`
+  - `imap_scan_account_spam`
+- **Updated** every `userId` Zod description on those tools to match the documented contract: *"either canonical user_id UUID or username from the users table."*
+- **Subscription-tools** now imports the shared helper instead of carrying a local copy.
+
+`imap_delete_usercheck_key` doesn't take `userId` (it takes `keyId`), so no change needed.
+
+#### 🛡️ Mitigated — `imap_check_skill_updates` response trimmed and sanitized
+
+Same hang shape as the v2.17.5 `imap_get_unsubscribe_links` issue: server returns a valid response in 175ms via local stdio (verified), but Claude Desktop hangs on it. We can't fix CD's renderer from here, but we can give it less surface area to choke on.
+
+- **Removed** the `baseUrl` field from the response (informational — can be reconstructed from `source`).
+- **Sanitized** the `summary` and per-skill `fetchError` strings via `sanitizeText` (the v2.17.6 helper). Caps lengths, replaces control characters with spaces.
+- **Removed** `cached` field (was always `false` — never wired up).
+
+Response size dropped from 542 → 428 bytes (21% smaller, fewer string fields for CD to render). Whether this fully resolves the CD hang is for end-user verification post-install; if not, the v2.17.6 skill workaround pattern (avoid the affected tool in skill workflows) extends to anything that depends on `imap_check_skill_updates`.
+
+#### 🧪 Acceptance verification
+
+Local stdio MCP test against v2.17.7 build:
+
+```
+imap_check_skill_updates       → 175ms / 44ms cached, 428 bytes  (was 542 bytes)
+imap_get_subscription_summary  →   2ms,   4557 bytes  ✓ unchanged
+imap_list_unsubscribe_candidates → 0ms,   4732 bytes  ✓ unchanged
+imap_get_unsubscribe_links     →   1ms,  11589 bytes  ✓ unchanged
+```
+
+All 50 unit tests pass.
+
+userId resolution path verified by code review: all 7 usercheck handlers now extract via `userId: userIdRaw` then call `resolveUserOrThrow(db, userIdRaw)` at the top of the handler body, exactly matching the subscription-tools pattern shipped in v2.17.2.
+
+#### 🛡️ Backward compatibility
+
+- **userId is now strict superset** on usercheck tools — UUIDs that worked previously still work; usernames now also work.
+- **No schema changes.** No DB migration.
+- **`imap_check_skill_updates` response shape is a subset** of v2.17.6's. Callers that depended on the dropped fields (`baseUrl`, `cached`) will see them as `undefined`. Those fields were never used by the bundled `unsubscribe-cleanup` skill or any internal tool.
+
+#### 📋 Tracked
+
+- Issue #145 — root-cause filing with both bugs and the diagnostic data
+- v2.17.x test plan (Phase 6 + Phase 8) — first run-through to surface these issues during plan-authoring
+
 ## [2.17.6] - 2026-05-02
 
 ### Patch — sanitize unsubscribe content; skill avoids the row-level read tool (#143)

--- a/dxt/manifest.template.json
+++ b/dxt/manifest.template.json
@@ -37,7 +37,9 @@
         "IMAP_MCP_LOG_LEVEL": "${user_config.log_level}",
         "IMAP_MCP_ALLOWED_ATTACHMENT_DIRS": "${user_config.allowed_attachment_dirs}",
         "IMAP_MCP_ENCRYPTION_KEY": "${user_config.encryption_key}",
-        "IMAP_MCP_ATTACHMENT_MAX_BYTES": "${user_config.max_attachment_size_bytes}",
+        "IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES": "${user_config.max_attachment_size_bytes}",
+        "IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES": "${user_config.max_total_attachment_size_bytes}",
+        "IMAP_MCP_ALLOW_DOTFILES": "${user_config.allow_dotfiles}",
         "IMAP_MCP_AUTO_CREATE_SENT_FOLDER": "${user_config.auto_create_sent_folder}",
         "MCP_USER_ID": "${user_config.mcp_user_id}"
       }
@@ -76,12 +78,28 @@
     },
     "max_attachment_size_bytes": {
       "type": "number",
-      "title": "Maximum Attachment Size (bytes)",
-      "description": "Reject attachments larger than this value in bytes. Default 25 MiB.",
-      "default": 26214400,
+      "title": "Maximum Attachment Size — per file (bytes)",
+      "description": "Reject any single attachment larger than this value, in bytes. Applies uniformly to inline (base64-in-JSON), path-based, and staged attachment forms. Default 20 MiB (20971520). Range: 1 MiB to 100 MiB.",
+      "default": 20971520,
       "min": 1048576,
       "max": 104857600,
       "required": true
+    },
+    "max_total_attachment_size_bytes": {
+      "type": "number",
+      "title": "Maximum Attachment Size — aggregate per send (bytes)",
+      "description": "Reject a send whose attachments collectively exceed this value, in bytes. The budget spans all forms (inline + path + staged) in a single send. Default 20 MiB (20971520). Range: 1 MiB to 200 MiB. Most SMTP providers reject messages over 25–35 MiB; staying near the per-file cap is recommended.",
+      "default": 20971520,
+      "min": 1048576,
+      "max": 209715200,
+      "required": true
+    },
+    "allow_dotfiles": {
+      "type": "boolean",
+      "title": "Allow Dotfile / Dotdir Attachments",
+      "description": "When false (default and recommended), the server refuses to attach any file whose path or filename has a segment starting with '.' (.ssh, .aws, .config, .bashrc, .envrc, etc.). Most dotfile-prefixed paths are OS or app secrets and should never leave the host as an email attachment. Set to true only if you have a legitimate workflow that emails a dotfile.",
+      "default": false,
+      "required": false
     },
     "auto_create_sent_folder": {
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.7",
+  "version": "2.17.9",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/attachment-validator.test.ts
+++ b/src/services/attachment-validator.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for attachment-validator.ts security policies introduced in v2.17.9:
+ *   - sanitizeFilename basename semantics + control-char strip
+ *   - isDotfileBasename
+ *   - findDotSegment (path component scan, skipping '.' and '..')
+ *   - validateAttachmentPaths dotfile reject (default-on, opt-out)
+ *   - validateAttachmentPaths size caps (per-attachment + aggregate)
+ *
+ * These policies enforce: attachments cannot accidentally exfiltrate
+ * dotfile-prefixed host secrets (~/.ssh, ~/.aws, ~/.config) and cannot
+ * exceed configurable size caps. Tests verify both the rejection paths
+ * and the override knob.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  findDotSegment,
+  isDotfileBasename,
+  sanitizeFilename,
+  validateAttachmentPaths,
+} from './attachment-validator.js';
+
+describe('sanitizeFilename', () => {
+  it('extracts basename from a full path', () => {
+    expect(sanitizeFilename('/foo/bar/baz.txt')).toBe('baz.txt');
+  });
+
+  it('extracts basename from a Windows-style path', () => {
+    // path.basename on POSIX treats backslash as a literal character; on
+    // Windows it would split. Either way, no path separator survives in
+    // the output of a Workspace-supplied filename like
+    // "..\\..\\windows\\sec.dat" because either basename strips it or
+    // (POSIX) the whole thing is the basename without a separator.
+    const result = sanitizeFilename('foo\\bar.dat');
+    expect(result).not.toContain('/');
+  });
+
+  it('strips control characters', () => {
+    expect(sanitizeFilename('hello\x00\x07world.txt')).toBe('helloworld.txt');
+  });
+
+  it('does not strip leading dots (policy is the caller\'s)', () => {
+    expect(sanitizeFilename('.bashrc')).toBe('.bashrc');
+  });
+
+  it('caps at 255 bytes', () => {
+    const long = 'a'.repeat(300) + '.txt';
+    expect(sanitizeFilename(long).length).toBeLessThanOrEqual(255);
+  });
+
+  it('returns empty for path-only input with no basename', () => {
+    expect(sanitizeFilename('/')).toBe('');
+  });
+});
+
+describe('isDotfileBasename', () => {
+  it('returns true for .bashrc', () => {
+    expect(isDotfileBasename('.bashrc')).toBe(true);
+  });
+  it('returns false for normal filename', () => {
+    expect(isDotfileBasename('report.pdf')).toBe(false);
+  });
+  it('returns false for empty string', () => {
+    expect(isDotfileBasename('')).toBe(false);
+  });
+});
+
+describe('findDotSegment', () => {
+  it('finds .ssh in /Users/colin/.ssh/id_rsa', () => {
+    expect(findDotSegment('/Users/colin/.ssh/id_rsa')).toBe('.ssh');
+  });
+  it('finds .aws in /home/user/.aws/credentials', () => {
+    expect(findDotSegment('/home/user/.aws/credentials')).toBe('.aws');
+  });
+  it('returns null when no segment starts with .', () => {
+    expect(findDotSegment('/Users/colin/Downloads/foo.txt')).toBeNull();
+  });
+  it('skips . and .. (those are caught elsewhere)', () => {
+    expect(findDotSegment('/Users/./colin/../colin/Downloads')).toBeNull();
+  });
+  it('detects a dotfile in the basename position', () => {
+    expect(findDotSegment('/Users/colin/Downloads/.envrc')).toBe('.envrc');
+  });
+});
+
+describe('validateAttachmentPaths — dotfile policy', () => {
+  let tmpDir: string;
+  let normalFile: string;
+  let dotDir: string;
+  let dotDirFile: string;
+  let dotFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'imap-att-test-'));
+    normalFile = path.join(tmpDir, 'report.pdf');
+    await fs.promises.writeFile(normalFile, 'pdf-bytes');
+    dotDir = path.join(tmpDir, '.ssh');
+    await fs.promises.mkdir(dotDir);
+    dotDirFile = path.join(dotDir, 'id_rsa');
+    await fs.promises.writeFile(dotDirFile, 'PRIVATE KEY');
+    dotFile = path.join(tmpDir, '.envrc');
+    await fs.promises.writeFile(dotFile, 'export FOO=bar');
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('accepts a normal file in an allowed dir', async () => {
+    const result = await validateAttachmentPaths(
+      [{ path: normalFile }],
+      { globalAllowedDirs: [tmpDir], maxSizeBytes: 1_000_000, maxTotalSizeBytes: 1_000_000 },
+      [tmpDir]
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].filename).toBe('report.pdf');
+  });
+
+  it('rejects a path with a .dotdir segment by default', async () => {
+    const result = await validateAttachmentPaths(
+      [{ path: dotDirFile }],
+      { globalAllowedDirs: [tmpDir], maxSizeBytes: 1_000_000, maxTotalSizeBytes: 1_000_000 },
+      [tmpDir]
+    );
+    expect(result.errors).toEqual([
+      expect.objectContaining({ kind: 'dotfile-or-dotdir-rejected', component: '.ssh' }),
+    ]);
+    expect(result.attachments).toHaveLength(0);
+  });
+
+  it('rejects a dotfile in the basename position by default', async () => {
+    const result = await validateAttachmentPaths(
+      [{ path: dotFile }],
+      { globalAllowedDirs: [tmpDir], maxSizeBytes: 1_000_000, maxTotalSizeBytes: 1_000_000 },
+      [tmpDir]
+    );
+    expect(result.errors).toEqual([
+      expect.objectContaining({ kind: 'dotfile-or-dotdir-rejected', component: '.envrc' }),
+    ]);
+  });
+
+  it('accepts dotdir paths when denyDotfiles is false', async () => {
+    const result = await validateAttachmentPaths(
+      [{ path: dotDirFile }],
+      {
+        globalAllowedDirs: [tmpDir],
+        maxSizeBytes: 1_000_000,
+        maxTotalSizeBytes: 1_000_000,
+        denyDotfiles: false,
+      },
+      [tmpDir]
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].filename).toBe('id_rsa');
+  });
+});
+
+describe('validateAttachmentPaths — size caps', () => {
+  let tmpDir: string;
+  let smallFile: string;
+  let bigFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'imap-att-size-'));
+    smallFile = path.join(tmpDir, 'small.bin');
+    await fs.promises.writeFile(smallFile, Buffer.alloc(100));
+    bigFile = path.join(tmpDir, 'big.bin');
+    await fs.promises.writeFile(bigFile, Buffer.alloc(20_000));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rejects per-attachment size over cap', async () => {
+    const result = await validateAttachmentPaths(
+      [{ path: bigFile }],
+      { globalAllowedDirs: [tmpDir], maxSizeBytes: 10_000, maxTotalSizeBytes: 1_000_000 },
+      [tmpDir]
+    );
+    expect(result.errors[0]?.kind).toBe('size-exceeds-per-attachment');
+  });
+
+  it('rejects aggregate size over cap', async () => {
+    const result = await validateAttachmentPaths(
+      [{ path: smallFile }, { path: bigFile }],
+      { globalAllowedDirs: [tmpDir], maxSizeBytes: 100_000, maxTotalSizeBytes: 15_000 },
+      [tmpDir]
+    );
+    expect(result.errors.some(e => e.kind === 'aggregate-size-exceeds')).toBe(true);
+  });
+
+  it('accepts within both caps', async () => {
+    const result = await validateAttachmentPaths(
+      [{ path: smallFile }],
+      { globalAllowedDirs: [tmpDir], maxSizeBytes: 1_000, maxTotalSizeBytes: 1_000 },
+      [tmpDir]
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.attachments).toHaveLength(1);
+  });
+});

--- a/src/services/attachment-validator.ts
+++ b/src/services/attachment-validator.ts
@@ -31,6 +31,15 @@ export interface ValidatorConfig {
   maxSizeBytes: number;
   /** Aggregate max bytes for one send. */
   maxTotalSizeBytes: number;
+  /**
+   * When true (default) reject any path with a segment starting with '.'
+   * (dotfiles/dotdirs like .ssh, .aws, .config) and any inline filename
+   * starting with '.'. Set false via IMAP_MCP_ALLOW_DOTFILES=true to opt
+   * back in. Reason: dotfile paths are overwhelmingly OS/app secrets
+   * (~/.ssh/id_rsa, ~/.aws/credentials, ~/.config/...) that should never
+   * leave the host as an email attachment.
+   */
+  denyDotfiles?: boolean;
 }
 
 export interface ValidatedAttachment {
@@ -55,7 +64,9 @@ export type ValidationFailure =
   | { kind: 'outside-allowed-dirs'; path: string; resolved: string }
   | { kind: 'size-exceeds-per-attachment'; path: string; sizeBytes: number; limitBytes: number }
   | { kind: 'aggregate-size-exceeds'; pendingPath: string; totalBytes: number; limitBytes: number }
-  | { kind: 'no-allowed-dirs-configured' };
+  | { kind: 'no-allowed-dirs-configured' }
+  | { kind: 'dotfile-or-dotdir-rejected'; path: string; component: string }
+  | { kind: 'invalid-filename'; raw: string };
 
 export interface ValidationResult {
   attachments: ValidatedAttachment[];
@@ -86,15 +97,49 @@ export function resolveAllowedDirs(
 }
 
 /**
- * Per RFC 2183: filenames must not contain path separators or control
- * chars. We also strip leading dots (avoid hidden-file confusion) and
- * cap to 255 bytes UTF-8.
+ * Strip any path component from a filename and clean it for use in a MIME
+ * Content-Disposition header (RFC 2183).
+ *
+ *   "/foo/bar/baz.txt"        -> "baz.txt"
+ *   "..\\..\\windows\\sec.dat" -> "sec.dat"
+ *   "report\x00.pdf"         -> "report.pdf"
+ *
+ * Leading dots are NOT stripped here — that is a policy decision exposed
+ * via the `denyDotfiles` config knob, so callers can choose to allow
+ * legitimate dotfile sends while the default rejects them outright.
+ *
+ * Returns an empty string if the input has no usable basename (e.g. "/"
+ * or "..."). Callers should treat empty as a validation failure.
  */
 export function sanitizeFilename(filename: string): string {
-  const noSep = filename.replace(/[\/\\]/g, '_');
-  const noCtl = noSep.replace(/[\x00-\x1f\x7f]/g, '');
-  const noLeadDot = noCtl.replace(/^\.+/, '');
-  return noLeadDot.slice(0, 255);
+  const base = path.basename(filename);
+  const noCtl = base.replace(/[\x00-\x1f\x7f]/g, '');
+  return noCtl.slice(0, 255);
+}
+
+/**
+ * Returns true when the basename indicates a dotfile (e.g. ".bashrc",
+ * "..hidden"). Distinct from path-component scanning: this only inspects
+ * a single sanitized filename string.
+ */
+export function isDotfileBasename(filename: string): boolean {
+  return filename.length > 0 && filename.startsWith('.');
+}
+
+/**
+ * Returns the first dot-prefixed segment of an absolute path, or null if
+ * none. Skips '.' and '..' (those are caught by the parent-traversal /
+ * realpath checks). Only the segments between separators are considered;
+ * symbolic-link resolution is the caller's responsibility (validate both
+ * the input path and the realpath).
+ */
+export function findDotSegment(absolutePath: string): string | null {
+  const segments = absolutePath.split(path.sep).filter(Boolean);
+  for (const s of segments) {
+    if (s === '.' || s === '..') continue;
+    if (s.startsWith('.')) return s;
+  }
+  return null;
 }
 
 /** True if `child` (after realpath) is inside `parent` (after realpath). */
@@ -162,12 +207,33 @@ export async function validateAttachmentPaths(
       continue;
     }
 
+    // Dotfile / dotdir reject (default-on). Scan the input path; we re-scan
+    // the realpath below in case a non-dotted symlink resolves into a dotted
+    // directory.
+    const denyDot = config.denyDotfiles !== false;
+    if (denyDot) {
+      const seg = findDotSegment(p);
+      if (seg) {
+        errors.push({ kind: 'dotfile-or-dotdir-rejected', path: p, component: seg });
+        continue;
+      }
+    }
+
     let realPath: string;
     try {
       realPath = await fs.promises.realpath(p);
     } catch {
       errors.push({ kind: 'not-found', path: p });
       continue;
+    }
+
+    // Re-scan after realpath to catch symlinks into dotdirs.
+    if (denyDot) {
+      const seg = findDotSegment(realPath);
+      if (seg) {
+        errors.push({ kind: 'dotfile-or-dotdir-rejected', path: p, component: seg });
+        continue;
+      }
     }
 
     // Containment check after realpath.
@@ -216,6 +282,14 @@ export async function validateAttachmentPaths(
 
     const baseName = path.basename(realPath);
     const filename = sanitizeFilename(input.filename ?? baseName);
+    if (filename.length === 0) {
+      errors.push({ kind: 'invalid-filename', raw: input.filename ?? baseName });
+      continue;
+    }
+    if (config.denyDotfiles !== false && isDotfileBasename(filename)) {
+      errors.push({ kind: 'dotfile-or-dotdir-rejected', path: p, component: filename });
+      continue;
+    }
     const contentType =
       input.contentType ??
       (mimeLookup(realPath) || 'application/octet-stream');
@@ -244,13 +318,42 @@ export function formatValidationErrors(errors: ValidationFailure[]): string[] {
       case 'not-found':                 return `File not found or unreadable: ${e.path}`;
       case 'not-regular-file':          return `Not a regular file: ${e.path}`;
       case 'not-readable':              return `File not readable by server: ${e.path}`;
-      case 'outside-allowed-dirs':      return `Path resolves outside allowed dirs: ${e.path} -> ${e.resolved}`;
+      case 'outside-allowed-dirs':
+        return (
+          `Path resolves outside allowed dirs: ${e.path} -> ${e.resolved}. ` +
+          'If this file lives in a sandbox the server cannot read (Claude Desktop Workspace, ' +
+          'Claude.ai /mnt/user-data/outputs/, remote host), pass it via the inline `attachments` ' +
+          'form: [{ filename, content: <base64>, contentType }]. That form does not consult the ' +
+          'allow-list and completes in one round-trip.'
+        );
       case 'size-exceeds-per-attachment':
         return `Attachment exceeds per-file limit: ${e.path} (${e.sizeBytes} bytes > ${e.limitBytes})`;
       case 'aggregate-size-exceeds':
         return `Aggregate attachments exceed limit at ${e.pendingPath}: ${e.totalBytes} bytes > ${e.limitBytes}`;
       case 'no-allowed-dirs-configured':
-        return 'No allowed attachment directories configured. Set IMAP_MCP_ALLOWED_ATTACHMENT_DIRS or users.allowed_attachment_dirs.';
+        return (
+          'No allowed attachment directories configured for path-based attachments. ' +
+          'Two ways forward: ' +
+          '(a) if your file lives in a sandbox the server cannot read (Claude Desktop Workspace, ' +
+          'Claude.ai /mnt/user-data/outputs/, remote host), retry with the inline `attachments` ' +
+          'form: [{ filename, content: <base64>, contentType }] — single round-trip, no ' +
+          'allow-list involvement; ' +
+          '(b) if your file is on this server host, set IMAP_MCP_ALLOWED_ATTACHMENT_DIRS ' +
+          '(env, comma-separated absolute paths) or populate users.allowed_attachment_dirs ' +
+          'for the active user, then retry with attachmentPaths.'
+        );
+      case 'dotfile-or-dotdir-rejected':
+        return (
+          `Refused: path or filename contains a dotfile/dotdir segment ('${e.component}') in ` +
+          `${e.path}. Dotfile-prefixed paths (.ssh, .aws, .config, .bashrc, etc.) are denied by ` +
+          'default to prevent accidental exfiltration of host secrets. To opt back in for a ' +
+          'legitimate dotfile send, set IMAP_MCP_ALLOW_DOTFILES=true on the server.'
+        );
+      case 'invalid-filename':
+        return (
+          `Refused: filename '${e.raw}' has no usable basename after sanitization (e.g. it was ` +
+          'just a path separator or all control chars). Provide a non-empty filename string.'
+        );
     }
   });
 }

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -459,7 +459,13 @@ export function emailTools(
       'Send an email via SMTP and (by default) append the message to the IMAP Sent folder. ' +
       'Sent folder resolution: cache → SPECIAL-USE \\Sent flag → provider preset → fallback name probe. ' +
       'Gmail accounts skip the APPEND by default because Gmail server-copies sent messages; ' +
-      "pass forceAppendToSent=true to override. Bcc is preserved in the Sent copy per RFC 5322 §3.6.3.",
+      "pass forceAppendToSent=true to override. Bcc is preserved in the Sent copy per RFC 5322 §3.6.3. " +
+      'Attachment input — pick one form per file: ' +
+      '(1) `attachments` (inline base64) when the file lives in a sandbox the server cannot read ' +
+      '(Claude Desktop Workspace, Claude.ai code sandbox, remote host); ' +
+      '(2) `attachmentPaths` when the file is on the same host as this server and inside the ' +
+      'configured allow-list; ' +
+      '(3) `stagedAttachmentIds` only for files > ~10 MB that need chunked upload.',
     inputSchema: {
       accountId: z.string().describe('Account ID to send from'),
       to: z.union([z.string(), z.array(z.string())]).describe('Recipient email address(es)'),
@@ -470,16 +476,32 @@ export function emailTools(
       bcc: z.union([z.string(), z.array(z.string())]).optional().describe('BCC recipients'),
       replyTo: z.string().optional().describe('Reply-to address'),
       attachments: z.array(z.object({
-        filename: z.string().describe('Attachment filename'),
-        content: z.string().optional().describe('Base64 encoded content'),
-        path: z.string().optional().describe('File path to attach'),
-        contentType: z.string().optional().describe('MIME type'),
-      })).optional().describe('Email attachments (legacy form: { filename, content?, path?, contentType? }).'),
+        filename: z.string().describe('Attachment filename (used as the MIME part filename).'),
+        content: z.string().optional().describe(
+          'Base64-encoded file bytes. Use this when the file is not on the server host ' +
+          '(e.g., generated inside a Claude Desktop Workspace or Claude.ai sandbox).'
+        ),
+        path: z.string().optional().describe(
+          'DEPRECATED: prefer the top-level attachmentPaths field, which enforces the ' +
+          'attachment-directory allow-list. This inline path is forwarded directly to the SMTP ' +
+          'composer and bypasses allow-list validation; treat it as a legacy escape hatch.'
+        ),
+        contentType: z.string().optional().describe('MIME type. Auto-detected from filename if omitted.'),
+      })).optional().describe(
+        'INLINE FORM (preferred when the file is not on the server host). Each attachment carries ' +
+        'its bytes inline as base64 in the `content` field. One round-trip, no allow-list, no ' +
+        'staging. This is the right choice when the file lives in a Claude Desktop Workspace or ' +
+        'Claude.ai sandbox where /mnt/user-data/outputs/ paths are not visible to this server. ' +
+        'Practical size ceiling: ~10 MB per request (MCP transport limit). For larger files, use ' +
+        'stagedAttachmentIds.'
+      ),
       attachmentPaths: z.array(z.string()).optional().describe(
-        'WP1: array of absolute file paths to attach. Server reads, validates, and encodes ' +
-        'the files internally (no base64 in the JSON payload). Each path must resolve inside ' +
-        'one of the allowed attachment directories — see env IMAP_MCP_ALLOWED_ATTACHMENT_DIRS ' +
-        'or per-user override in users.allowed_attachment_dirs.'
+        'PATH FORM (preferred when the file is on the same host as this server). Array of ' +
+        'absolute file paths. The server reads, validates, and encodes the files internally. ' +
+        'Each path must resolve inside one of the allowed attachment directories (env ' +
+        'IMAP_MCP_ALLOWED_ATTACHMENT_DIRS, or per-user override in users.allowed_attachment_dirs). ' +
+        'If your file lives in a sandbox the server cannot read, use the inline `attachments` ' +
+        'form instead — the path-based form will fail with attachment_validation_failed.'
       ),
       attachmentContentTypes: z.array(z.string()).optional().describe(
         'Parallel array to attachmentPaths overriding the detected Content-Type. ' +
@@ -490,8 +512,10 @@ export function emailTools(
         'Use "" or omit an entry to keep the basename.'
       ),
       stagedAttachmentIds: z.array(z.string()).optional().describe(
-        'WP2: array of stagingIds from imap_attachment_stage_finalize. The server reads each ' +
-        'assembled blob, attaches it, and deletes the staging session on successful send.'
+        'STAGED FORM (for large files or streaming uploads). Array of stagingIds returned from ' +
+        'imap_attachment_stage_finalize. Use this only when the file exceeds the inline size ' +
+        'ceiling (~10 MB) and is not on the server host. For small files in a Workspace/sandbox, ' +
+        'prefer the inline `attachments` form — it avoids the multi-call staging dance.'
       ),
       appendToSent: z.boolean().optional().default(true).describe(
         'Append the sent message to the IMAP Sent folder after a successful SMTP send. Default true.'
@@ -534,12 +558,20 @@ export function emailTools(
       } : undefined
     };
 
+    // ---- shared attachment policy (applies to inline, path-based, staged) ----
+    const {
+      validateAttachmentPaths, resolveAllowedDirs, formatValidationErrors,
+      sanitizeFilename, isDotfileBasename,
+    } = await import('../services/attachment-validator.js');
+
+    const denyDotfiles = (process.env.IMAP_MCP_ALLOW_DOTFILES ?? '').toLowerCase() !== 'true';
+    const maxBytes = Number(process.env.IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES ?? 20 * 1024 * 1024);
+    const maxTotalBytes = Number(process.env.IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES ?? 20 * 1024 * 1024);
+    let runningTotalBytes = 0;
+
     // ---- WP1: resolve and validate path-based attachments ----
     const validatedPathAttachments: Array<{ filename: string; path: string; contentType: string }> = [];
     if (attachmentPaths && attachmentPaths.length > 0) {
-      const { validateAttachmentPaths, resolveAllowedDirs, formatValidationErrors } =
-        await import('../services/attachment-validator.js');
-
       const userId = (() => {
         try {
           const u = db.getUserByUsername(process.env.MCP_USER_ID || 'default');
@@ -553,9 +585,6 @@ export function emailTools(
         ? resolveAllowedDirs(db, userId, globalDirs)
         : globalDirs;
 
-      const maxBytes = Number(process.env.IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES ?? 25 * 1024 * 1024);
-      const maxTotalBytes = Number(process.env.IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES ?? 50 * 1024 * 1024);
-
       const inputs = attachmentPaths.map((p, i) => ({
         path: p,
         contentType: attachmentContentTypes?.[i] || undefined,
@@ -564,7 +593,12 @@ export function emailTools(
 
       const result = await validateAttachmentPaths(
         inputs,
-        { globalAllowedDirs: globalDirs, maxSizeBytes: maxBytes, maxTotalSizeBytes: maxTotalBytes },
+        {
+          globalAllowedDirs: globalDirs,
+          maxSizeBytes: maxBytes,
+          maxTotalSizeBytes: maxTotalBytes,
+          denyDotfiles,
+        },
         allowedDirs
       );
 
@@ -588,6 +622,63 @@ export function emailTools(
           path: a.realPath,
           contentType: a.contentType,
         });
+        runningTotalBytes += a.sizeBytes;
+      }
+    }
+
+    // ---- Inline attachments: sanitize, dotfile-reject, size cap ----
+    const sanitizedInlineAttachments: Array<{ filename: string; content?: Buffer; path?: string; contentType?: string }> = [];
+    if (attachments && attachments.length > 0) {
+      const inlineErrors: Array<{ kind: string; detail: string }> = [];
+      for (const att of attachments) {
+        const cleanName = sanitizeFilename(att.filename ?? '');
+        if (cleanName.length === 0) {
+          inlineErrors.push({ kind: 'invalid-filename', detail: `Inline attachment has no usable filename basename: ${JSON.stringify(att.filename)}` });
+          continue;
+        }
+        if (denyDotfiles && isDotfileBasename(cleanName)) {
+          inlineErrors.push({ kind: 'dotfile-or-dotdir-rejected', detail: `Inline attachment filename '${cleanName}' is a dotfile and is denied by default. Set IMAP_MCP_ALLOW_DOTFILES=true to opt back in.` });
+          continue;
+        }
+
+        let contentBuf: Buffer | undefined;
+        if (att.content) {
+          try {
+            contentBuf = Buffer.from(att.content, 'base64');
+          } catch {
+            inlineErrors.push({ kind: 'invalid-base64', detail: `Inline attachment '${cleanName}': content is not valid base64.` });
+            continue;
+          }
+          if (contentBuf.length > maxBytes) {
+            inlineErrors.push({ kind: 'size-exceeds-per-attachment', detail: `Inline attachment '${cleanName}' is ${contentBuf.length} bytes, exceeds per-attachment cap of ${maxBytes} bytes (override IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES).` });
+            continue;
+          }
+          if (runningTotalBytes + contentBuf.length > maxTotalBytes) {
+            inlineErrors.push({ kind: 'aggregate-size-exceeds', detail: `Inline attachment '${cleanName}' would push aggregate size to ${runningTotalBytes + contentBuf.length} bytes, exceeds total cap of ${maxTotalBytes} bytes (override IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES, or move large files to imap_attachment_stage_*).` });
+            continue;
+          }
+          runningTotalBytes += contentBuf.length;
+        }
+
+        sanitizedInlineAttachments.push({
+          filename: cleanName,
+          content: contentBuf,
+          path: att.path,
+          contentType: att.contentType,
+        });
+      }
+      if (inlineErrors.length > 0) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: false,
+              result: 'attachment_validation_failed',
+              errors: inlineErrors.map(e => e.detail),
+              errorDetails: inlineErrors,
+            }, null, 2)
+          }]
+        };
       }
     }
 
@@ -625,18 +716,51 @@ export function emailTools(
         };
       }
       const missing: string[] = [];
+      const stagedErrors: Array<{ kind: string; detail: string }> = [];
       for (const sid of stagedAttachmentIds) {
         const f = staging.getFinalized(userId, sid);
         if (!f) {
           missing.push(sid);
           continue;
         }
+        const cleanName = sanitizeFilename(f.filename ?? '');
+        if (cleanName.length === 0) {
+          stagedErrors.push({ kind: 'invalid-filename', detail: `Staged attachment ${sid}: stored filename has no usable basename.` });
+          continue;
+        }
+        if (denyDotfiles && isDotfileBasename(cleanName)) {
+          stagedErrors.push({ kind: 'dotfile-or-dotdir-rejected', detail: `Staged attachment ${sid}: filename '${cleanName}' is a dotfile and is denied by default. Set IMAP_MCP_ALLOW_DOTFILES=true to opt back in.` });
+          continue;
+        }
+        const stagedSize = f.size;
+        if (stagedSize > maxBytes) {
+          stagedErrors.push({ kind: 'size-exceeds-per-attachment', detail: `Staged attachment '${cleanName}' is ${stagedSize} bytes, exceeds per-attachment cap of ${maxBytes} (override IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES).` });
+          continue;
+        }
+        if (runningTotalBytes + stagedSize > maxTotalBytes) {
+          stagedErrors.push({ kind: 'aggregate-size-exceeds', detail: `Staged attachment '${cleanName}' would push aggregate size to ${runningTotalBytes + stagedSize} bytes, exceeds total cap of ${maxTotalBytes} (override IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES).` });
+          continue;
+        }
+        runningTotalBytes += stagedSize;
         stagedAttachments.push({
-          filename: f.filename,
+          filename: cleanName,
           path: f.assembledPath,
           contentType: f.contentType,
           stagingId: sid,
         });
+      }
+      if (stagedErrors.length > 0) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: false,
+              result: 'attachment_validation_failed',
+              errors: stagedErrors.map(e => e.detail),
+              errorDetails: stagedErrors,
+            }, null, 2)
+          }]
+        };
       }
       if (missing.length > 0) {
         return {
@@ -657,12 +781,7 @@ export function emailTools(
       from: account.user,
       to, subject, text, html, cc, bcc, replyTo,
       attachments: [
-        ...(attachments?.map(att => ({
-          filename: att.filename,
-          content: att.content ? Buffer.from(att.content, 'base64') : undefined,
-          path: att.path,
-          contentType: att.contentType,
-        })) ?? []),
+        ...sanitizedInlineAttachments,
         ...validatedPathAttachments,
         ...stagedAttachments.map(s => ({
           filename: s.filename,
@@ -905,10 +1024,15 @@ export function emailTools(
   if (staging) {
     server.registerTool('imap_attachment_stage_init', {
       description:
-        'Begin a chunked attachment upload. Returns a stagingId, server-recommended chunkSizeBytes ' +
-        '(default 256 KiB), and an expiresAt timestamp (default 1 hour). Subsequent chunks are sent ' +
-        'via imap_attachment_stage_append. Per-user disk quota is enforced — the call fails if the ' +
-        "session's expectedSize would exceed it.",
+        'Begin a chunked attachment upload. Use only when the file exceeds the ~10 MB inline ' +
+        'ceiling of imap_send_email\'s `attachments` form, or when streaming from a source that ' +
+        "cannot fit a single MCP request. For small files in a sandbox (Claude Desktop Workspace, " +
+        'Claude.ai /mnt/user-data/outputs/), prefer the inline `attachments` form on imap_send_email ' +
+        '— it is a single tool call, no chunking, no allow-list. ' +
+        'Returns a stagingId, server-recommended chunkSizeBytes (default 256 KiB), and an expiresAt ' +
+        'timestamp (default 1 hour). Subsequent chunks are sent via imap_attachment_stage_append. ' +
+        "Per-user disk quota is enforced — the call fails if the session's expectedSize would " +
+        'exceed it.',
       inputSchema: {
         filename: z.string().describe('Original filename (used as the attachment basename).'),
         expectedSize: z.number().int().nonnegative().describe('Total size the client intends to upload, in bytes.'),

--- a/src/tools/skills-tools.ts
+++ b/src/tools/skills-tools.ts
@@ -23,6 +23,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { withErrorHandling } from '../utils/error-handler.js';
+import { sanitizeText } from '../utils/sanitize-content.js';
 import {
   SkillsInstallerService,
   defaultGitHubSource,
@@ -52,10 +53,30 @@ export function skillsTools(
   }, withErrorHandling(async ({ ref, timeoutMs }) => {
     const source = ref ? { ...defaultGitHubSource(), ref } : defaultGitHubSource();
     const report = await installer.checkForUpdates({ source, timeoutMs });
+
+    // v2.17.7 (#145): minimize the response shape to reduce content
+    // surface area. Same defensive principle as v2.17.6 — bounded,
+    // sanitized strings for every field that's user-visible. Drop
+    // baseUrl (informational; can be reconstructed from `source`),
+    // cap fetchError to 200 chars, sanitize summary text.
+    const minimal = {
+      checkedAt: report.checkedAt,
+      source: report.source,
+      skills: report.skills.map(s => ({
+        name: s.name,
+        installed: s.installed,
+        bundled: s.bundled,
+        available: s.available,
+        hasUpdate: s.hasUpdate,
+        fetchError: sanitizeText(s.fetchError, 200),
+      })),
+      summary: sanitizeText(report.summary, 300) ?? '',
+    };
+
     return {
       content: [{
         type: 'text',
-        text: JSON.stringify(report, null, 2),
+        text: JSON.stringify(minimal, null, 2),
       }],
     };
   }));

--- a/src/tools/subscription-tools.ts
+++ b/src/tools/subscription-tools.ts
@@ -19,33 +19,7 @@ import { UnsubscribeService } from '../services/unsubscribe-service.js';
 import { UnsubscribeExecutorService } from '../services/unsubscribe-executor-service.js';
 import { withErrorHandling } from '../utils/error-handler.js';
 import { sanitizeText, sanitizeUrl } from '../utils/sanitize-content.js';
-
-/**
- * Thrown when the caller-supplied `userId` doesn't match any row in the
- * users table by UUID or by username. `withErrorHandling` converts this
- * into a structured error response back to the LLM with a clear hint.
- */
-class UnknownUserError extends Error {
-  constructor(provided: string) {
-    super(
-      `Unknown user: "${provided}". Pass a valid user_id (UUID) or a username ` +
-      `that exists in the users table. Call imap_list_users to see valid values.`
-    );
-    this.name = 'UnknownUserError';
-  }
-}
-
-/**
- * Resolve `userId` input (UUID or username) → canonical UUID. Throws
- * UnknownUserError if neither match — this stops FK constraint failures
- * deep in INSERT paths (issue #130) by failing fast at the tool boundary
- * with a clear, actionable error.
- */
-function resolveUserOrThrow(db: DatabaseService, input: string): string {
-  const resolved = db.resolveUserId(input);
-  if (!resolved) throw new UnknownUserError(input);
-  return resolved;
-}
+import { resolveUserOrThrow } from '../utils/user-resolver.js';
 
 export function registerSubscriptionTools(
   server: McpServer,

--- a/src/tools/usercheck-tools.ts
+++ b/src/tools/usercheck-tools.ts
@@ -15,6 +15,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { withErrorHandling } from '../utils/error-handler.js';
+import { resolveUserOrThrow } from '../utils/user-resolver.js';
 import { UserCheckService, SpamCheckCriteria } from '../services/usercheck-service.js';
 import { DatabaseService } from '../services/database-service.js';
 import { ImapService } from '../services/imap-service.js';
@@ -27,12 +28,13 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
   server.registerTool('imap_add_usercheck_key', {
     description: 'Add a UserCheck API key for a user (admin or own user only)',
     inputSchema: {
-      userId: z.string().describe('User ID to add the key for'),
+      userId: z.string().describe('User ID — either canonical user_id UUID or username from the users table. Call imap_list_users for valid values.'),
       apiKey: z.string().describe('UserCheck API key from https://usercheck.com/register?platform=api'),
       dailyLimit: z.number().optional().default(1000).describe('Daily API call limit (default: 1000)'),
       notes: z.string().optional().describe('Optional notes about this API key')
     }
-  }, withErrorHandling(async ({ userId, apiKey, dailyLimit, notes }) => {
+  }, withErrorHandling(async ({ userId: userIdRaw, apiKey, dailyLimit, notes }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     // Issue #83: Use DatabaseService method instead of direct SQL
     const result = db.createUserCheckKey({
       user_id: userId,
@@ -57,9 +59,10 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
   server.registerTool('imap_get_usercheck_key', {
     description: 'Get UserCheck API key information for a user',
     inputSchema: {
-      userId: z.string().describe('User ID')
+      userId: z.string().describe('User ID — either canonical user_id UUID or username from the users table.')
     }
-  }, withErrorHandling(async ({ userId }) => {
+  }, withErrorHandling(async ({ userId: userIdRaw }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     // Issue #83: Use DatabaseService method instead of direct SQL
     const keys = db.listUserCheckKeys(userId);
 
@@ -110,7 +113,7 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
   server.registerTool('imap_check_email_spam', {
     description: 'Check a single email address against UserCheck for spam',
     inputSchema: {
-      userId: z.string().describe('User ID (must have active UserCheck API key)'),
+      userId: z.string().describe('User ID — either canonical user_id UUID or username from the users table (must have active UserCheck API key).'),
       email: z.string().email().describe('Email address to check'),
       checkDisposable: z.boolean().optional().default(true).describe('Flag disposable email addresses'),
       checkBlocklisted: z.boolean().optional().default(true).describe('Flag blocklisted email addresses'),
@@ -119,7 +122,8 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
       allowPublicDomains: z.boolean().optional().default(true).describe('Allow public email domains'),
       useCache: z.boolean().optional().default(true).describe('Use cached results if available')
     }
-  }, withErrorHandling(async ({ userId, email, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains, useCache }) => {
+  }, withErrorHandling(async ({ userId: userIdRaw, email, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains, useCache }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     const criteria: SpamCheckCriteria = {
       checkDisposable,
       checkBlocklisted,
@@ -166,14 +170,15 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
   server.registerTool('imap_check_domain', {
     description: 'Check a domain against UserCheck for spam/validity',
     inputSchema: {
-      userId: z.string().describe('User ID (must have active UserCheck API key)'),
+      userId: z.string().describe('User ID — either canonical user_id UUID or username from the users table (must have active UserCheck API key).'),
       domain: z.string().describe('Domain to validate (e.g., example.com)'),
       checkDisposable: z.boolean().optional().default(true).describe('Flag disposable/temporary domains'),
       checkBlocklisted: z.boolean().optional().default(true).describe('Flag blocklisted domains'),
       checkMx: z.boolean().optional().default(true).describe('Check MX records'),
       allowPublicDomains: z.boolean().optional().default(true).describe('Allow public email domains')
     }
-  }, withErrorHandling(async ({ userId, domain, checkDisposable, checkBlocklisted, checkMx, allowPublicDomains }) => {
+  }, withErrorHandling(async ({ userId: userIdRaw, domain, checkDisposable, checkBlocklisted, checkMx, allowPublicDomains }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     const criteria: SpamCheckCriteria = {
       checkDisposable,
       checkBlocklisted,
@@ -198,7 +203,7 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
   server.registerTool('imap_check_emails_spam_bulk', {
     description: 'Check multiple email addresses against UserCheck for spam (max 1000)',
     inputSchema: {
-      userId: z.string().describe('User ID (must have active UserCheck API key)'),
+      userId: z.string().describe('User ID — either canonical user_id UUID or username from the users table (must have active UserCheck API key).'),
       emails: z.array(z.string().email()).max(1000).describe('Array of email addresses to check'),
       checkDisposable: z.boolean().optional().default(true).describe('Flag disposable email addresses'),
       checkBlocklisted: z.boolean().optional().default(true).describe('Flag blocklisted email addresses'),
@@ -207,7 +212,8 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
       allowPublicDomains: z.boolean().optional().default(true).describe('Allow public email domains'),
       useCache: z.boolean().optional().default(true).describe('Use cached results if available')
     }
-  }, withErrorHandling(async ({ userId, emails, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains, useCache }) => {
+  }, withErrorHandling(async ({ userId: userIdRaw, emails, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains, useCache }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     const criteria: SpamCheckCriteria = {
       checkDisposable,
       checkBlocklisted,
@@ -269,7 +275,7 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
   server.registerTool('imap_check_folder_spam', {
     description: 'Check all emails in a folder against UserCheck and return spam messages',
     inputSchema: {
-      userId: z.string().describe('User ID (must have active UserCheck API key)'),
+      userId: z.string().describe('User ID — either canonical user_id UUID or username from the users table (must have active UserCheck API key).'),
       accountId: z.string().describe('IMAP account ID'),
       folder: z.string().default('INBOX').describe('Folder to check'),
       limit: z.number().optional().default(100).describe('Maximum emails to check'),
@@ -280,7 +286,8 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
       allowPublicDomains: z.boolean().optional().default(true).describe('Allow public email domains'),
       useCache: z.boolean().optional().default(true).describe('Use cached results if available')
     }
-  }, withErrorHandling(async ({ userId, accountId, folder, limit, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains, useCache }) => {
+  }, withErrorHandling(async ({ userId: userIdRaw, accountId, folder, limit, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains, useCache }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     const criteria: SpamCheckCriteria = {
       checkDisposable,
       checkBlocklisted,
@@ -342,7 +349,7 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
   server.registerTool('imap_scan_account_spam', {
     description: 'Scan entire IMAP account for spam using UserCheck, checking all folders',
     inputSchema: {
-      userId: z.string().describe('User ID (must have active UserCheck API key)'),
+      userId: z.string().describe('User ID — either canonical user_id UUID or username from the users table (must have active UserCheck API key).'),
       accountId: z.string().describe('IMAP account ID'),
       maxEmailsPerFolder: z.number().optional().default(100).describe('Max emails to check per folder'),
       checkDisposable: z.boolean().optional().default(true).describe('Flag disposable email addresses'),
@@ -351,7 +358,8 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
       checkMx: z.boolean().optional().default(true).describe('Check MX records'),
       allowPublicDomains: z.boolean().optional().default(true).describe('Allow public email domains')
     }
-  }, withErrorHandling(async ({ userId, accountId, maxEmailsPerFolder, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains }) => {
+  }, withErrorHandling(async ({ userId: userIdRaw, accountId, maxEmailsPerFolder, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains }) => {
+    const userId = resolveUserOrThrow(db, userIdRaw);
     const criteria: SpamCheckCriteria = {
       checkDisposable,
       checkBlocklisted,

--- a/src/utils/user-resolver.ts
+++ b/src/utils/user-resolver.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared userId resolver for MCP tools that write or query the database
+ * by `users.user_id`.
+ *
+ * Background (#130, #145): tools that accept `userId` from the caller
+ * historically inserted whatever string was passed, which produced
+ * `FOREIGN KEY constraint failed` deep in INSERT paths when the caller
+ * supplied the username (e.g., "colin") instead of the canonical UUID.
+ * v2.17.2 introduced this resolver locally in subscription-tools.ts and
+ * applied it to 8 subscription handlers. v2.17.7 extracts it here and
+ * applies it consistently across the usercheck tools so every userId-
+ * accepting MCP tool follows the same rule:
+ *
+ *   - canonical user_id UUID  → returned as-is if the row exists
+ *   - username (e.g. "colin") → looked up; returns the matched user_id
+ *   - neither matches         → throws UnknownUserError, which
+ *                               withErrorHandling converts to a clean
+ *                               error envelope with an actionable hint.
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-05-03
+ * Version: 0.1.0
+ */
+
+import { DatabaseService } from '../services/database-service.js';
+
+/**
+ * Thrown when the caller-supplied `userId` matches neither a UUID nor a
+ * username row in the users table. `withErrorHandling` converts this
+ * into a structured error response back to the LLM with a clear hint.
+ */
+export class UnknownUserError extends Error {
+  constructor(provided: string) {
+    super(
+      `Unknown user: "${provided}". Pass a valid user_id (UUID) or a username ` +
+      `that exists in the users table. Call imap_list_users to see valid values.`
+    );
+    this.name = 'UnknownUserError';
+  }
+}
+
+/**
+ * Resolve `userId` input (UUID or username) → canonical UUID. Throws
+ * UnknownUserError if neither matches.
+ */
+export function resolveUserOrThrow(db: DatabaseService, input: string): string {
+  const resolved = db.resolveUserId(input);
+  if (!resolved) throw new UnknownUserError(input);
+  return resolved;
+}


### PR DESCRIPTION
## Summary

- **v2.17.8** (text-only): rewrote the `imap_send_email` schema descriptions so callers from sandboxed environments (Claude Desktop Workspace, Claude.ai code sandbox at `/mnt/user-data/outputs/`) reach for the inline base64 form first instead of falling into the path-based / staging dance. Validation error strings now offer two paths forward: inline for sandbox files, allow-list config for host files.
- **v2.17.9** (real enforcement): adds dotfile / dotdir rejection (default-on, `IMAP_MCP_ALLOW_DOTFILES` to opt out), per-attachment + aggregate size caps applied uniformly to inline / path / staged forms (default 20 MiB, sliders in the Claude Desktop UI), and `path.basename` semantics on filenames everywhere. Also fixes a latent manifest env-var name mismatch (`IMAP_MCP_ATTACHMENT_MAX_BYTES` was never read by the server) so the per-file slider in the Claude Desktop user_config now actually drives the runtime cap.

Both increments are bundled here because v2.17.8 was never tagged. `package.json` is at 2.17.9. See `CHANGELOG.md` for the full breakdown and the commit message body for rationale.

## Test plan

- [x] `npm run build` clean (tsc + postbuild)
- [x] `npm test`: 71/71 pass (was 50; +21 new tests in `src/services/attachment-validator.test.ts` covering `sanitizeFilename` basename behavior, `findDotSegment`, dotfile reject default + `denyDotfiles=false` override against real tmpdir fixtures, per-attachment + aggregate size cap enforcement)
- [ ] Manual: `.mcpb` install on Claude Desktop, verify the three new sliders/toggles render: *Maximum Attachment Size — per file*, *Maximum Attachment Size — aggregate per send*, *Allow Dotfile / Dotdir Attachments*
- [ ] Manual: send a small inline attachment from a Claude.ai Workspace context (`/mnt/user-data/outputs/foo.docx`) using the `attachments: [{ filename, content }]` form — should succeed in one round-trip with the basename'd filename in the MIME header
- [ ] Manual: attempt `attachmentPaths: ["/Users/colin/.ssh/id_rsa"]` — should fail with `dotfile-or-dotdir-rejected` and the human-readable hint
- [ ] Manual: attempt a 25 MB attachment with default settings — should fail with `size-exceeds-per-attachment`; raise the slider, retry, succeed

## Backward compatibility

- Default size caps changed (25/50 MB → 20/20 MiB). Sends between 20 MiB and 25 MB that previously succeeded will fail until the user raises either ceiling.
- Dotfile sends now refused by default; `IMAP_MCP_ALLOW_DOTFILES=true` to opt back in.
- `sanitizeFilename` now produces basename instead of separator-substituted strings (`foo_bar_baz.txt` → `baz.txt`).
- Manifest env-var rename (`IMAP_MCP_ATTACHMENT_MAX_BYTES` → `IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES`) is a fix to a never-working knob; not a breaking change for any working config.
- No tool surface change. No schema migration. DB stays at 1.10.0.

## Still open — tracked for follow-up

- **Inline `attachments[].path` allow-list bypass.** Flagged DEPRECATED in v2.17.8's schema description; routing it through `validateAttachmentPaths` (or removing the field) is the next iteration of attachment-input hardening.
- **Per-user outbox dir** at `~/.imap-mcp/users/<userId>/outbox/`, auto-created and auto-allowlisted. Eliminates the "no allowed dirs configured" first-run friction without widening attack surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
