### PR TITLE
v2.17.15: observability + SPA catch-all + env-resolver doc (closes #158 #159 #160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,79 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.15] - 2026-05-08
+
+### Patch — three observability/UX fixes from the v2.17.14 retrospective (closes #158, #159, #160)
+
+#### 🐛 #158 — `[startup] component=web-ui` log line now reliably emitted
+
+The log line documenting the Web UI's bound URL/port was missing in v2.17.14 test runs. Three improvements stack so the breadcrumb is unmissable:
+
+1. **Pre-await breadcrumb.** `src/index.ts` now emits `[startup] component=web-ui outcome=starting` *before* awaiting `webUIManager.start()`, so even a hang during port probing or `listen()` produces a startup log entry. The post-await log (`outcome=success` or `outcome=error`) keeps the existing fields (`url`, `port`, `triedPorts`, `alreadyRunning`).
+2. **Port-probe timeout.** `src/services/web-ui-manager.ts`'s `isPortFree()` now caps each probe at 1 second. If neither `error` nor `listening` fires within the window the port is treated as unusable and the next +100 candidate is tried. Prevents a stalled bind from hanging the entire post-handshake stage.
+3. **stderr-only console output.** `WebUIServer` was using `console.log` for its `🌐 Web UI server running at...` and `[WebUIServer] serving static assets from...` banners. Stdout is reserved for JSON-RPC, so those lines could be filtered by the v2.17.3 stdout sanitizer. Switched to `console.error` so Claude Desktop captures them via stderr alongside the structured `logEvent` lines.
+
+Net effect: a v2.17.15 install will produce the following sequence in `~/Library/Logs/Claude/mcp-server-IMAP MCP Pro.log`:
+
+```
+[startup] component=web-ui outcome=starting
+[WebUIServer] serving static assets from <path>
+🌐 Web UI server running at http://localhost:<port>
+🔒 Security: Server bound to localhost only (127.0.0.1)
+[startup] component=web-ui outcome=success url=<url> port=<port> ...
+```
+
+The `outcome=starting` line guarantees a visible breadcrumb even if the `outcome=success` line never fires.
+
+#### 🐛 #159 — Web UI Express SPA catch-all
+
+The Web UI's client-side router handles routes like `/accounts`, `/dns-firewall`, `/categories`, `/claudeSetup`, `/spamCheck`, `/profile`, `/rules`. Without an Express catch-all, `curl http://localhost:4500/accounts` returns 404 (and `<browser refresh on a sub-page>` shows the same 404). Now: an Express middleware at the end of `setupRoutes()` falls through to `index.html` for any GET that:
+
+- is not under `/api/*` (those still 404 cleanly)
+- does not match a known static-asset extension (`.js .css .json .map .png .jpg .jpeg .gif .svg .ico .webp .woff(2) .ttf .eot .otf` — those 404 honestly so missing-asset bugs surface)
+
+Verified with a smoke-test loop:
+
+```
+/                  HTTP 200 | 40080 bytes
+/accounts          HTTP 200 | 40080 bytes
+/dns-firewall      HTTP 200 | 40080 bytes
+/categories        HTTP 200 | 40080 bytes
+/claudeSetup       HTTP 200 | 40080 bytes
+/nonexistent       HTTP 200 | 40080 bytes  ← intentional; SPA renders 404 client-side
+/api/nope          HTTP 404                 ← API namespace excluded
+/missing.js        HTTP 404                 ← asset miss surfaces honestly
+/index.html        HTTP 200                 ← static handler still wins
+```
+
+`publicPath` was promoted from a `setupMiddleware()` local to a `WebUIServer` instance field so the catch-all in `setupRoutes()` can reference it.
+
+#### 📝 #160 — env-resolver precedence now documented
+
+`src/utils/env-resolver.ts` got an expanded header comment that explicitly states the precedence:
+
+1. process.env (after this module's cleanup pass — placeholders cleared, `${HOME}` expanded) is authoritative
+2. Saved per-extension settings JSON is the fallback for `IMAP_MCP_ALLOWED_ATTACHMENT_DIRS` only
+3. Server-side code defaults apply when neither yields a value
+
+Plus an explicit note about the known edge case: `if (!process.env.X)` treats both undefined and empty string as missing, so a future Claude Desktop release that ships an explicit empty value would still trigger the settings-JSON fallback. Acceptable for the v2.17.x cohort; worth distinguishing if/when Desktop ships its own substitution fix.
+
+#### Backward compatibility
+
+- All changes are additive on the observability side: existing log consumers continue to see all the v2.17.14 fields. The new `outcome=starting` and `outcome=success` lines are new keys, not replacements.
+- SPA catch-all only fires for routes that currently return 404 — any route handler registered earlier in the chain still wins.
+- env-resolver behavior is unchanged; only the comments grew.
+- No tool surface change. No DB schema change.
+
+#### Tests
+
+- All 87/87 still pass. The SPA catch-all is verified via the smoke-test transcript above; adding a unit test would require booting Express in-process and isn't worth the harness complexity for a 7-line route.
+
+#### Still open from v2.17.14 retrospective
+
+- **#161** Replicate the `usage` workflow-hint pattern on other discovery-style tools (`imap_list_accounts`, `imap_list_users`, `imap_list_providers`, etc.). Enhancement, not behavior.
+- **#162** Test plan tweaks (merge A1+A2, clarify D2 browser-not-curl, add Phase E claude.ai parallel test). Documentation, applies to next test cycle.
+
 ## [2.17.14] - 2026-05-08
 
 ### Patch — two P0 fixes from v2.17.13 test-plan execution (closes #155, #156)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.14",
+  "version": "2.17.15",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,10 +232,16 @@ void timeStage('post-handshake', async () => {
   // Probes ports starting at IMAP_MCP_WEB_UI_PORT (default 4500), incrementing
   // by 100 on EADDRINUSE up to 10 attempts. Best-effort: a failure here logs
   // but never blocks the MCP server from serving tool calls.
+  //
+  // Logging: emit a 'starting' breadcrumb BEFORE the await so a hang during
+  // port probing or listen() still produces a startup log entry (#158). Then
+  // emit a final success/error line after the call resolves.
+  logEvent('[startup]', { component: 'web-ui', outcome: 'starting' });
   try {
     const r = await webUIManager.start({ autoOpen: false });
     logEvent('[startup]', {
       component: 'web-ui',
+      outcome: 'success',
       url: r.url,
       port: r.port,
       alreadyRunning: r.alreadyRunning,

--- a/src/services/web-ui-manager.ts
+++ b/src/services/web-ui-manager.ts
@@ -31,13 +31,28 @@ const PORT_INCREMENT = 100;
 const MAX_PORT_ATTEMPTS = 10;
 const DEFAULT_PORT = 4500;
 
+/** Per-port probe timeout. If neither 'error' nor 'listening' fires inside
+ *  this window, treat the port as unusable and move on. Prevents a stalled
+ *  bind from hanging the entire post-handshake stage and suppressing the
+ *  component=web-ui startup log line (#158). */
+const PROBE_TIMEOUT_MS = 1000;
+
 /** Probe whether `port` can be bound on 127.0.0.1 right now. */
 async function isPortFree(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const tester = net.createServer();
-    tester.once('error', () => resolve(false));
+    let settled = false;
+    const finish = (free: boolean) => {
+      if (settled) return;
+      settled = true;
+      try { tester.close(); } catch { /* ignore */ }
+      resolve(free);
+    };
+    const timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
+    tester.once('error', () => { clearTimeout(timer); finish(false); });
     tester.once('listening', () => {
-      tester.close(() => resolve(true));
+      clearTimeout(timer);
+      tester.close(() => finish(true));
     });
     tester.listen(port, '127.0.0.1');
   });

--- a/src/utils/env-resolver.ts
+++ b/src/utils/env-resolver.ts
@@ -2,7 +2,47 @@
  * env-resolver.ts (#156) — heal env vars that Claude Desktop fails to
  * substitute before launching the extension's child process.
  *
- * Two failure modes observed in v2.17.13 + Claude Desktop 1.5354:
+ * # Precedence (#160)
+ *
+ * The bundle has TWO config sources of truth. They are consulted in this
+ * order; the first non-empty value wins:
+ *
+ *   1. process.env, AFTER this module finishes its cleanup pass:
+ *        - lingering "${user_config.X}" or "${HOME}" placeholders are
+ *          treated as "broken substitution" and CLEARED before any other
+ *          code reads the value
+ *        - "${HOME}" / "${USER}" inside otherwise-valid values are
+ *          expanded in place
+ *      A non-empty value at this point is treated as authoritative —
+ *      i.e., a future Claude Desktop release that ships properly-
+ *      substituted user_config values is always preferred over the
+ *      fallback below.
+ *
+ *   2. The saved per-extension settings JSON
+ *      (~/Library/Application Support/Claude/Claude Extensions Settings/
+ *       *imap-mcp-pro.json on darwin; platform equivalents elsewhere).
+ *      Read directly when env was cleared in step 1. Currently scoped to
+ *      IMAP_MCP_ALLOWED_ATTACHMENT_DIRS only — that's the single field
+ *      Claude Desktop 1.5354 cannot ship correctly via env (array
+ *      values stringify as the literal placeholder).
+ *
+ *   3. Server-side code defaults — applied by the consumer (e.g., the
+ *      attachment validator's empty allow-list rejects every path).
+ *
+ * # Known edge case
+ *
+ * `if (!process.env.X)` treats both undefined AND empty string as
+ * missing. If a future Claude Desktop release fixes substitution and
+ * ships an explicit empty value (user opted out), the fallback in step 2
+ * will fire and may incorrectly repopulate the value from the settings
+ * JSON. This is acceptable today (v2.17.x users are not in that scenario
+ * — the env is broken, not legitimately empty), but worth distinguishing
+ * if/when Desktop ships its own fix. Tracked on #160.
+ *
+ * # Why two failure modes
+ *
+ * Two distinct Claude Desktop substitution gaps observed against
+ * Claude Desktop 1.5354:
  *
  *   1. user_config fields with `type: "directory"` + `multiple: true`
  *      (i.e., array values) ship as the literal string

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -36,6 +36,7 @@ export class WebUIServer {
   private port: number;
   private defaultUserId: string;
   private authLimiter: any; // Rate limiter for auth endpoints
+  private publicPath!: string; // resolved during setupMiddleware; SPA catch-all uses it
 
   /**
    * Construct a WebUIServer.
@@ -143,7 +144,9 @@ export class WebUIServer {
         `Run 'npm run build' (postbuild stages public/ -> dist/public/) or check that the .mcpb extension was built with v2.17.10+.`
       );
     }
-    console.log(`[WebUIServer] serving static assets from ${publicPath}`);
+    this.publicPath = publicPath;
+    // stderr so Claude Desktop captures it; stdout is reserved for JSON-RPC.
+    console.error(`[WebUIServer] serving static assets from ${publicPath}`);
     this.app.use(express.static(publicPath));
   }
 
@@ -1300,6 +1303,24 @@ export class WebUIServer {
         });
       }
     });
+
+    // ---- SPA catch-all (#159) ----
+    // The Web UI is a single-page app: /, /accounts, /dns-firewall, etc.
+    // are all rendered client-side from public/index.html. Without this
+    // catch-all, deep links and browser refresh on a sub-route 404. Match
+    // every GET that:
+    //   - is not under /api/  (those should still 404 cleanly)
+    //   - does not look like a static asset by extension (so missing
+    //     assets fail honestly rather than silently returning HTML)
+    // Falls through to publicPath/index.html for everything else.
+    const ASSET_EXT_RE = /\.(js|css|map|json|png|jpg|jpeg|gif|svg|ico|webp|woff2?|ttf|eot|otf)$/i;
+    this.app.get(/^\/(?!api\/).*/, (req, res, next) => {
+      if (ASSET_EXT_RE.test(req.path)) return next();
+      const indexFile = path.join(this.publicPath, 'index.html');
+      res.sendFile(indexFile, (err) => {
+        if (err) next(err);
+      });
+    });
   }
 
   private getClaudeConfigPath(): string {
@@ -1334,8 +1355,9 @@ export class WebUIServer {
     return new Promise((resolve) => {
       // SECURITY: Explicitly bind to localhost (127.0.0.1) to prevent external access
       const server = this.app.listen(this.port, '127.0.0.1', () => {
-        console.log(`🌐 Web UI server running at http://localhost:${this.port}`);
-        console.log(`🔒 Security: Server bound to localhost only (127.0.0.1)`);
+        // stderr (Claude Desktop captures stderr; stdout is JSON-RPC).
+        console.error(`🌐 Web UI server running at http://localhost:${this.port}`);
+        console.error(`🔒 Security: Server bound to localhost only (127.0.0.1)`);
 
         if (autoOpen) {
           // Open browser after a short delay


### PR DESCRIPTION
## Summary

Three observability + UX fixes from the v2.17.14 retrospective. Closes #158, #159, #160.

- **#158** — `[startup] component=web-ui` log line is now reliably emitted: pre-await `outcome=starting` breadcrumb, 1s timeout on each port-probe so a stalled bind can't hang the whole post-handshake stage, and `WebUIServer`'s banner messages moved from stdout to stderr (stdout is reserved for JSON-RPC).
- **#159** — Express SPA catch-all so `/accounts`, `/dns-firewall`, `/categories`, etc. fall through to `index.html` for client-side routing. `/api/*` and asset-extension routes still 404 honestly.
- **#160** — `env-resolver.ts` now has an explicit header comment documenting the env-vs-settings-JSON precedence, plus the known edge case (empty string vs undefined).

## Test plan

- [x] `npm run build` clean
- [x] `npm test`: 87/87 pass
- [x] Smoke: SPA catch-all verified via curl loop — `/accounts`, `/nonexistent`, `/dns-firewall` all return `HTTP 200 | 40080 bytes`; `/api/nope` returns `404`; `/missing.js` returns `404`; `/index.html` returns `200`
- [ ] Manual: install v2.17.15 .mcpb. After restart, log should contain `[startup] component=web-ui outcome=starting` followed by `outcome=success` with `url`, `port`, `triedPorts` fields. Browser refresh on `localhost:4500/accounts` should render the panel (not 404)

## Backward compatibility

- All log additions are new keys (`outcome=starting`, `outcome=success`); existing fields preserved.
- SPA catch-all only fires for routes that currently return 404.
- env-resolver behavior unchanged — only the comments grew.
- No tool surface change. No DB schema change.

## Still deferred

- **#161** — replicate `usage` field pattern on `imap_list_accounts`, `imap_list_users`, etc. (enhancement)
- **#162** — test plan tweaks for next cycle (docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
