### PR TITLE
v2.17.13: per-user attachment outbox (#148) + CHANGELOG heading fix (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.13] - 2026-05-08
+
+### Patch — per-user attachment outbox (closes #148) + CHANGELOG heading typo (closes #149)
+
+#### 🆕 Per-user attachment outbox (#148)
+
+Eliminates the "no allowed attachment directories configured" first-run friction that motivated the v2.17.x attachment cycle. Server now provides a sanctioned drop zone for agent-generated files at:
+
+```
+~/.imap-mcp/users/<userId>/outbox/   (mode 0700, lazy-created on first access)
+```
+
+The outbox is always present in the resolved allow-list, so files written there can be attached via `imap_send_email`'s `attachmentPaths` field with no env / user_config setup. Same v2.17.9 dotfile / size / basename rules apply — the outbox is just one allow-listed dir among potentially many, not a special exempt zone.
+
+**New MCP tool — `imap_get_outbox_dir`**: returns the per-user path so agents can discover where to write without env access. Annotated `READ_ONLY`. Inputs: none.
+
+**Tool count: 95 → 96.**
+
+#### 🛡️ Dotfile-policy refactor — required for the outbox to work
+
+The v2.17.9 dotfile-rejection algorithm scanned every path segment for `.`-prefixes. That blocked the outbox itself, since the path naturally contains the dotdir `.imap-mcp`. The fix moves the scan to *after* containment matching: only segments **beneath** the matched allow-listed prefix are scanned for dotted entries.
+
+Before:
+```
+input ~/Downloads/.envrc                  -> dotfile rejected (.envrc)
+input ~/.imap-mcp/users/UID/outbox/x.pdf  -> false-rejected (.imap-mcp)
+input symlink-into-.ssh                   -> dotfile rejected (.ssh)
+input /etc/passwd (Downloads allowlisted) -> outside-allowed-dirs rejected
+```
+
+After:
+```
+input ~/Downloads/.envrc                  -> dotfile rejected (.envrc)  ← unchanged
+input ~/.imap-mcp/users/UID/outbox/x.pdf  -> accepted (matched dir = outbox; tail = x.pdf, no dots)
+input symlink-into-.ssh                   -> outside-allowed-dirs rejected (realpath escapes the allowlist)
+input /etc/passwd (Downloads allowlisted) -> outside-allowed-dirs rejected ← unchanged
+```
+
+The security posture is equivalent: any dotted path *outside* an explicitly allowlisted dir still rejects (including via symlink escape). The change exempts `.`-prefixed segments that are *part of* an operator-blessed allowlist entry — which is the only path the dotted segment can have a legitimate reason to exist on.
+
+Updated `formatValidationErrors` for `no-allowed-dirs-configured` to mention the outbox + the `imap_get_outbox_dir` tool as the recommended first option.
+
+#### 📝 #149 — CHANGELOG v2.17.9 heading drift
+
+```diff
+-### Patch — attachment hardening: dotfile reject, 10 MB default cap, filename basename on all forms
++### Patch — attachment hardening: dotfile reject, 20 MiB default cap, filename basename on all forms
+```
+
+The body was correct; the heading had not been updated when the cap changed mid-iteration. One-line doc fix.
+
+#### 🧪 New tests
+
+`src/services/attachment-validator.test.ts` (4 new tests, total 25):
+- `getOutboxDir` returns `~/.imap-mcp/users/<userId>/outbox/`
+- creates the directory with mode 0700 on first access
+- is idempotent across repeated calls
+- `validateAttachmentPaths` accepts a file inside the outbox even with otherwise-empty allow-list
+
+Total test count: **79/79 pass** (was 75).
+
+#### Backward compatibility
+
+- The outbox is *additive* — it appears in the resolved allow-list ahead of any operator-configured dirs but does not displace them. Existing allow-listed paths still work.
+- The dotfile refactor preserves the exact same rejection behavior for *unallowlisted* dotted paths (the canonical exfiltration vectors `~/.ssh`, `~/.aws`, `~/.config`, `~/.bashrc`, etc.). Only the false-positive on the server's own `~/.imap-mcp/...` paths is removed.
+- The new `imap_get_outbox_dir` tool is a pure addition.
+- No DB schema change. No tool surface removals.
+
+#### What this closes
+
+Companion to v2.17.11's inline-path bypass closure (#147). With both shipped, an agent's natural workflow for "email this generated file to <recipient>" is:
+
+1. Call `imap_get_outbox_dir` → get path
+2. `Write` the file to that path
+3. Call `imap_send_email` with `attachmentPaths: ["<that-path>/foo.pdf"]`
+
+Single allow-list entry, single round-trip, no chunking, no env configuration, full v2.17.9 dotfile/size/basename hardening applied.
+
 ## [2.17.12] - 2026-05-08
 
 ### Patch — IMAP username override on provider tools (#87) + new `imap_test_account` tool (#90)
@@ -186,7 +264,7 @@ Total: **75/75 pass** (was 71).
 
 ## [2.17.9] - 2026-05-06
 
-### Patch — attachment hardening: dotfile reject, 10 MB default cap, filename basename on all forms
+### Patch — attachment hardening: dotfile reject, 20 MiB default cap, filename basename on all forms
 
 Closes the first batch of attachment-input security gaps surfaced while diagnosing the Claude Desktop Workspace attachment failure that motivated v2.17.8. v2.17.8 fixed *discoverability* (the inline form was buried as "legacy"). v2.17.9 fixes *enforcement* (the rules now apply to all three input forms — inline, path, staged — uniformly).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.12",
+  "version": "2.17.13",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/attachment-validator.test.ts
+++ b/src/services/attachment-validator.test.ts
@@ -18,6 +18,7 @@ import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   findDotSegment,
+  getOutboxDir,
   isDotfileBasename,
   sanitizeFilename,
   validateAttachmentPaths,
@@ -203,5 +204,60 @@ describe('validateAttachmentPaths — size caps', () => {
     );
     expect(result.errors).toEqual([]);
     expect(result.attachments).toHaveLength(1);
+  });
+});
+
+describe('getOutboxDir (#148)', () => {
+  it('returns a path under ~/.imap-mcp/users/<userId>/outbox/', () => {
+    const userId = 'test-user-' + Date.now();
+    const dir = getOutboxDir(userId);
+    expect(dir).toBe(path.join(os.homedir(), '.imap-mcp', 'users', userId, 'outbox'));
+  });
+
+  it('creates the directory on first access (mode 0700)', async () => {
+    const userId = 'test-user-mkdir-' + Date.now();
+    const dir = getOutboxDir(userId);
+    const stats = await fs.promises.stat(dir);
+    expect(stats.isDirectory()).toBe(true);
+    // mode bits — on most POSIX filesystems mkdir-with-mode-0o700 produces
+    // a dir whose mode masked with 0o777 is 0o700. (Some filesystems
+    // collapse to 0o755; we only assert the *user* bits are set.)
+    expect(stats.mode & 0o700).toBe(0o700);
+    await fs.promises.rmdir(dir);
+  });
+
+  it('is idempotent across repeated calls', async () => {
+    const userId = 'test-user-idempotent-' + Date.now();
+    const a = getOutboxDir(userId);
+    const b = getOutboxDir(userId);
+    expect(a).toBe(b);
+    await fs.promises.rmdir(a);
+  });
+});
+
+describe('validateAttachmentPaths — outbox auto-allowlist (#148)', () => {
+  it('accepts a file inside the per-user outbox even when no other allowed dirs are configured', async () => {
+    const userId = 'test-validator-outbox-' + Date.now();
+    const outbox = getOutboxDir(userId);
+    const filePath = path.join(outbox, 'agent-generated.pdf');
+    await fs.promises.writeFile(filePath, 'pdf-bytes');
+    try {
+      const result = await validateAttachmentPaths(
+        [{ path: filePath }],
+        { globalAllowedDirs: [], maxSizeBytes: 1_000_000, maxTotalSizeBytes: 1_000_000 },
+        // Caller passes an empty allow-list; the outbox is the safety net.
+        // Note: this test exercises validateAttachmentPaths directly with
+        // [outbox] passed in; resolveAllowedDirs always prepends it in
+        // practice. We pass it explicitly here to keep the test
+        // independent of DB state.
+        [outbox]
+      );
+      expect(result.errors).toEqual([]);
+      expect(result.attachments).toHaveLength(1);
+      expect(result.attachments[0].filename).toBe('agent-generated.pdf');
+    } finally {
+      await fs.promises.unlink(filePath);
+      await fs.promises.rmdir(outbox);
+    }
   });
 });

--- a/src/services/attachment-validator.ts
+++ b/src/services/attachment-validator.ts
@@ -20,9 +20,36 @@
  */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { lookup as mimeLookup } from 'mime-types';
 import { DatabaseService } from './database-service.js';
+
+/**
+ * Per-user attachment outbox directory (#148). Server-managed sanctioned
+ * drop zone for agent-generated files. Auto-created on first access with
+ * mode 0700 and always present in the resolved allow-list, so an
+ * unconfigured server still has *one* path that path-based attachments
+ * (`attachmentPaths`) can target without the operator setting
+ * `IMAP_MCP_ALLOWED_ATTACHMENT_DIRS`.
+ *
+ * Path: ~/.imap-mcp/users/<userId>/outbox/
+ *
+ * The same v2.17.9 dotfile / size / basename rules apply -- the outbox
+ * is just one allow-listed dir among potentially many, not a special
+ * exempt zone.
+ */
+export function getOutboxDir(userId: string): string {
+  const dir = path.join(os.homedir(), '.imap-mcp', 'users', userId, 'outbox');
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch {
+    // Best effort. If mkdir fails (permission, disk full), the validator's
+    // realpath check will reject any attachment path inside this dir
+    // anyway -- preferable to crashing the whole imap_send_email call.
+  }
+  return dir;
+}
 
 export interface ValidatorConfig {
   /** Global allowed dirs from ServerConfig (already absolute paths). */
@@ -74,14 +101,20 @@ export interface ValidationResult {
 }
 
 /**
- * Resolve the per-user allowed dirs (CSV) plus the global ones.
- * User column wins when present (could be the empty string to opt out).
+ * Resolve the per-user allowed dirs (CSV) plus the global ones, with the
+ * per-user outbox dir (#148) always prepended. User column wins over globals
+ * when present (could be the empty string to opt out of globals); the outbox
+ * is always present regardless. Outbox is created lazily on first call.
  */
 export function resolveAllowedDirs(
   db: DatabaseService,
   userId: string,
   globalDirs: string[]
 ): string[] {
+  // Outbox first so resolvedAllowed.find(isInside) prefers it for files
+  // written there. Lazy-creates the dir.
+  const outbox = getOutboxDir(userId);
+
   let raw: string | null = null;
   try {
     const row = db.getDb()
@@ -92,8 +125,11 @@ export function resolveAllowedDirs(
     // Column may not exist (pre-1.9.0 schema) — fall through to globals.
     raw = null;
   }
-  if (raw === null) return globalDirs;
-  return raw.split(',').map((s) => s.trim()).filter(Boolean);
+  const userOrGlobal = raw === null
+    ? globalDirs
+    : raw.split(',').map((s) => s.trim()).filter(Boolean);
+
+  return [outbox, ...userOrGlobal];
 }
 
 /**
@@ -207,18 +243,6 @@ export async function validateAttachmentPaths(
       continue;
     }
 
-    // Dotfile / dotdir reject (default-on). Scan the input path; we re-scan
-    // the realpath below in case a non-dotted symlink resolves into a dotted
-    // directory.
-    const denyDot = config.denyDotfiles !== false;
-    if (denyDot) {
-      const seg = findDotSegment(p);
-      if (seg) {
-        errors.push({ kind: 'dotfile-or-dotdir-rejected', path: p, component: seg });
-        continue;
-      }
-    }
-
     let realPath: string;
     try {
       realPath = await fs.promises.realpath(p);
@@ -227,20 +251,37 @@ export async function validateAttachmentPaths(
       continue;
     }
 
-    // Re-scan after realpath to catch symlinks into dotdirs.
+    // Containment check after realpath. Find the longest matching allow-list
+    // entry — that's the prefix we'll exempt from the dotfile scan below
+    // (a path *inside* an explicitly allowlisted dotdir like .imap-mcp/outbox
+    // is intentional; only segments *beneath* the allow-listed prefix are
+    // suspicious).
+    let matchedDir: string | null = null;
+    for (const dir of resolvedAllowed) {
+      if (isInside(realPath, dir)) {
+        if (!matchedDir || dir.length > matchedDir.length) matchedDir = dir;
+      }
+    }
+    if (!matchedDir) {
+      errors.push({ kind: 'outside-allowed-dirs', path: p, resolved: realPath });
+      continue;
+    }
+
+    // Dotfile / dotdir reject (default-on), scanned only on the path tail
+    // *below* the allow-listed prefix. Catches `~/Downloads/.envrc` (when
+    // Downloads is allowlisted) without false-rejecting the per-user
+    // outbox at `~/.imap-mcp/users/<id>/outbox/...` whose own prefix
+    // contains `.imap-mcp`.
+    const denyDot = config.denyDotfiles !== false;
     if (denyDot) {
-      const seg = findDotSegment(realPath);
+      const relativeTail = path.relative(matchedDir, realPath);
+      // Prefix with separator so findDotSegment's split sees an "absolute"
+      // form. (findDotSegment skips empty segments from the leading sep.)
+      const seg = findDotSegment(path.sep + relativeTail);
       if (seg) {
         errors.push({ kind: 'dotfile-or-dotdir-rejected', path: p, component: seg });
         continue;
       }
-    }
-
-    // Containment check after realpath.
-    const inside = resolvedAllowed.some((dir) => isInside(realPath, dir));
-    if (!inside) {
-      errors.push({ kind: 'outside-allowed-dirs', path: p, resolved: realPath });
-      continue;
     }
 
     let stat: fs.Stats;
@@ -332,15 +373,18 @@ export function formatValidationErrors(errors: ValidationFailure[]): string[] {
         return `Aggregate attachments exceed limit at ${e.pendingPath}: ${e.totalBytes} bytes > ${e.limitBytes}`;
       case 'no-allowed-dirs-configured':
         return (
-          'No allowed attachment directories configured for path-based attachments. ' +
-          'Two ways forward: ' +
+          'No allowed attachment directories configured for path-based attachments — including ' +
+          'the per-user outbox, which would normally always be present. This usually means the ' +
+          'outbox could not be created (disk full, permission, ~/.imap-mcp/ unwritable). ' +
+          'Three ways forward: ' +
           '(a) if your file lives in a sandbox the server cannot read (Claude Desktop Workspace, ' +
           'Claude.ai /mnt/user-data/outputs/, remote host), retry with the inline `attachments` ' +
           'form: [{ filename, content: <base64>, contentType }] — single round-trip, no ' +
           'allow-list involvement; ' +
-          '(b) if your file is on this server host, set IMAP_MCP_ALLOWED_ATTACHMENT_DIRS ' +
-          '(env, comma-separated absolute paths) or populate users.allowed_attachment_dirs ' +
-          'for the active user, then retry with attachmentPaths.'
+          '(b) call imap_get_outbox_dir to discover the per-user outbox path, then write your ' +
+          'file there and reference it via attachmentPaths; ' +
+          '(c) set IMAP_MCP_ALLOWED_ATTACHMENT_DIRS (env, comma-separated absolute paths) or ' +
+          'populate users.allowed_attachment_dirs for the active user, then retry with attachmentPaths.'
         );
       case 'dotfile-or-dotdir-rejected':
         return (

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -361,6 +361,39 @@ export function accountTools(
     };
   })));
 
+  // imap_get_outbox_dir (#148): return the per-user attachment outbox path.
+  // Creates the dir on first access (mode 0700). The dir is always present
+  // in the resolved allow-list, so writing files there means imap_send_email
+  // can attach them via attachmentPaths without any env / user_config setup.
+  server.registerTool('imap_get_outbox_dir', {
+    description:
+      'Return the per-user attachment outbox directory path. Files written to this directory ' +
+      'can be attached via imap_send_email\'s attachmentPaths field with no additional setup — ' +
+      'the directory is always present in the resolved allow-list. The same v2.17.9 dotfile / ' +
+      'size / filename rules apply as for any allow-listed dir; this is a sanctioned drop zone, ' +
+      'not a special exempt zone. The directory is created lazily on first access (mode 0700) ' +
+      'under ~/.imap-mcp/users/<userId>/outbox/. Use this when an agent needs to email a file ' +
+      'it just generated on the server host, instead of base64-inlining the bytes through MCP.',
+    inputSchema: {}
+  }, withErrorHandling(withUserAuthorization(db, async (_args, context) => {
+    const { getOutboxDir } = await import('../services/attachment-validator.js');
+    const outboxDir = getOutboxDir(context.userId);
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          outboxDir,
+          userId: context.userId,
+          username: context.username,
+          usage:
+            'Write attachment files to this directory, then reference them via attachmentPaths ' +
+            'in imap_send_email. Same dotfile / size / filename rules apply as for any allow-listed dir.',
+        }, null, 2)
+      }]
+    };
+  })));
+
   // imap_test_account (#90): one-shot connectivity probe against an existing
   // account using stored credentials. Spawns a fresh ImapFlow client to avoid
   // touching the connection pool / circuit breaker — useful right after

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -56,6 +56,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_remove_account':               WRITE_LOCAL,
   'imap_list_accounts':                READ_ONLY,
   'imap_test_account':                 READ_ONLY,
+  'imap_get_outbox_dir':               READ_ONLY,
   'imap_list_providers':               READ_ONLY,
   'imap_share_account':                WRITE_LOCAL,
   'imap_unshare_account':              WRITE_LOCAL,

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -500,7 +500,10 @@ export function emailTools(
         'PATH FORM (preferred when the file is on the same host as this server). Array of ' +
         'absolute file paths. The server reads, validates, and encodes the files internally. ' +
         'Each path must resolve inside one of the allowed attachment directories (env ' +
-        'IMAP_MCP_ALLOWED_ATTACHMENT_DIRS, or per-user override in users.allowed_attachment_dirs). ' +
+        'IMAP_MCP_ALLOWED_ATTACHMENT_DIRS, per-user override in users.allowed_attachment_dirs, ' +
+        'or the always-present per-user outbox dir at ~/.imap-mcp/users/<userId>/outbox/ — ' +
+        'discoverable via the imap_get_outbox_dir tool). For agent-generated files on this host, ' +
+        'write to the outbox dir and reference by absolute path here; no env setup required. ' +
         'If your file lives in a sandbox the server cannot read, use the inline `attachments` ' +
         'form instead — the path-based form will fail with attachment_validation_failed.'
       ),


### PR DESCRIPTION
## Summary

Closes [#148](https://github.com/Temple-of-Epiphany/imap-mcp-pro/issues/148) (per-user attachment outbox) and [#149](https://github.com/Temple-of-Epiphany/imap-mcp-pro/issues/149) (CHANGELOG v2.17.9 heading typo). Companion to v2.17.11's inline-path bypass closure — together they make `imap_send_email` work cleanly out of the box for agent-generated files without any env / user_config setup.

- **#148 outbox:** `~/.imap-mcp/users/<userId>/outbox/` (mode 0700, lazy-created) is always present in the resolved allow-list. New MCP tool `imap_get_outbox_dir` returns the path. Tool count 95 → 96.
- **Required dotfile-policy refactor:** the v2.17.9 algorithm rejected the outbox itself because the path contains the dotdir `.imap-mcp`. Fix: scan only segments *beneath* the matched allow-list entry, not segments *of* it. Security posture for unallowlisted dotted paths is unchanged.
- **#149 doc:** v2.17.9 CHANGELOG heading said *"10 MB"* — body and code default are 20 MiB. One-line fix.

## Agent workflow this enables

Without any env / user_config:

```
1. imap_get_outbox_dir   ->  /Users/<u>/.imap-mcp/users/<id>/outbox
2. Write foo.pdf there
3. imap_send_email({ attachmentPaths: [".../outbox/foo.pdf"], ... })
```

Single round-trip, full v2.17.9 dotfile/size/basename hardening applied, no chunking, no inline base64.

## Test plan

- [x] `npm run build` clean
- [x] `npm test`: 79/79 pass (+4 new in `attachment-validator.test.ts` covering outbox creation, idempotency, and validator acceptance)
- [ ] Manual: install v2.17.13 .mcpb, call `imap_get_outbox_dir` → expect a path under `~/.imap-mcp/users/<userId>/outbox/`
- [ ] Manual: write a PDF to that path, then `imap_send_email` with `attachmentPaths: [".../outbox/test.pdf"]` → expect successful send with no allow-list configuration
- [ ] Manual: dotfile rejection still fires for `attachmentPaths: ["/Users/me/.ssh/id_rsa"]` (which would resolve outside any allow-list and be rejected for `outside-allowed-dirs`, or for `dotfile-or-dotdir-rejected` if `.ssh` were to be explicitly allow-listed and contain a non-dotted file — which would also reject because the file under `.ssh/` would have `.ssh` *between* the matched dir and the file basename — actually wait, if `.ssh` were the matched dir, the tail would just be `id_rsa` which has no dot prefix. Worth a manual sanity check.)

## Backward compatibility

- Outbox is additive — appears in the allow-list ahead of operator dirs but doesn't displace them.
- Dotfile refactor preserves all v2.17.9 rejections for unallowlisted dotted paths (`~/.ssh`, `~/.aws`, `~/.config`, etc.). The only behavioral change is removing the false-positive on the server's own `~/.imap-mcp/...` paths.
- New tool is a pure addition. No DB schema change.

## Note on the dotfile refactor edge case

If an operator explicitly allowlists `~/.ssh/` (a deliberate but unusual choice), files under it now pass dotfile validation since `.ssh` is the matched dir prefix. Previously they would have been rejected at validation, then potentially still attached if the `attachments[].path` bypass were used. This is the intended new behavior: the allow-list is the operator's final say. If you allowlist `.ssh`, you're explicitly saying the contents of that dir are OK to attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
