### PR TITLE
v2.17.16: replicate usage hint pattern across discovery tools (closes #161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.16] - 2026-05-08
+
+### Patch — replicate the v2.17.13 `usage` hint pattern across discovery tools (closes #161)
+
+`imap_get_outbox_dir` shipped a `usage` field on its response in v2.17.13 — a single short string telling the calling agent the next-step workflow. Worked well enough to be worth replicating on every discovery-style tool, so an LLM driving the server doesn't have to round-trip through the schema or invent a wrong follow-up call.
+
+**Discovery tools now shipping `usage` hints in their response envelope:**
+
+| Tool | Hint covers |
+|---|---|
+| `imap_list_accounts` | `id` is `accountId`; `imap_test_account` for cheap connectivity check; IMAP `user`/`host`/`port` are diagnostic-only |
+| `imap_list_users` | `userId` is canonical; UUID and `username` both accepted by tools that take `userId` (per the v2.17.7 / v2.17.2 resolver); `MCP_USER_ID` resolves the active user |
+| `imap_list_providers` | `id` → `providerId`; `requiresAppPassword: true` means generate one first; `imapUsername` override for Exchange-style |
+| `imap_about` | Recent feature gates by version (outbox v2.17.13+, dispatch fix v2.17.14+, web UI v2.17.10+, attachment-hardening matrix complete v2.17.11+, env-resolver v2.17.14+) |
+| `imap_list_tools` | Tool-name callability + canonical workflow chains (account add → test, outbox → write → send, etc.) |
+| `imap_get_metrics` | `failedOperations > 0` with breaker CLOSED is expected on aggressive-disconnect providers (Hostinger/Yahoo) since v2.16.0 #116; cross-references to circuit-breaker / per-op metrics tools |
+| `imap_get_operation_metrics` | Per-op vs aggregate distinction; cross-references to imap_get_metrics + imap_get_circuit_breaker |
+| `imap_get_circuit_breaker` | CLOSED/OPEN/HALF_OPEN semantics; `imap_reset_circuit_breaker` for manual recovery; non-zero `failedOperations` doesn't trip breaker since v2.16.0 |
+
+The hints are deliberately specific — they reference other tool names by exact MCP name and call out non-obvious gotchas (the breaker-metrics relationship, the per-Exchange-account login form, the placeholder leakage in older versions). Generic platitudes get filtered out at draft time.
+
+`imap_get_circuit_breaker` was also tightened: the no-state branch now returns a structured envelope (`error`, `usage`) instead of a bare error object, so callers can detect "no state yet" without parsing the message.
+
+#### End-to-end verification
+
+```
+imap_about              has usage: YES (608 chars)
+imap_list_accounts      has usage: YES (392 chars)
+imap_list_users         has usage: YES (474 chars)
+imap_list_providers     has usage: YES (549 chars)
+imap_list_tools         has usage: YES (720 chars)
+```
+
+Confirmed via direct stdio MCP probe of the compiled server.
+
+#### Backward compatibility
+
+- Pure additive on response shape: every existing field preserved, only the new top-level `usage` string added.
+- No tool-surface change. No DB schema change. No new env vars.
+- Callers that JSON.parse the response and ignore unknown keys (the default agent posture) just see the new field as extra context. Callers that schema-validate will need to extend their schemas — but no first-party caller does that.
+
+#### Still open from #161
+
+- A lint test that asserts every "discovery" tool returns `usage` is deferred — would require either AST parsing (messy) or a runtime probe across the live tool surface (boots the whole server). The eight tools above cover the obvious surface; future contributors can follow the pattern by reading any of them as a template. If new discovery tools are added without `usage`, the omission shows up at next inspection rather than at CI time. Acceptable trade-off for now.
+
 ## [2.17.15] - 2026-05-08
 
 ### Patch — three observability/UX fixes from the v2.17.14 retrospective (closes #158, #159, #160)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.15",
+  "version": "2.17.16",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -94,6 +94,12 @@ export function accountTools(
             user: acc.username,
             tls: acc.tls,
           })),
+          usage:
+            "Each entry's `id` (UUID) is the value to pass as `accountId` to imap_send_email, " +
+            'imap_search_emails, imap_get_email, imap_test_account, imap_connect, etc. ' +
+            'imap_test_account is the cheapest way to verify connectivity without warming the ' +
+            'connection pool. The IMAP `user`/`host`/`port` fields are diagnostic-only — do not ' +
+            'pass them anywhere; the server resolves them from the stored account row.',
         }, null, 2)
       }]
     };
@@ -205,6 +211,14 @@ export function accountTools(
           success: true,
           count: providers.length,
           providers,
+          usage:
+            "Pass an entry's `id` as `providerId` to imap_add_account_with_provider. If " +
+            '`requiresAppPassword` is true, the user must generate a provider-specific app ' +
+            'password before adding the account (Gmail, iCloud, Yahoo, Outlook with 2FA all ' +
+            'require this). `oauth2Supported` is informational; OAuth2 onboarding flows are not ' +
+            'yet wired into this server. For Exchange-style accounts where the IMAP login is ' +
+            'a non-email form (e.g., DOMAIN\\\\user), pass the `imapUsername` parameter to ' +
+            'imap_add_account_with_provider to override the default (which uses the email).',
         }, null, 2)
       }]
     };

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -1718,6 +1718,13 @@ export function emailTools(
             ...metrics,
             lastOperationTime: metrics.lastOperationTime?.toISOString(),
           },
+          usage:
+            '`failedOperations > 0` with the breaker still CLOSED indicates errors that did not ' +
+            'trip the breaker (commonly idle disconnects from Hostinger / Yahoo / similar — ' +
+            'fixed in v2.16.0 #116 by removing client.error from the breaker trip path). For the ' +
+            'breaker state itself call imap_get_circuit_breaker. To clear counters call ' +
+            'imap_reset_metrics. For per-operation latency / success-rate breakdown call ' +
+            'imap_get_operation_metrics with this same accountId.',
         }, null, 2)
       }]
     };
@@ -1742,6 +1749,11 @@ export function emailTools(
             ...m,
             lastExecuted: m.lastExecuted?.toISOString(),
           })),
+          usage:
+            'Per-operation counters across the lifetime of the connection. Pass `operationName` ' +
+            'on the input to filter to a single operation (e.g., "fetch", "search", "store"). ' +
+            'Compare to imap_get_metrics for per-account aggregate; compare to ' +
+            'imap_get_circuit_breaker for the protection state derived from these counters.',
         }, null, 2)
       }]
     };
@@ -1758,13 +1770,32 @@ export function emailTools(
     }
   }, withErrorHandling(async ({ accountId }) => {
     const state = imapService.getCircuitBreakerState(accountId);
+    if (!state) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            error: `No circuit breaker state for account ${accountId}`,
+            usage:
+              'No state yet — the circuit breaker is created lazily on the first connection. ' +
+              'Call imap_connect first, then re-invoke this tool to inspect state.',
+          }, null, 2)
+        }]
+      };
+    }
     return {
       content: [{
         type: 'text',
-        text: JSON.stringify(
-          state ?? { error: `No circuit breaker state for account ${accountId}` },
-          null, 2
-        )
+        text: JSON.stringify({
+          ...state,
+          usage:
+            'CLOSED = healthy, OPEN = blocked (operations short-circuit until timeoutMs elapses), ' +
+            'HALF_OPEN = trial state allowing one test call. To force a recovery, call ' +
+            'imap_reset_circuit_breaker. To see the underlying counters that drove the trip, ' +
+            'call imap_get_metrics. v2.16.0 (#116) removed idle-disconnect events from the ' +
+            'trip path, so a CLOSED breaker with non-zero failedOperations in metrics is ' +
+            'expected on Hostinger / Yahoo / similar providers.',
+        }, null, 2)
       }]
     };
   }));

--- a/src/tools/meta-tools.ts
+++ b/src/tools/meta-tools.ts
@@ -128,7 +128,16 @@ export function metaTools(server: McpServer, webUIManager?: WebUIManager): void 
           'Michael Nikolaus (original author)'
         ],
         basedOn: 'Original IMAP MCP Server by Michael Nikolaus (MIT License)'
-      }
+      },
+      usage:
+        'Use the `service.version` field to gate feature availability when authoring agents or ' +
+        'skills. Recent feature gates worth checking: imap_get_outbox_dir requires v2.17.13+ ' +
+        '(working call requires v2.17.14+ which fixed the dispatch hang), imap_open_web_ui ' +
+        'requires v2.17.10+, the per-form attachment hardening matrix (allow-list / dotfile / ' +
+        'size / basename) is complete as of v2.17.11, and the env-resolver heal for Claude ' +
+        'Desktop placeholder leakage is v2.17.14+. Use imap_list_tools for a categorized index ' +
+        'of every tool surface; imap_list_users + imap_list_accounts for the data the active ' +
+        'session can act on.'
     };
 
     return {
@@ -427,7 +436,17 @@ export function metaTools(server: McpServer, webUIManager?: WebUIManager): void 
         category: tool.category,
         description: tool.description,
         parameters: tool.parameters
-      }))
+      })),
+      usage:
+        'Each `tool.name` is a valid MCP tool name callable on this server. Pass a `category` ' +
+        'argument to scope the listing (one of: user, account, email, bulk, folder, sending, ' +
+        'metrics, meta). For full per-tool input schemas, the schema lives on the registered ' +
+        'tool itself (visible via the MCP tools/list method); this tool returns a hand-curated ' +
+        'parameter summary only. Common workflow chains: ' +
+        '(a) imap_list_users -> imap_list_accounts -> imap_search_emails / imap_send_email; ' +
+        '(b) imap_list_providers -> imap_add_account_with_provider -> imap_test_account; ' +
+        '(c) imap_get_outbox_dir -> Write file -> imap_send_email(attachmentPaths). For server ' +
+        'self-information call imap_about; for the embedded Web UI URL call imap_open_web_ui.'
     };
 
     return {

--- a/src/tools/user-tools.ts
+++ b/src/tools/user-tools.ts
@@ -69,6 +69,13 @@ export function userTools(
             organization: u.organization,
             createdAt: u.created_at
           })),
+          usage:
+            "Each entry's `userId` (UUID) is the canonical reference. Tools that take a `userId` " +
+            'parameter (e.g., imap_extract_unsubscribe_links, imap_check_email_spam, ' +
+            'imap_get_outbox_dir context) accept either the UUID or the `username` form via the ' +
+            'v2.17.7 / v2.17.2 resolver — pass whichever is more convenient. The MCP server ' +
+            'resolves the active user from the `MCP_USER_ID` env var (set by the user_config in ' +
+            'the .mcpb manifest); imap_about returns the resolved username at runtime.',
         }, null, 2)
       }]
     };


### PR DESCRIPTION
## Summary

Closes [#161](https://github.com/Temple-of-Epiphany/imap-mcp-pro/issues/161). Replicates the `usage` workflow-hint field that v2.17.13's `imap_get_outbox_dir` introduced — extends it to seven other discovery-style tools so an LLM driving the server has next-step guidance inline instead of round-tripping through the schema.

Tools updated (each gets a top-level `usage` string in its response):

- `imap_list_accounts`
- `imap_list_users`
- `imap_list_providers`
- `imap_about`
- `imap_list_tools`
- `imap_get_metrics`
- `imap_get_operation_metrics`
- `imap_get_circuit_breaker` (also tightened the no-state branch to return a structured envelope)

Hints reference other tool names by exact MCP name and call out non-obvious gotchas — the breaker/metrics relationship, the Exchange-style login form, placeholder leakage in older versions, etc. Generic platitudes were filtered out at draft time.

## Test plan

- [x] `npm run build` clean
- [x] `npm test`: 87/87 pass (no test changes — purely additive response shape)
- [x] End-to-end stdio probe of the compiled server confirms all five core discovery tools ship `usage` (sized 392–720 chars each)
- [ ] Manual: install v2.17.16 .mcpb, call `imap_about` from Claude Desktop and verify the response includes a `usage` field with a substantive next-step hint

## Backward compatibility

- Pure additive — every existing response field preserved; only the new top-level `usage` string added
- No tool surface change. No DB schema change. No new env vars
- `imap_get_circuit_breaker` no-state branch went from `{ error: "..." }` to `{ error: "...", usage: "..." }` — same shape, additional field

## Deferred

The lint test from #161's body (asserting every discovery tool ships `usage`) is deferred — would require either AST parsing or runtime probing across the live tool surface. Following the pattern by reading any of the eight implementations is good enough for now; future contributors who skip the field will be visible at next inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
