### PR TITLE
chore(legal): license labeling fix + NOTICE + CLA

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,83 @@
+# Contributor License Agreement (CLA)
+
+**Project:** IMAP MCP Pro
+**Maintainer / Licensor:** Temple of Epiphany (Colin Bitterfield)
+**Version:** 1.0 — June 2026
+
+Thank you for your interest in contributing to IMAP MCP Pro (the "Project").
+
+This Contributor License Agreement ("Agreement") clarifies the intellectual
+property rights granted with Contributions from any person or entity. It
+protects both you (the "Contributor") and the maintainer, and — importantly —
+it preserves the maintainer's ability to offer the Project under a **dual
+license** (non-commercial free / commercial paid), as described in `LICENSE`.
+
+By submitting a Contribution (a pull request, patch, or any code,
+documentation, or other material) to the Project, you agree to the following
+terms for your present and future Contributions.
+
+## 1. Definitions
+
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to existing work, that you intentionally submit
+  to the Project.
+- **"Submit"** means any form of electronic or written communication sent to
+  the maintainer or the Project (e.g., a pull request, issue attachment, or
+  email), excluding communication conspicuously marked "Not a Contribution."
+
+## 2. Copyright License and Right to Relicense
+
+You hereby grant to Temple of Epiphany a **perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable** copyright license to reproduce,
+prepare derivative works of, publicly display, publicly perform, sublicense,
+and distribute your Contributions and such derivative works.
+
+You expressly agree that Temple of Epiphany **may license your Contributions,
+and any derivative works, under any license terms it chooses, including
+proprietary and commercial licenses**, and may include your Contributions in
+commercially licensed distributions of the Project. You retain your own
+copyright in your Contributions and remain free to use them for any purpose.
+
+## 3. Patent License
+
+You grant Temple of Epiphany and recipients of the software a perpetual,
+worldwide, non-exclusive, royalty-free, irrevocable patent license to make,
+use, sell, offer to sell, import, and otherwise transfer your Contributions,
+where such license applies only to those patent claims you can license that
+are necessarily infringed by your Contribution alone or by combination of your
+Contribution with the Project.
+
+## 4. Your Representations
+
+You represent that:
+
+1. Each Contribution is your original creation, or you have sufficient rights
+   to submit it under this Agreement.
+2. Your Contributions do not, to your knowledge, violate any third party's
+   copyrights, patents, trademarks, trade secrets, or other rights.
+3. If your employer has rights to intellectual property you create, you have
+   either received permission to make the Contributions on behalf of that
+   employer, or your employer has waived such rights for the Contributions.
+4. You are legally entitled to grant the above licenses.
+
+## 5. Disclaimer
+
+Unless required by applicable law or agreed to in writing, you provide your
+Contributions on an "AS IS" basis, without warranties or conditions of any
+kind, either express or implied.
+
+## 6. How to Sign
+
+Sign by one of the following before your Contribution can be merged:
+
+- **Pull request:** Add a line to your PR description:
+  `I have read and agree to the CLA.md, signed: <Full Name> <email>`, **or**
+- **Per-commit (DCO-style):** Include a trailer in each commit:
+  `CLA-Signed-by: Full Name <email>`
+
+Submitting a Contribution after the maintainer has adopted this Agreement
+constitutes acceptance of these terms.
+
+---
+
+Questions: colin.bitterfield@templeofepiphany.com

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
 # IMAP MCP Pro License
 
+SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+
 ## Dual License Model
 
 This software is available under a dual-license model:
@@ -10,7 +12,7 @@ This software is available under a dual-license model:
 
 ## Non-Commercial License
 
-Copyright (c) 2025 Temple of Epiphany / Colin Bitterfield
+Copyright (c) 2025-2026 Temple of Epiphany / Colin Bitterfield
 Copyright (c) 2024 Michael Nikolaus (Original Base Code)
 
 ### Terms
@@ -118,5 +120,5 @@ If you are unsure whether your use case requires a commercial license, please co
 
 ---
 
-**Last Updated:** January 2025
-**Version:** 1.0
+**Last Updated:** June 2026
+**Version:** 1.1

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,37 @@
+IMAP MCP Pro
+SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+
+Copyright (c) 2025-2026 Temple of Epiphany / Colin Bitterfield.
+All rights reserved.
+
+This product is distributed under a dual license (non-commercial free /
+commercial paid). See the accompanying LICENSE file for the full terms.
+Commercial licensing: colin.bitterfield@templeofepiphany.com
+
+--------------------------------------------------------------------------------
+Third-party / upstream attribution
+--------------------------------------------------------------------------------
+
+This project is a fork and substantial extension of the original IMAP MCP
+Server created by Michael Nikolaus, which was licensed under the MIT License.
+
+    Original Project: https://github.com/nikolausm/imap-mcp-server
+    Original Author:  Michael Nikolaus (https://github.com/nikolausm)
+    Original License: MIT License (applies to the unmodified base code only)
+
+    Copyright (c) 2024 Michael Nikolaus
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the inclusion of the above
+    copyright notice and this permission notice in all copies or substantial
+    portions of the Software.
+
+All enterprise enhancements, modifications, and additions created by
+Temple of Epiphany are governed by the dual license described in LICENSE,
+not by the MIT terms above.
+
+Dependencies retain their own licenses; see node_modules/<pkg>/LICENSE for each.

--- a/dxt/build.mjs
+++ b/dxt/build.mjs
@@ -89,6 +89,16 @@ cpr(path.join(repoRoot, 'node_modules'), path.join(serverDir, 'node_modules'));
 cpr(path.join(repoRoot, 'package.json'), path.join(serverDir, 'package.json'));
 cpr(path.join(repoRoot, 'package-lock.json'), path.join(serverDir, 'package-lock.json'));
 
+// Ship the license + copyright notice with the bundle. The manifest declares
+// LicenseRef-ImapMcpPro-Dual; these files carry the actual terms and copyright.
+for (const legal of ['LICENSE', 'NOTICE']) {
+  const srcLegal = path.join(repoRoot, legal);
+  if (fs.existsSync(srcLegal)) {
+    cpr(srcLegal, path.join(buildDir, legal));
+    cpr(srcLegal, path.join(serverDir, legal));
+  }
+}
+
 // Trim node_modules: drop devDependencies-only packages and obvious bloat
 function pruneNodeModules() {
   const nm = path.join(serverDir, 'node_modules');

--- a/dxt/manifest.template.json
+++ b/dxt/manifest.template.json
@@ -20,7 +20,7 @@
   "icon": "icon.png",
   "screenshots": [],
   "keywords": ["email", "imap", "smtp", "mailbox", "mcp", "spam", "outlook", "gmail"],
-  "license": "MIT",
+  "license": "LicenseRef-ImapMcpPro-Dual",
   "compatibility": {
     "claude_desktop": ">=0.10.0",
     "platforms": ["darwin", "win32", "linux"]


### PR DESCRIPTION
## Summary

License/copyright hardening for distribution. No code behavior changes.

- **Fixes the `.mcpb` license bug:** `dxt/manifest.template.json` declared `"MIT"` — corrected to `"LicenseRef-ImapMcpPro-Dual"` (the valid SPDX form for a custom license, matching the actual dual non-commercial/commercial `LICENSE`).
- **Bundle now ships the license text:** previously `build.mjs` staged only `dist/` + `node_modules/` + package files, so the `.mcpb` carried **no license at all**. It now copies `LICENSE` + `NOTICE` into the bundle root and `server/`.
- **`LICENSE`:** added an `SPDX-License-Identifier` header, extended copyright to `2025-2026`, bumped to v1.1 (June 2026). Terms unchanged.
- **`NOTICE` (new):** canonical copyright assertion + the required upstream MIT attribution.
- **`CLA.md` (new):** Contributor License Agreement; its relicensing clause preserves the ability to sell commercial licenses on contributed code.

## Validation

- `dxt/manifest.template.json` parses; `license = LicenseRef-ImapMcpPro-Dual`
- `node --check dxt/build.mjs` passes

## Follow-ups (separate)

- Wire CLA enforcement into PRs (cla-assistant or PR-template checkbox)
- `server.json` for MCP Registry via GitHub release (no npm)
- #166: remove remaining upstream code, then switch attribution to "inspired by"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
