### PR TITLE
v2.17.11: close inline attachments[].path allow-list bypass (closes #147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.11] - 2026-05-07
+
+### Patch — close inline `attachments[].path` allow-list bypass (closes #147)
+
+The inline `attachments[]` form on `imap_send_email` accepted a `path` field that was forwarded straight to nodemailer at `src/tools/email-tools.ts:660`, completely bypassing the WP1 (#100) allow-list and the v2.17.9 dotfile / size / basename rules. v2.17.8 flagged the field DEPRECATED in the schema description and v2.17.9 hardened every other attachment input — leaving this as the last un-gated entry point. v2.17.11 closes it.
+
+#### 🛡️ Security — inline path now validated identically to `attachmentPaths`
+
+Each inline attachment is now classified at handler time:
+
+- **Bytes shape** (`{ filename, content (base64) }`) — same v2.17.9 size + dotfile + basename rules as before. Decoded bytes capped against the per-attachment + aggregate size budget. If both `content` and `path` are passed, `content` wins (forward-compat: it has been the documented primary field since v1).
+- **Path shape** (`{ filename, path }`) — **new in v2.17.11.** Routed through `validateAttachmentPaths()` against the caller's allow-list, dotfile policy, and size caps. The same envelope (`attachment_validation_failed`, `errorDetails[].kind`) is returned on rejection as the top-level `attachmentPaths` field already produced. The validated `realPath` and basename'd filename are used downstream — symbolic-link traversal into a dotdir is rejected, paths outside the allow-list are rejected, files over the per-attachment cap are rejected, and the running aggregate budget is shared across all three attachment forms in one send.
+- **Empty shape** (neither `content` nor `path`) — now rejected with `empty-attachment` instead of being silently passed to the MIME composer (which would have produced a zero-byte attachment).
+
+User + allow-list resolution was hoisted to handler scope so the inline-path validation and the top-level `attachmentPaths` validation share one source of truth instead of duplicating the lookup. No behavior change for callers using `attachmentPaths` only — same SQL queries, same env reads, same outcomes.
+
+#### 📝 Schema description updated
+
+`attachments[].path` is no longer flagged DEPRECATED-as-bypass. New text:
+
+> *"Absolute file path on the server host. Validated against the same allow-list, dotfile-policy, and size caps as the top-level attachmentPaths field (since v2.17.11 / #147). Prefer the top-level attachmentPaths form for new code — this inline-path field remains for backward compatibility and is targeted for removal in v3.0."*
+
+The v3.0 removal target is preserved — long-term, `attachmentPaths` is the canonical host-path entry and the inline `attachments` form is for inline bytes only.
+
+#### Backward compatibility
+
+- Callers using `attachments: [{ filename, content }]` only: **no change.** Same behavior as v2.17.9 / v2.17.10.
+- Callers using `attachments: [{ filename, path }]`: **breaking change in the unsafe direction.** Previously an unconfigured server (`IMAP_MCP_ALLOWED_ATTACHMENT_DIRS` empty + per-user override null) accepted any path; now it rejects with `no-allowed-dirs-configured`. Configure the allow-list via the user_config slider or the env var, then retry.
+- Callers passing both `content` and `path` on the same entry: **content now wins decisively.** Previously both were forwarded to nodemailer and behavior depended on nodemailer's preference. Now `content` is used and `path` is ignored.
+- No tool surface change. No DB schema change.
+
+#### Verified
+
+- `npm run build`: clean.
+- `npm test`: 75/75 pass (the v2.17.9 attachment-validator tests cover the validator logic this patch reuses; the new code is a routing change, not new validation logic).
+- Schema description rewrite is the user-visible API change; verified to be backward-readable for any LLM client driving `imap_send_email`.
+
+#### What this closes
+
+The last attachment-input gap surfaced by the v2.17.7→v2.17.10 work. Per-form summary:
+
+| Form | Allow-list | Dotfile reject | Size caps | Filename basename |
+|---|---|---|---|---|
+| `attachmentPaths` | ✅ since #100 | ✅ v2.17.9 | ✅ v2.17.9 | ✅ v2.17.9 |
+| `attachments[].content` (base64) | n/a | ✅ v2.17.9 | ✅ v2.17.9 | ✅ v2.17.9 |
+| `attachments[].path` | ✅ **v2.17.11** | ✅ **v2.17.11** | ✅ **v2.17.11** | ✅ **v2.17.11** |
+| `stagedAttachmentIds` | ✅ implicit (server owns the bytes) | ✅ v2.17.9 | ✅ v2.17.9 | ✅ v2.17.9 |
+
 ## [2.17.10] - 2026-05-07
 
 ### Patch — embedded Web UI: bundle into .mcpb, auto-start with port-collision fallback (closes #150)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.10",
+  "version": "2.17.11",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -482,9 +482,10 @@ export function emailTools(
           '(e.g., generated inside a Claude Desktop Workspace or Claude.ai sandbox).'
         ),
         path: z.string().optional().describe(
-          'DEPRECATED: prefer the top-level attachmentPaths field, which enforces the ' +
-          'attachment-directory allow-list. This inline path is forwarded directly to the SMTP ' +
-          'composer and bypasses allow-list validation; treat it as a legacy escape hatch.'
+          'Absolute file path on the server host. Validated against the same allow-list, ' +
+          'dotfile-policy, and size caps as the top-level attachmentPaths field (since v2.17.11 / ' +
+          '#147). Prefer the top-level attachmentPaths form for new code — this inline-path field ' +
+          'remains for backward compatibility and is targeted for removal in v3.0.'
         ),
         contentType: z.string().optional().describe('MIME type. Auto-detected from filename if omitted.'),
       })).optional().describe(
@@ -569,38 +570,38 @@ export function emailTools(
     const maxTotalBytes = Number(process.env.IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES ?? 20 * 1024 * 1024);
     let runningTotalBytes = 0;
 
+    // Hoist user + allow-list resolution so both the path-based block AND
+    // the inline `attachments[].path` validation (#147) share one source of
+    // truth. Computed once per call regardless of which forms the caller
+    // uses; cheap (single SELECT) and avoids drift between the two paths.
+    const callerUserId = (() => {
+      try {
+        const u = db.getUserByUsername(process.env.MCP_USER_ID || 'default');
+        return u?.user_id ?? null;
+      } catch { return null; }
+    })();
+    const globalAllowedDirs = (process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS ?? '')
+      .split(',').map(s => s.trim()).filter(Boolean);
+    const callerAllowedDirs = callerUserId
+      ? resolveAllowedDirs(db, callerUserId, globalAllowedDirs)
+      : globalAllowedDirs;
+    const validatorConfig = {
+      globalAllowedDirs,
+      maxSizeBytes: maxBytes,
+      maxTotalSizeBytes: maxTotalBytes,
+      denyDotfiles,
+    };
+
     // ---- WP1: resolve and validate path-based attachments ----
     const validatedPathAttachments: Array<{ filename: string; path: string; contentType: string }> = [];
     if (attachmentPaths && attachmentPaths.length > 0) {
-      const userId = (() => {
-        try {
-          const u = db.getUserByUsername(process.env.MCP_USER_ID || 'default');
-          return u?.user_id ?? null;
-        } catch { return null; }
-      })();
-
-      const globalDirs = (process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS ?? '')
-        .split(',').map(s => s.trim()).filter(Boolean);
-      const allowedDirs = userId
-        ? resolveAllowedDirs(db, userId, globalDirs)
-        : globalDirs;
-
       const inputs = attachmentPaths.map((p, i) => ({
         path: p,
         contentType: attachmentContentTypes?.[i] || undefined,
         filename: attachmentFilenames?.[i] || undefined,
       }));
 
-      const result = await validateAttachmentPaths(
-        inputs,
-        {
-          globalAllowedDirs: globalDirs,
-          maxSizeBytes: maxBytes,
-          maxTotalSizeBytes: maxTotalBytes,
-          denyDotfiles,
-        },
-        allowedDirs
-      );
+      const result = await validateAttachmentPaths(inputs, validatorConfig, callerAllowedDirs);
 
       if (result.errors.length > 0) {
         return {
@@ -627,22 +628,37 @@ export function emailTools(
     }
 
     // ---- Inline attachments: sanitize, dotfile-reject, size cap ----
+    //
+    // Three input shapes supported on each entry:
+    //   1. { filename, content (base64) }            - inline bytes
+    //   2. { filename, path }                        - host-resident file
+    //   3. { filename, content, path }               - both; content wins,
+    //                                                  path is ignored
+    //
+    // Shape 2 (the inline `path` field) was historically forwarded straight
+    // to nodemailer, bypassing the WP1 (#100) allow-list and v2.17.9 dotfile
+    // / size / basename rules. v2.17.11 (#147) closes that bypass: any inline
+    // entry with `path` set goes through validateAttachmentPaths with the
+    // same policies that gate `attachmentPaths`. Result is byte-for-byte
+    // equivalent to using `attachmentPaths` directly; the inline `path` form
+    // remains for backward compat and will be removed in v3.0.
     const sanitizedInlineAttachments: Array<{ filename: string; content?: Buffer; path?: string; contentType?: string }> = [];
     if (attachments && attachments.length > 0) {
       const inlineErrors: Array<{ kind: string; detail: string }> = [];
       for (const att of attachments) {
-        const cleanName = sanitizeFilename(att.filename ?? '');
-        if (cleanName.length === 0) {
-          inlineErrors.push({ kind: 'invalid-filename', detail: `Inline attachment has no usable filename basename: ${JSON.stringify(att.filename)}` });
-          continue;
-        }
-        if (denyDotfiles && isDotfileBasename(cleanName)) {
-          inlineErrors.push({ kind: 'dotfile-or-dotdir-rejected', detail: `Inline attachment filename '${cleanName}' is a dotfile and is denied by default. Set IMAP_MCP_ALLOW_DOTFILES=true to opt back in.` });
-          continue;
-        }
-
-        let contentBuf: Buffer | undefined;
+        // Bytes-shape branch (`content` set; `path` ignored if also present).
         if (att.content) {
+          const cleanName = sanitizeFilename(att.filename ?? '');
+          if (cleanName.length === 0) {
+            inlineErrors.push({ kind: 'invalid-filename', detail: `Inline attachment has no usable filename basename: ${JSON.stringify(att.filename)}` });
+            continue;
+          }
+          if (denyDotfiles && isDotfileBasename(cleanName)) {
+            inlineErrors.push({ kind: 'dotfile-or-dotdir-rejected', detail: `Inline attachment filename '${cleanName}' is a dotfile and is denied by default. Set IMAP_MCP_ALLOW_DOTFILES=true to opt back in.` });
+            continue;
+          }
+
+          let contentBuf: Buffer;
           try {
             contentBuf = Buffer.from(att.content, 'base64');
           } catch {
@@ -658,13 +674,51 @@ export function emailTools(
             continue;
           }
           runningTotalBytes += contentBuf.length;
+
+          sanitizedInlineAttachments.push({
+            filename: cleanName,
+            content: contentBuf,
+            contentType: att.contentType,
+          });
+          continue;
         }
 
-        sanitizedInlineAttachments.push({
-          filename: cleanName,
-          content: contentBuf,
-          path: att.path,
-          contentType: att.contentType,
+        // Path-shape branch (`path` set, `content` not). Closes #147 bypass:
+        // route through the same validator that gates `attachmentPaths`.
+        if (att.path) {
+          const result = await validateAttachmentPaths(
+            [{ path: att.path, contentType: att.contentType, filename: att.filename }],
+            validatorConfig,
+            callerAllowedDirs
+          );
+          if (result.errors.length > 0) {
+            for (const e of result.errors) {
+              inlineErrors.push({
+                kind: e.kind,
+                detail: formatValidationErrors([e])[0],
+              });
+            }
+            continue;
+          }
+          for (const a of result.attachments) {
+            if (runningTotalBytes + a.sizeBytes > maxTotalBytes) {
+              inlineErrors.push({ kind: 'aggregate-size-exceeds', detail: `Inline path attachment '${a.filename}' would push aggregate size to ${runningTotalBytes + a.sizeBytes} bytes, exceeds total cap of ${maxTotalBytes} bytes (override IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES).` });
+              continue;
+            }
+            runningTotalBytes += a.sizeBytes;
+            sanitizedInlineAttachments.push({
+              filename: a.filename,
+              path: a.realPath,
+              contentType: a.contentType,
+            });
+          }
+          continue;
+        }
+
+        // Neither `content` nor `path` set — nothing to attach.
+        inlineErrors.push({
+          kind: 'empty-attachment',
+          detail: `Inline attachment '${att.filename ?? '<unnamed>'}' has neither 'content' (base64) nor 'path' set.`,
         });
       }
       if (inlineErrors.length > 0) {


### PR DESCRIPTION
## Summary

Closes [#147](https://github.com/Temple-of-Epiphany/imap-mcp-pro/issues/147), the last attachment-input bypass surfaced by the v2.17.7 → v2.17.10 hardening cycle. Inline `attachments[].path` (forwarded straight to nodemailer at `email-tools.ts:660`, fully bypassing the WP1 allow-list, dotfile rule, and size caps) is now routed through the same `validateAttachmentPaths()` pipeline as the top-level `attachmentPaths` field.

## Per-form hardening matrix

| Form | Allow-list | Dotfile reject | Size caps | Filename basename |
|---|---|---|---|---|
| `attachmentPaths` | ✅ since #100 | ✅ v2.17.9 | ✅ v2.17.9 | ✅ v2.17.9 |
| `attachments[].content` (base64) | n/a | ✅ v2.17.9 | ✅ v2.17.9 | ✅ v2.17.9 |
| `attachments[].path` | ✅ **v2.17.11** | ✅ **v2.17.11** | ✅ **v2.17.11** | ✅ **v2.17.11** |
| `stagedAttachmentIds` | ✅ implicit | ✅ v2.17.9 | ✅ v2.17.9 | ✅ v2.17.9 |

## Behavior changes

Each inline `attachments[]` entry is now classified by shape:

- **Bytes shape** (`content` set) — unchanged from v2.17.9. If both `content` and `path` are passed on the same entry, `content` now wins decisively (was previously implementation-defined via nodemailer).
- **Path shape** (`path` set, `content` not) — newly validated. Same error envelope (`attachment_validation_failed` + `errorDetails[].kind`) as the top-level `attachmentPaths` field already produced. Symlinks into dotdirs are rejected; files outside the allow-list are rejected; files over the per-attachment cap are rejected; the running aggregate budget is shared across all three attachment forms in one send.
- **Empty shape** (neither field) — now `empty-attachment` rejection rather than silent zero-byte attachment.

User + allow-list resolution was hoisted to handler scope so both the path-based block and the inline-path branch share one source of truth.

## Test plan

- [x] `npm run build` clean
- [x] `npm test`: 75/75 pass (the v2.17.9 attachment-validator tests cover the validator logic this patch reuses)
- [ ] Manual smoke: install v2.17.11 .mcpb, attempt `attachments: [{ filename: "x.txt", path: "/etc/hostname" }]` with `IMAP_MCP_ALLOWED_ATTACHMENT_DIRS` empty → expect `attachment_validation_failed` / `no-allowed-dirs-configured` (was previously a successful exfiltration)
- [ ] Manual smoke: same call with allowed dirs configured to include `/etc` → expect rejection with `dotfile-or-dotdir-rejected: hostname` if the file's basename starts with a dot, otherwise success
- [ ] Manual smoke: `attachments: [{ filename: "x", path: "/Users/me/.ssh/id_rsa" }]` → expect `dotfile-or-dotdir-rejected: .ssh` regardless of allow-list configuration

## Backward compatibility

- Callers using `attachments: [{ filename, content }]` only → no change.
- Callers using `attachments: [{ filename, path }]` → **breaking in the safe direction.** Previously accepted on any unconfigured server; now rejects with `no-allowed-dirs-configured` until the allow-list is configured. This is the intended secure outcome.
- Callers passing both fields → `content` wins (was implementation-defined before).
- No tool surface change. No DB schema change.

## What this closes

The v3.0 removal target for the inline `path` field is preserved — long-term, `attachmentPaths` is the canonical host-path entry. v2.17.11 is the security closure; v2.18.0 will add a one-shot deprecation log when the field is used; v3.0 will remove the field entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
