### PR TITLE
v2.17.14: two P0 fixes — angle-bracket dispatcher hang (#155) + env placeholder leakage (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.14] - 2026-05-08
+
+### Patch — two P0 fixes from v2.17.13 test-plan execution (closes #155, #156)
+
+#### 🐛 #155 — `imap_get_outbox_dir` no longer hangs in Claude Desktop
+
+The tool description contained the literal substring `<userId>` as a placeholder gloss for the per-user path. Claude Desktop's tool dispatcher silently refused to send `tools/call` for any tool whose description contains `<word>`-style angle-bracket tokens (apparent XML/HTML sanitization at the client side). Server logs showed zero `tools/call` entries during the 4-minute timeout window — the request never made it to the wire.
+
+Fix: replace `<userId>` and `<name>` placeholder syntax with curly-brace `{userId}` / `{name}`. Affects three tool descriptions:
+
+- `imap_get_outbox_dir` — `~/.imap-mcp/users/<userId>/outbox/` → `~/.imap-mcp/users/{userId}/outbox/`
+- `imap_send_email` (the `attachmentPaths` field gloss) — same change
+- `imap_update_skills` — `~/.claude/skills/imap-mcp-pro/<name>/` → `…/{name}/`
+
+Plus a regression test (`src/tools/tool-descriptions.test.ts`) that walks every string literal in `src/tools/*.ts` and fails CI if any contain `<word>`-style tokens. Allowlists obvious-non-XML cases (`html`, `body`, `br`, etc.) so error-message references to email content tags don't false-trip.
+
+#### 🐛 #156 — Manifest user_config substitution leaks literal placeholders
+
+Claude Desktop has two distinct failure modes when handing user_config values to the extension's child process:
+
+1. **Array-typed fields** (`type: "directory"` + `multiple: true`) ship as the literal string `"${user_config.<field>}"` because Desktop has no rule for serializing an array into a single env-var string.
+2. **Default values containing `${HOME}`** ship verbatim because Desktop only substitutes `${user_config.X}` references, not POSIX-style shell variables.
+
+Both observed against Claude Desktop 1.5354. Both make the path-based attachment feature non-functional out of the box (`attachmentPaths` rejects every send with `outside-allowed-dirs`).
+
+Fix: server-side env-resolver runs in the very-early pre-handshake stage, before any other code reads env. New module `src/utils/env-resolver.ts`:
+
+- **Expands `${HOME}` and `${USER}`** in any `IMAP_MCP_*` env var (so the `database_path` default works without help from Desktop).
+- **Detects literal `${user_config.X}` and other lingering `${...}` placeholders** and clears the variable (lets server-side defaults apply).
+- **Recovers `IMAP_MCP_ALLOWED_ATTACHMENT_DIRS` from the saved settings JSON** when the env var is unset or got cleared. Looks up `~/Library/Application Support/Claude/Claude Extensions Settings/*imap-mcp-pro.json` (and platform equivalents on Linux / Windows), reads `userConfig.allowed_attachment_dirs`, expands `~` and `${HOME}` in each entry, joins with `,`, and re-exports as the env var.
+- **Logs every cleanup** via `[startup] component=env-resolver expanded=[…] cleared=[…] recoveredFromSettings=[…]` so the operator can see exactly what was rewritten.
+
+End-to-end smoke verified with `node dist/index.js` launched with the buggy env Claude Desktop produces:
+
+```
+IMAP_MCP_ALLOWED_ATTACHMENT_DIRS=${user_config.allowed_attachment_dirs}
+IMAP_MCP_DATABASE_PATH=${HOME}/.imap-mcp/data.db
+```
+
+Server cleans both up at startup, recovers `[/tmp, /Users/<u>/Downloads]` from the settings JSON, and `imap_send_email` with `attachmentPaths: ["/tmp/foo.txt"]` succeeds.
+
+#### 🧪 New tests
+
+- `src/tools/tool-descriptions.test.ts` (1 test) — regression guard for #155.
+- `src/utils/env-resolver.test.ts` (7 tests) — `${HOME}`/`${USER}` expansion, placeholder clearing, no-op on well-formed env, settings JSON recovery (darwin only — other platforms are a no-op against the test fixture's directory layout).
+
+Total: **87/87 pass** (was 80).
+
+#### Backward compatibility
+
+- Pure additive on the env side: well-formed env values pass through unchanged. The resolver only rewrites values it can prove are broken.
+- No tool-surface change. No DB schema change.
+- The settings-JSON recovery path is best-effort: if the settings file is missing, malformed, or on a non-Desktop platform, the resolver no-ops and the server falls back to its zero-allow-list default (which is then still ameliorated by the per-user outbox from v2.17.13).
+
+#### Recommended action for users
+
+Reinstall the v2.17.14 `.mcpb` once it builds. After restart, `imap_get_outbox_dir` should return immediately, and `attachmentPaths` should work for any directory listed in the *Allowed Attachment Directories* user_config slider.
+
+If you still see issues, the `[startup] component=env-resolver` log line tells the full story of what got rewritten — paste that into a new issue.
+
 ## [2.17.13] - 2026-05-08
 
 ### Patch — per-user attachment outbox (closes #148) + CHANGELOG heading typo (closes #149)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.13",
+  "version": "2.17.14",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,12 @@ const {
   sentFolderService, appendRetryService, attachmentStaging, messageCache,
   skillsInstaller, webUIManager,
 } = await timeStage('pre-handshake', async () => {
+    // 0. Heal env vars Claude Desktop failed to substitute (#156). Runs
+    //    before loadConfig() / DatabaseService construction so every
+    //    downstream consumer sees the cleaned-up values.
+    const { resolveEnvPlaceholdersWithLogging } = await import('./utils/env-resolver.js');
+    resolveEnvPlaceholdersWithLogging();
+
     // 1. Load + validate config
     let config;
     try {

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -372,8 +372,9 @@ export function accountTools(
       'the directory is always present in the resolved allow-list. The same v2.17.9 dotfile / ' +
       'size / filename rules apply as for any allow-listed dir; this is a sanctioned drop zone, ' +
       'not a special exempt zone. The directory is created lazily on first access (mode 0700) ' +
-      'under ~/.imap-mcp/users/<userId>/outbox/. Use this when an agent needs to email a file ' +
-      'it just generated on the server host, instead of base64-inlining the bytes through MCP.',
+      'under ~/.imap-mcp/users/{userId}/outbox/ (curly braces are placeholder syntax — call this ' +
+      'tool to get the resolved path). Use this when an agent needs to email a file it just ' +
+      'generated on the server host, instead of base64-inlining the bytes through MCP.',
     inputSchema: {}
   }, withErrorHandling(withUserAuthorization(db, async (_args, context) => {
     const { getOutboxDir } = await import('../services/attachment-validator.js');

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -112,7 +112,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   // ---- v2.17.4 skill update from GitHub (#138) ----
   // check: read-only network call to raw.githubusercontent.com.
   'imap_check_skill_updates':          READ_REMOTE,
-  // update: writes to ~/.claude/skills/imap-mcp-pro/<name>/ from GitHub.
+  // update: writes to ~/.claude/skills/imap-mcp-pro/{name}/ from GitHub.
   'imap_update_skills':                WRITE_LOCAL,
 
   // ---- folder-tools (6) ----

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -501,7 +501,7 @@ export function emailTools(
         'absolute file paths. The server reads, validates, and encodes the files internally. ' +
         'Each path must resolve inside one of the allowed attachment directories (env ' +
         'IMAP_MCP_ALLOWED_ATTACHMENT_DIRS, per-user override in users.allowed_attachment_dirs, ' +
-        'or the always-present per-user outbox dir at ~/.imap-mcp/users/<userId>/outbox/ — ' +
+        'or the always-present per-user outbox dir at ~/.imap-mcp/users/{userId}/outbox/ — ' +
         'discoverable via the imap_get_outbox_dir tool). For agent-generated files on this host, ' +
         'write to the outbox dir and reference by absolute path here; no env setup required. ' +
         'If your file lives in a sandbox the server cannot read, use the inline `attachments` ' +

--- a/src/tools/skills-tools.ts
+++ b/src/tools/skills-tools.ts
@@ -88,7 +88,7 @@ export function skillsTools(
     description:
       'Apply skill updates from public GitHub for explicitly named skills. ' +
       'Fetches SKILL.md + version.json from raw.githubusercontent.com, writes ' +
-      'to ~/.claude/skills/imap-mcp-pro/<name>/, preserves files when the ' +
+      'to ~/.claude/skills/imap-mcp-pro/{name}/, preserves files when the ' +
       'on-disk version is already at or ahead of remote unless force=true. ' +
       'Skills not present in the bundled manifest are rejected (the manifest ' +
       'is the allowlist). Always pair with imap_check_skill_updates first to ' +

--- a/src/tools/tool-descriptions.test.ts
+++ b/src/tools/tool-descriptions.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Lint-style guard against XML/HTML-like patterns in tool descriptions.
+ *
+ * Why this exists: in v2.17.13 we shipped tool descriptions containing
+ * `<userId>` and `<name>` as placeholder syntax. Claude Desktop's tool
+ * dispatcher hangs on those tools indefinitely (issue #155) — apparently
+ * an XML/HTML sanitizer somewhere in the client trips on the bracket pair.
+ * v2.17.14 replaced the placeholders with curly-brace `{name}` form. This
+ * test ensures no future contributor reintroduces the pattern.
+ *
+ * Scope: scans every `description: '...'` and `.describe('...')` string in
+ * `src/tools/**.ts` for `<word>`-style patterns. Allowlists obvious-non-XML
+ * cases (URLs, code-block angle brackets, comparison operators).
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-05-08
+ * Version: 0.1.0
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TOOLS_DIR = __dirname; // src/tools
+
+function listToolFiles(): string[] {
+  return fs.readdirSync(TOOLS_DIR)
+    .filter(f => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    .map(f => path.join(TOOLS_DIR, f));
+}
+
+/**
+ * Match a JS/TS string literal (single, double, or template) and return its
+ * raw inner content. Approximate — does not handle every edge case (escaped
+ * quotes inside, etc.) but is robust enough for our tool description shape.
+ */
+function* iterStringLiterals(source: string): Generator<{ content: string; line: number }> {
+  // Single quote, double quote, or backtick. Greedy until matching closer,
+  // not respecting escapes for simplicity (false-positives are acceptable
+  // for a lint-style check).
+  const re = /(['"`])((?:(?!\1)[\s\S])*?)\1/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) {
+    const before = source.slice(0, m.index);
+    const line = before.split('\n').length;
+    yield { content: m[2], line };
+  }
+}
+
+const ANGLE_TOKEN = /<([A-Za-z][A-Za-z0-9_]*)>/g;
+
+const ALLOWED_TOKENS = new Set<string>([
+  // Common HTML/email tags that legitimately show up in error messages
+  // about email body parsing.
+  'html', 'head', 'body', 'br', 'p', 'div', 'span',
+  'a', 'b', 'i', 'em', 'strong',
+  'unnamed', // used in 'Inline attachment <unnamed>' formatter
+]);
+
+describe('tool descriptions — no XML-like placeholders', () => {
+  it('no <name>-style angle-bracket tokens in any tool string literal', () => {
+    const offenders: Array<{ file: string; line: number; token: string; snippet: string }> = [];
+
+    for (const file of listToolFiles()) {
+      const source = fs.readFileSync(file, 'utf8');
+      for (const { content, line } of iterStringLiterals(source)) {
+        if (!content.includes('<')) continue;
+        let m: RegExpExecArray | null;
+        const local = new RegExp(ANGLE_TOKEN.source, 'g');
+        while ((m = local.exec(content)) !== null) {
+          const tok = m[1];
+          if (ALLOWED_TOKENS.has(tok.toLowerCase())) continue;
+          offenders.push({
+            file: path.relative(path.resolve(__dirname, '..', '..'), file),
+            line,
+            token: `<${tok}>`,
+            snippet: content.slice(Math.max(0, m.index - 30), m.index + tok.length + 32),
+          });
+        }
+      }
+    }
+
+    if (offenders.length > 0) {
+      const report = offenders
+        .map(o => `${o.file}:${o.line}  token=${o.token}\n    "...${o.snippet}..."`)
+        .join('\n');
+      throw new Error(
+        `Found XML/HTML-like placeholder tokens in tool source. ` +
+        `Claude Desktop's dispatcher hangs on these (#155). ` +
+        `Use curly-brace {name} form instead.\n\n${report}`
+      );
+    }
+
+    expect(offenders.length).toBe(0);
+  });
+});

--- a/src/utils/env-resolver.test.ts
+++ b/src/utils/env-resolver.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for env-resolver.ts (#156).
+ *
+ * Covers:
+ *   - ${HOME} / ${USER} expansion in env values
+ *   - Lingering literal ${user_config.X} placeholders are cleared
+ *   - Recovery of IMAP_MCP_ALLOWED_ATTACHMENT_DIRS from a settings JSON
+ *     when the env was never set or got cleared
+ *   - No-op when env is well-formed
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-05-08
+ * Version: 0.1.0
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveEnvPlaceholders } from './env-resolver.js';
+
+const SAVED_ENV = new Map<string, string | undefined>();
+const SAVED_KEYS = [
+  'IMAP_MCP_DATABASE_PATH',
+  'IMAP_MCP_LOG_LEVEL',
+  'IMAP_MCP_ALLOWED_ATTACHMENT_DIRS',
+  'IMAP_MCP_ENCRYPTION_KEY',
+  'IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES',
+  'IMAP_MCP_ALLOW_DOTFILES',
+  'IMAP_MCP_WEB_UI_PORT',
+  'IMAP_MCP_TEST_FAKE',
+];
+
+function snapshotEnv() {
+  for (const k of SAVED_KEYS) SAVED_ENV.set(k, process.env[k]);
+}
+function restoreEnv() {
+  for (const k of SAVED_KEYS) {
+    const v = SAVED_ENV.get(k);
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  SAVED_ENV.clear();
+}
+
+describe('resolveEnvPlaceholders — ${HOME}/${USER} expansion', () => {
+  beforeEach(snapshotEnv);
+  afterEach(restoreEnv);
+
+  it('expands ${HOME} in IMAP_MCP_DATABASE_PATH', () => {
+    process.env.IMAP_MCP_DATABASE_PATH = '${HOME}/.imap-mcp-pro/data.db';
+    const r = resolveEnvPlaceholders();
+    expect(r.expanded).toContain('IMAP_MCP_DATABASE_PATH');
+    expect(process.env.IMAP_MCP_DATABASE_PATH).toBe(`${os.homedir()}/.imap-mcp-pro/data.db`);
+  });
+
+  it('expands ${USER} as well', () => {
+    process.env.IMAP_MCP_TEST_FAKE = '/srv/${USER}/data';
+    const r = resolveEnvPlaceholders();
+    expect(r.expanded).toContain('IMAP_MCP_TEST_FAKE');
+    expect(process.env.IMAP_MCP_TEST_FAKE).toBe(`/srv/${os.userInfo().username}/data`);
+  });
+
+  it('leaves a well-formed value untouched', () => {
+    process.env.IMAP_MCP_LOG_LEVEL = 'INFO';
+    const r = resolveEnvPlaceholders();
+    expect(r.expanded).not.toContain('IMAP_MCP_LOG_LEVEL');
+    expect(r.cleared).not.toContain('IMAP_MCP_LOG_LEVEL');
+    expect(process.env.IMAP_MCP_LOG_LEVEL).toBe('INFO');
+  });
+});
+
+describe('resolveEnvPlaceholders — clear unsubstituted ${user_config.X}', () => {
+  beforeEach(snapshotEnv);
+  afterEach(restoreEnv);
+
+  it('clears IMAP_MCP_ALLOWED_ATTACHMENT_DIRS when value is the literal placeholder', () => {
+    process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS = '${user_config.allowed_attachment_dirs}';
+    const r = resolveEnvPlaceholders();
+    // Cleared from env. Note: a recovery path may then repopulate from a
+    // real settings JSON if one happens to exist on the test host — so we
+    // assert on the cleared bookkeeping, not the final env value. The final
+    // value is whatever recovery produced (possibly unset, possibly real
+    // dirs from the host's saved settings).
+    expect(r.cleared).toContain('IMAP_MCP_ALLOWED_ATTACHMENT_DIRS');
+    const finalValue = process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS;
+    if (finalValue !== undefined) {
+      expect(finalValue).not.toContain('${');
+    }
+  });
+
+  it('clears any IMAP_MCP_* env that still contains a generic ${...} placeholder after expansion', () => {
+    process.env.IMAP_MCP_TEST_FAKE = '${weird.placeholder}';
+    const r = resolveEnvPlaceholders();
+    expect(r.cleared).toContain('IMAP_MCP_TEST_FAKE');
+    expect(process.env.IMAP_MCP_TEST_FAKE).toBeUndefined();
+  });
+});
+
+describe('resolveEnvPlaceholders — array recovery from settings JSON', () => {
+  let tmpHome: string;
+  let restoreHomeFn: () => void;
+
+  beforeEach(() => {
+    snapshotEnv();
+    // Create an isolated fake home with a Claude Desktop settings file.
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'env-resolver-test-'));
+    const settingsDir = path.join(tmpHome, 'Library', 'Application Support', 'Claude', 'Claude Extensions Settings');
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, 'local.mcpb.test-author.imap-mcp-pro.json'),
+      JSON.stringify({
+        isEnabled: true,
+        userConfig: {
+          allowed_attachment_dirs: ['/tmp', '~/Downloads'],
+        },
+      }),
+    );
+    // Spoof os.homedir() for the duration of this test.
+    const origHomedir = os.homedir;
+    (os as any).homedir = () => tmpHome;
+    restoreHomeFn = () => { (os as any).homedir = origHomedir; };
+  });
+
+  afterEach(() => {
+    restoreHomeFn();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    restoreEnv();
+  });
+
+  it('recovers IMAP_MCP_ALLOWED_ATTACHMENT_DIRS from settings JSON when env is unset, only on darwin', () => {
+    delete process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS;
+    const r = resolveEnvPlaceholders();
+    if (process.platform === 'darwin') {
+      expect(r.recoveredFromSettings).toContain('IMAP_MCP_ALLOWED_ATTACHMENT_DIRS');
+      const expanded = (process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS ?? '').split(',');
+      expect(expanded).toContain('/tmp');
+      // Tilde-prefixed entries get expanded against the spoofed home.
+      expect(expanded.some(d => d === path.join(tmpHome, 'Downloads'))).toBe(true);
+    } else {
+      // On other platforms our spoofed dir layout lives at the wrong
+      // candidate path; recovery should be a no-op rather than crashing.
+      expect(r.recoveredFromSettings).not.toContain('IMAP_MCP_ALLOWED_ATTACHMENT_DIRS');
+    }
+  });
+
+  it('does not overwrite a well-formed env value', () => {
+    process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS = '/explicit/path';
+    const r = resolveEnvPlaceholders();
+    expect(r.recoveredFromSettings).not.toContain('IMAP_MCP_ALLOWED_ATTACHMENT_DIRS');
+    expect(process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS).toBe('/explicit/path');
+  });
+});

--- a/src/utils/env-resolver.ts
+++ b/src/utils/env-resolver.ts
@@ -1,0 +1,210 @@
+/**
+ * env-resolver.ts (#156) — heal env vars that Claude Desktop fails to
+ * substitute before launching the extension's child process.
+ *
+ * Two failure modes observed in v2.17.13 + Claude Desktop 1.5354:
+ *
+ *   1. user_config fields with `type: "directory"` + `multiple: true`
+ *      (i.e., array values) ship as the literal string
+ *      "${user_config.<field>}" — Claude Desktop has no rule for
+ *      serializing an array into a single env-var string.
+ *
+ *   2. user_config defaults containing "${HOME}" ship verbatim — Claude
+ *      Desktop only substitutes "${user_config.X}" references, not
+ *      "${HOME}" / "${USER}" / etc.
+ *
+ * What this module does at startup:
+ *
+ *   - Scans every IMAP_MCP_* env var.
+ *   - Expands "${HOME}" -> os.homedir() and "${USER}" -> os.userInfo().username
+ *     within env values.
+ *   - Detects values that still contain literal "${user_config.X}" or
+ *     plain "${HOME}" placeholders and CLEARS them (treats as unset, so
+ *     the server-side code defaults apply).
+ *   - For IMAP_MCP_ALLOWED_ATTACHMENT_DIRS specifically (the array case),
+ *     when the env was cleared, looks up the per-extension settings JSON
+ *     file Claude Desktop persists, reads userConfig.allowed_attachment_dirs
+ *     directly, joins with ',', and re-exports as the env var.
+ *
+ * Cleanups are logged via [startup] component=env-resolver so the operator
+ * can see exactly what got rewritten. Side effects are limited to
+ * mutation of `process.env`.
+ *
+ * Author: Colin Bitterfield
+ * Email: colin.bitterfield@templeofepiphany.com
+ * Date Created: 2026-05-08
+ * Version: 0.1.0
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { logEvent } from '../startup.js';
+
+const PLACEHOLDER_RE = /\$\{[^}]+\}/;
+const USER_CONFIG_RE = /\$\{user_config\.[A-Za-z0-9_]+\}/;
+const HOME_RE = /\$\{HOME\}/g;
+const USER_RE = /\$\{USER\}/g;
+
+/** Settings-dir candidates per platform; first one that exists wins. */
+function settingsDirCandidates(): string[] {
+  const home = os.homedir();
+  const platform = process.platform;
+  if (platform === 'darwin') {
+    return [path.join(home, 'Library', 'Application Support', 'Claude', 'Claude Extensions Settings')];
+  }
+  if (platform === 'win32') {
+    const appdata = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    return [path.join(appdata, 'Claude', 'Claude Extensions Settings')];
+  }
+  // Linux / others — Claude Desktop config dir convention is XDG-style.
+  return [
+    path.join(home, '.config', 'Claude', 'Claude Extensions Settings'),
+    path.join(home, '.local', 'share', 'Claude', 'Claude Extensions Settings'),
+  ];
+}
+
+/**
+ * Look up the per-extension settings JSON Claude Desktop persists. We
+ * don't know the exact filename ahead of time (it includes the publisher
+ * username), so we glob for `*imap-mcp-pro.json` in the settings dir and
+ * pick the most-recently-modified match.
+ */
+function findSettingsFile(): string | null {
+  for (const dir of settingsDirCandidates()) {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      continue;
+    }
+    const matches = entries.filter(f => f.endsWith('imap-mcp-pro.json'));
+    if (matches.length === 0) continue;
+    if (matches.length === 1) return path.join(dir, matches[0]);
+    // Multiple matches (shouldn't happen, but handle gracefully). Pick newest.
+    let newest: { path: string; mtime: number } | null = null;
+    for (const f of matches) {
+      const p = path.join(dir, f);
+      try {
+        const stat = fs.statSync(p);
+        const mtime = stat.mtimeMs;
+        if (!newest || mtime > newest.mtime) newest = { path: p, mtime };
+      } catch { /* skip */ }
+    }
+    if (newest) return newest.path;
+  }
+  return null;
+}
+
+interface SettingsFile {
+  isEnabled?: boolean;
+  userConfig?: Record<string, unknown>;
+}
+
+function readSettings(file: string): SettingsFile | null {
+  try {
+    const raw = fs.readFileSync(file, 'utf8');
+    return JSON.parse(raw) as SettingsFile;
+  } catch {
+    return null;
+  }
+}
+
+/** Expand ${HOME} and ${USER} in a string. Returns the expanded value. */
+function expandShellVars(value: string): string {
+  return value
+    .replace(HOME_RE, os.homedir())
+    .replace(USER_RE, os.userInfo().username);
+}
+
+/**
+ * Walk every IMAP_MCP_* env var and apply both cleanups (placeholder
+ * detection + ${HOME}/${USER} expansion). Returns a structured summary
+ * for logging.
+ */
+export function resolveEnvPlaceholders(): {
+  expanded: string[];        // names of env vars where ${HOME} / ${USER} expanded
+  cleared: string[];         // names of env vars where unsubstituted ${user_config.X} was cleared
+  recoveredFromSettings: string[];  // names of env vars repopulated from the settings JSON
+} {
+  const expanded: string[] = [];
+  const cleared: string[] = [];
+  const recoveredFromSettings: string[] = [];
+
+  for (const [name, raw] of Object.entries(process.env)) {
+    if (!name.startsWith('IMAP_MCP_')) continue;
+    if (typeof raw !== 'string') continue;
+
+    let value = raw;
+    let didExpand = false;
+
+    // First: ${HOME}/${USER} expansion. Idempotent; expands only if present.
+    if (HOME_RE.test(value) || USER_RE.test(value)) {
+      // Reset lastIndex on the global regexes (test() advances it).
+      HOME_RE.lastIndex = 0;
+      USER_RE.lastIndex = 0;
+      const replaced = expandShellVars(value);
+      if (replaced !== value) {
+        value = replaced;
+        didExpand = true;
+      }
+    }
+
+    // Second: detect lingering literal ${...} placeholders. Treat as unset.
+    if (USER_CONFIG_RE.test(value) || PLACEHOLDER_RE.test(value)) {
+      delete process.env[name];
+      cleared.push(name);
+      continue;
+    }
+
+    if (didExpand) {
+      process.env[name] = value;
+      expanded.push(name);
+    }
+  }
+
+  // Targeted recovery for the array case: if the allow-list env var got
+  // cleared (or was never set), pull it from the saved settings JSON.
+  if (!process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS) {
+    const file = findSettingsFile();
+    if (file) {
+      const settings = readSettings(file);
+      const dirs = settings?.userConfig?.allowed_attachment_dirs;
+      if (Array.isArray(dirs) && dirs.length > 0) {
+        // Each entry may itself contain ${HOME} / ~. Expand both.
+        const expandedDirs = dirs
+          .map(d => typeof d === 'string' ? d : '')
+          .filter(d => d.length > 0)
+          .map(d => expandShellVars(d))
+          .map(d => d.startsWith('~/') ? path.join(os.homedir(), d.slice(2)) : d);
+        if (expandedDirs.length > 0) {
+          process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS = expandedDirs.join(',');
+          recoveredFromSettings.push('IMAP_MCP_ALLOWED_ATTACHMENT_DIRS');
+        }
+      }
+    }
+  }
+
+  return { expanded, cleared, recoveredFromSettings };
+}
+
+/**
+ * Convenience wrapper that runs the resolver and emits a single
+ * [startup] log line summarizing what got rewritten. Safe to call from
+ * the early pre-handshake stage.
+ */
+export function resolveEnvPlaceholdersWithLogging(): void {
+  const r = resolveEnvPlaceholders();
+  if (r.expanded.length === 0 && r.cleared.length === 0 && r.recoveredFromSettings.length === 0) {
+    return;
+  }
+  logEvent('[startup]', {
+    component: 'env-resolver',
+    expanded: r.expanded,
+    cleared: r.cleared,
+    recoveredFromSettings: r.recoveredFromSettings,
+    detail:
+      'Claude Desktop user_config substitution leaks literal placeholders for some field types ' +
+      '(arrays, ${HOME} defaults). Server-side cleanup applied at startup; see issue #156.',
+  });
+}


### PR DESCRIPTION
## Summary

Closes [#155](https://github.com/Temple-of-Epiphany/imap-mcp-pro/issues/155) and [#156](https://github.com/Temple-of-Epiphany/imap-mcp-pro/issues/156) — the two P0s that surfaced during v2.17.13 test plan execution.

- **#155 — `imap_get_outbox_dir` hangs in Claude Desktop.** Tool description contained literal `<userId>` placeholder text. Claude Desktop's dispatcher silently refuses to send `tools/call` for any tool whose description contains `<word>`-style angle-bracket tokens (apparent XML/HTML sanitization at the client). Fix: replace `<userId>` / `<name>` with curly-brace `{userId}` / `{name}` across three tool descriptions, plus a regression test that lints all of `src/tools/*.ts`.
- **#156 — Manifest `user_config` substitution leaks literal placeholders.** Two distinct Claude Desktop bugs: (1) array-typed user_config fields ship as `${user_config.<field>}` literal because Desktop can't serialize arrays into env strings; (2) `${HOME}` in defaults ships verbatim. Fix: new server-side env-resolver runs in pre-handshake, expands `${HOME}` / `${USER}`, clears lingering `${...}` placeholders, and falls back to reading the per-extension settings JSON for `allowed_attachment_dirs` recovery.

## Test plan

- [x] `npm run build` clean
- [x] `npm test`: 87/87 pass (+8 new tests across `tool-descriptions.test.ts` and `env-resolver.test.ts`)
- [x] End-to-end smoke: launched compiled server with the buggy env Claude Desktop produces (`IMAP_MCP_ALLOWED_ATTACHMENT_DIRS=${user_config.allowed_attachment_dirs}`, `IMAP_MCP_DATABASE_PATH=${HOME}/.imap-mcp/data.db`); resolver heals both at startup, `imap_get_outbox_dir` returns in 51ms (not 4 minutes)
- [ ] Manual: install v2.17.14 .mcpb, restart Claude Desktop, confirm `[startup] component=env-resolver` appears in the log with `expanded`, `cleared`, `recoveredFromSettings` arrays populated. Confirm `imap_get_outbox_dir` returns immediately. Confirm `attachmentPaths` works against directories listed in the user_config slider

## Backward compatibility

- Well-formed env values pass through unchanged.
- No tool surface change. No DB schema change.
- Settings-JSON recovery is best-effort: missing file, malformed, or non-Desktop platform → resolver no-ops; server falls back to its zero-allow-list default (still ameliorated by the v2.17.13 per-user outbox).

## What was broken before

- `imap_get_outbox_dir`: 4-minute hang every call (#155)
- Path-based attachment sends: every call rejected with `outside-allowed-dirs` regardless of what the user configured in the UI (#156)
- Inline `attachments` form was the only working attachment path; outbox was reachable via lazy-mkdir from other code paths but the tool to discover its location was unreachable
- `${HOME}/.imap-mcp-pro` default DB path silently fell back to legacy `~/.imap-mcp` because the literal placeholder couldn't be opened

## What works after this patch

- All four attachment input forms work in Claude Desktop with the v2.17.14 .mcpb installed
- The `[startup] component=env-resolver` log line documents exactly what got rewritten so misconfiguration is debuggable
- Future tool descriptions can't reintroduce the angle-bracket pattern — the lint test catches it at CI time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
