### PR TITLE
v2.17.12: imapUsername override (#87) + imap_test_account tool (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.12] - 2026-05-08
+
+### Patch — IMAP username override on provider tools (#87) + new `imap_test_account` tool (#90)
+
+Two small upstream-port additions bundled together because both touch `account-tools.ts` and target the same "post-add account verification" flow that an agent walking a user through onboarding would use.
+
+#### 🆕 `imap_add_account_with_provider` and `imap_add_account_auto` accept `imapUsername` (#87)
+
+Both provider-based account-creation tools now expose an optional `imapUsername` parameter. When set, it overrides the IMAP login username (which previously was hardcoded to `email`); when unset, behavior is unchanged (`username = email`). The same value is also used as the SMTP username when SMTP is enabled.
+
+This unblocks the Exchange-style case where the IMAP login is `DOMAIN\user` while the email is `user@domain.com`. Previously the only path was `imap_add_account` (manual config); the provider/auto-detect helpers couldn't be used.
+
+Schema is fine — `accounts.username` has been a separate column from any email field since v1.7.0. No DB migration. ~12 lines of code total across the two tool registrations.
+
+#### 🆕 New tool `imap_test_account` (#90)
+
+```json
+{ "accountId": "<uuid-from-imap_list_accounts>" }
+```
+
+One-shot connectivity probe against an existing account using its stored credentials. Spawns a fresh ImapFlow client that **does not** interact with the connection pool, retry queue, or circuit breaker — the probe is for diagnostics, not for warming up state.
+
+Returns:
+```json
+{
+  "success": true,
+  "accountId": "...",
+  "accountName": "...",
+  "host": "imap.example.com",
+  "port": 993,
+  "tls": true,
+  "folderCount": 12,
+  "inboxMessageCount": 1638,
+  "durationMs": 412
+}
+```
+
+On failure, the same envelope with `success: false`, the `error` string from ImapFlow (auth / TLS / DNS / timeout — passes through verbatim so the operator can diagnose), and `durationMs` so partial timeouts are visible.
+
+Implementation lives in two pieces:
+
+- `ImapService.testConnection(account)` (new method, ~30 lines): connect → list → status INBOX → logout. Catches errors and returns structured success/failure instead of throwing, so the tool wrapper can produce a clean envelope without bouncing through `withErrorHandling`. INBOX status is tried after `list()`; if it fails the probe still returns `ok: true` with `folderCount` set and `inboxMessageCount` undefined (rare but possible on misconfigured servers).
+- `imap_test_account` MCP tool (new registration in `src/tools/account-tools.ts`): looks up the account, verifies caller ownership against `MCP_USER_ID`, calls the service method, formats the envelope. Annotated `READ_ONLY` (no state mutation; just connects and queries).
+
+Tool count: **94 → 95**.
+
+#### Backward compatibility
+
+- `imap_add_account_with_provider` and `imap_add_account_auto` accept the new `imapUsername` parameter as **optional**. Existing callers passing only `{providerId, name, email, password, smtpEnabled}` work unchanged.
+- `imap_test_account` is a pure addition. No removal, no schema change.
+- No tool surface change beyond the additions. No DB schema change.
+
+#### Verified
+
+- `npm run build` clean.
+- `npm test`: 75/75 pass.
+- Manual smoke test deferred until installed `.mcpb` updates (requires a fresh release tag).
+
 ## [2.17.11] - 2026-05-07
 
 ### Patch — close inline `attachments[].path` allow-list bypass (closes #147)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.11",
+  "version": "2.17.12",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -547,6 +547,52 @@ export class ImapService {
   }
 
   /**
+   * One-shot connectivity probe (#90). Spawns a fresh ImapFlow client so the
+   * test does not interact with the connection pool, retry queue, or circuit
+   * breaker — the probe is for diagnostics, not for warming up state. Returns
+   * a structured result instead of throwing so the tool wrapper can produce a
+   * clean envelope on failure (auth error, DNS, TLS, etc.) without bouncing
+   * through withErrorHandling.
+   */
+  async testConnection(account: ImapAccount): Promise<{
+    ok: boolean;
+    folderCount?: number;
+    inboxMessageCount?: number;
+    error?: string;
+    durationMs: number;
+  }> {
+    const t0 = Date.now();
+    const client = new ImapFlow({
+      host: account.host,
+      port: account.port,
+      secure: account.tls,
+      auth: { user: account.user, pass: account.password },
+      logger: false,
+      emitLogs: false,
+      verifyOnly: false,
+      socketTimeout: account.connTimeout ?? 10000,
+    });
+    try {
+      await client.connect();
+      const list = await client.list();
+      const folderCount = list.length;
+      let inboxMessageCount: number | undefined;
+      try {
+        const status = await client.status('INBOX', { messages: true });
+        inboxMessageCount = status.messages;
+      } catch {
+        // INBOX may not exist on this server (rare) — fold into a successful
+        // probe with folderCount but no inboxMessageCount.
+      }
+      return { ok: true, folderCount, inboxMessageCount, durationMs: Date.now() - t0 };
+    } catch (err: any) {
+      return { ok: false, error: err?.message ?? String(err), durationMs: Date.now() - t0 };
+    } finally {
+      try { await client.logout(); } catch { /* best-effort */ }
+    }
+  }
+
+  /**
    * Get active connection or throw error
    */
   private getConnection(accountId: string): ImapFlow {

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -219,13 +219,21 @@ export function accountTools(
       email: z.string().describe('Email address'),
       password: z.string().describe('Password or app-specific password (see provider notes)'),
       smtpEnabled: z.boolean().default(false).describe('Enable SMTP for sending emails (default: false)'),
+      imapUsername: z.string().optional().describe(
+        'Override the IMAP login username. Defaults to the email address. Set this when the ' +
+        'provider requires a non-email login form (e.g., "DOMAIN\\\\user" on Exchange, a short ' +
+        'username on certain hosting setups). When set, the same value is also used as the SMTP ' +
+        'username unless overridden separately.'
+      ),
     }
-  }, withErrorHandling(withUserAuthorization(db, async ({ providerId, name, email, password, smtpEnabled }, context) => {
+  }, withErrorHandling(withUserAuthorization(db, async ({ providerId, name, email, password, smtpEnabled, imapUsername }, context) => {
     // Get provider preset
     const provider = getProviderById(providerId);
     if (!provider) {
       throw new Error(`Unknown provider: ${providerId}. Use imap_list_providers to see available providers.`);
     }
+
+    const loginUsername = imapUsername ?? email;
 
     // Create account with provider settings
     const account = db.createAccount({
@@ -233,14 +241,14 @@ export function accountTools(
       name,
       host: provider.imapHost,
       port: provider.imapPort,
-      username: email,
+      username: loginUsername,
       password,
       tls: provider.imapSecurity === 'SSL' || provider.imapSecurity === 'TLS',
       is_active: true,
       smtp_host: smtpEnabled && provider.smtpHost ? provider.smtpHost : undefined,
       smtp_port: smtpEnabled && provider.smtpPort ? provider.smtpPort : undefined,
       smtp_secure: smtpEnabled && provider.smtpSecurity ? (provider.smtpSecurity === 'SSL' || provider.smtpSecurity === 'TLS') : undefined,
-      smtp_username: smtpEnabled ? email : undefined,
+      smtp_username: smtpEnabled ? loginUsername : undefined,
       smtp_password: smtpEnabled ? password : undefined,
     });
 
@@ -286,13 +294,20 @@ export function accountTools(
       email: z.string().describe('Email address (provider will be auto-detected from domain)'),
       password: z.string().describe('Password or app-specific password'),
       smtpEnabled: z.boolean().default(false).describe('Enable SMTP for sending emails (default: false)'),
+      imapUsername: z.string().optional().describe(
+        'Override the IMAP login username. Defaults to the email address. Set this when the ' +
+        'provider requires a non-email login form (e.g., "DOMAIN\\\\user" on Exchange). When set, ' +
+        'the same value is also used as the SMTP username.'
+      ),
     }
-  }, withErrorHandling(withUserAuthorization(db, async ({ name, email, password, smtpEnabled }, context) => {
+  }, withErrorHandling(withUserAuthorization(db, async ({ name, email, password, smtpEnabled, imapUsername }, context) => {
     // Auto-detect provider from email
     const provider = getProviderByEmail(email);
     if (!provider) {
       throw new Error(`Could not auto-detect provider for ${email}. Use imap_add_account for manual configuration or imap_add_account_with_provider with a specific provider.`);
     }
+
+    const loginUsername = imapUsername ?? email;
 
     // Create account with auto-detected provider settings
     const account = db.createAccount({
@@ -300,14 +315,14 @@ export function accountTools(
       name,
       host: provider.imapHost,
       port: provider.imapPort,
-      username: email,
+      username: loginUsername,
       password,
       tls: provider.imapSecurity === 'SSL' || provider.imapSecurity === 'TLS',
       is_active: true,
       smtp_host: smtpEnabled && provider.smtpHost ? provider.smtpHost : undefined,
       smtp_port: smtpEnabled && provider.smtpPort ? provider.smtpPort : undefined,
       smtp_secure: smtpEnabled && provider.smtpSecurity ? (provider.smtpSecurity === 'SSL' || provider.smtpSecurity === 'TLS') : undefined,
-      smtp_username: smtpEnabled ? email : undefined,
+      smtp_username: smtpEnabled ? loginUsername : undefined,
       smtp_password: smtpEnabled ? password : undefined,
     });
 
@@ -341,6 +356,82 @@ export function accountTools(
               security: provider.smtpSecurity,
             } : undefined,
           },
+        }, null, 2)
+      }]
+    };
+  })));
+
+  // imap_test_account (#90): one-shot connectivity probe against an existing
+  // account using stored credentials. Spawns a fresh ImapFlow client to avoid
+  // touching the connection pool / circuit breaker — useful right after
+  // imap_add_account_with_provider to confirm the credentials work without
+  // first calling imap_connect (which would warm up state and reroute through
+  // breaker logic).
+  server.registerTool('imap_test_account', {
+    description:
+      'Test an existing account\'s IMAP connectivity using its stored credentials. ' +
+      'Spawns a one-shot connection that does not affect the persistent connection pool ' +
+      'or circuit breaker state. Returns folder count and INBOX message count on success, ' +
+      'or a structured error (TLS / auth / DNS / timeout) on failure with a duration in ms. ' +
+      'Useful immediately after imap_add_account_with_provider or imap_add_account_auto to ' +
+      'verify credentials before relying on the account.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID to test (from imap_list_accounts).'),
+    }
+  }, withErrorHandling(withUserAuthorization(db, async ({ accountId }, context) => {
+    const dbAccount = db.getDecryptedAccount(accountId);
+    if (!dbAccount) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            result: 'account_not_found',
+            accountId,
+          }, null, 2)
+        }]
+      };
+    }
+    if (dbAccount.user_id !== context.userId) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            result: 'account_not_owned_by_caller',
+            accountId,
+            hint: 'The accountId belongs to a different user. Pass an accountId returned by imap_list_accounts for the current MCP_USER_ID.',
+          }, null, 2)
+        }]
+      };
+    }
+
+    const account = {
+      id: dbAccount.account_id,
+      name: dbAccount.name,
+      host: dbAccount.host,
+      port: dbAccount.port,
+      user: dbAccount.username,
+      password: dbAccount.password,
+      tls: dbAccount.tls,
+    };
+
+    const result = await imapService.testConnection(account);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: result.ok,
+          accountId,
+          accountName: dbAccount.name,
+          host: dbAccount.host,
+          port: dbAccount.port,
+          tls: dbAccount.tls,
+          folderCount: result.folderCount,
+          inboxMessageCount: result.inboxMessageCount,
+          error: result.error,
+          durationMs: result.durationMs,
         }, null, 2)
       }]
     };

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -55,6 +55,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_add_account_with_provider':    WRITE_LOCAL,
   'imap_remove_account':               WRITE_LOCAL,
   'imap_list_accounts':                READ_ONLY,
+  'imap_test_account':                 READ_ONLY,
   'imap_list_providers':               READ_ONLY,
   'imap_share_account':                WRITE_LOCAL,
   'imap_unshare_account':              WRITE_LOCAL,


### PR DESCRIPTION
## Summary

Closes [#87](https://github.com/Temple-of-Epiphany/imap-mcp-pro/issues/87) and [#90](https://github.com/Temple-of-Epiphany/imap-mcp-pro/issues/90). Two small upstream-port additions bundled because both touch `account-tools.ts` and target the same post-add account verification flow an agent walks a user through.

- **#87 — `imapUsername` override on provider tools.** `imap_add_account_with_provider` and `imap_add_account_auto` now accept an optional `imapUsername` parameter. When set, it overrides the IMAP login username (was hardcoded to `email`); same value is also used as the SMTP username when SMTP is enabled. Unblocks Exchange-style accounts (`DOMAIN\user` IMAP login).
- **#90 — `imap_test_account` MCP tool.** One-shot connectivity probe using stored credentials. Spawns a fresh ImapFlow client that does *not* interact with the connection pool, retry queue, or circuit breaker. Returns folder count + INBOX message count + duration on success, structured error on failure (TLS / auth / DNS / timeout).

Schema is unchanged — `accounts.username` has been a separate column from any email field since v1.7.0. No DB migration.

Tool count: **94 → 95**.

## Test plan

- [x] `npm run build` clean
- [x] `npm test`: 75/75 pass
- [ ] Manual: install v2.17.12 .mcpb, call `imap_test_account` against an existing account → expect structured success envelope with `folderCount` and `inboxMessageCount`
- [ ] Manual: call `imap_add_account_with_provider` with `imapUsername: "DOMAIN\\user"` against a fake test account → verify the stored row has `username = DOMAIN\user` (not the email)
- [ ] Manual: call `imap_test_account` against a deliberately broken account (wrong password) → expect `success: false` with the auth error string in `error` and a non-zero `durationMs`

## Backward compatibility

- New `imapUsername` parameter is optional; existing callers continue to work unchanged.
- `imap_test_account` is a pure addition — no removal, no schema change.
- No tool surface change beyond the additions.

## Implementation notes

- `ImapService.testConnection(account)` (new method, ~30 lines): `connect → list → status('INBOX', { messages: true }) → logout`. Wrapped in try/catch/finally so it returns a structured `{ ok, folderCount?, inboxMessageCount?, error?, durationMs }` instead of throwing. INBOX status fetch is itself try/wrapped — a server where INBOX is unavailable still returns `ok: true` with `folderCount` and `inboxMessageCount: undefined` rather than failing the whole probe.
- `imap_test_account` enforces caller ownership against `MCP_USER_ID`-derived `userId` so a multi-tenant deployment can't probe arbitrary accounts.
- Annotated `READ_ONLY` (no state mutation; just connects + queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
