### PR TITLE
fix(web): add missing /api/usercheck/check-email route

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -682,6 +682,43 @@ export class WebUIServer {
       }
     });
 
+    // Check email with UserCheck (backs the "Test" button in the SPAM Check view)
+    this.app.post('/api/usercheck/check-email', async (req, res) => {
+      try {
+        const { email, checkDisposable, checkBlocklisted, checkMx, checkRoleAccount, allowPublicDomains } = req.body;
+
+        if (!email) {
+          return res.status(400).json({
+            success: false,
+            error: 'Email is required'
+          });
+        }
+
+        const userCheckService = new UserCheckService(this.db);
+        const result = await userCheckService.checkEmail(
+          this.defaultUserId,
+          email,
+          {
+            checkDisposable: checkDisposable !== false,
+            checkBlocklisted: checkBlocklisted !== false,
+            checkMx: checkMx !== false,
+            checkRoleAccount: checkRoleAccount !== false,
+            allowPublicDomains: allowPublicDomains !== false
+          }
+        );
+
+        res.json({
+          success: true,
+          result
+        });
+      } catch (error) {
+        res.status(500).json({
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to check email'
+        });
+      }
+    });
+
     // Check domain with UserCheck
     this.app.post('/api/usercheck/check-domain', async (req, res) => {
       try {


### PR DESCRIPTION
## Summary

Fixes the UserCheck API key **Test** feature, which failed for every key with `✗ Test Failed — Unexpected token '<', ...`.

### Root cause
The Test button in the SPAM Check view calls `POST /api/usercheck/check-email` (`public/js/app.js:745`), but the web server only implemented `/api/usercheck/check-domain` (`src/web/server.ts`). Hitting the undefined route returns Express's default **HTML** 404 page, so the frontend's `await response.json()` chokes on the leading `<` — making valid API keys appear to fail.

The keys themselves were fine (one showed `Daily Usage: 1/1000` with a successful last-use timestamp).

### Fix
Add the missing `POST /api/usercheck/check-email` route, mirroring the existing `check-domain` handler: validate `email`, call `UserCheckService.checkEmail()`, and return proper JSON.

## Testing
- `npm run build` passes (tsc + postbuild).
- After restart, the Test button reaches `https://api.usercheck.com/email/test@tempmail.com` and returns a real result (`Disposable: Yes`).

## Follow-up (not in this PR)
The test resolves the key via `defaultUserId` → `getApiKey()`, not the specific `keyId` of the clicked row. With multiple keys configured, "Test" exercises whichever key `getApiKey` selects, not necessarily that exact row. Per-key testing would be a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
