### PR TITLE
refactor(folder-tools): clean-room rewrite + route tests (#166)

### DIFF
--- a/src/tools/folder-tools.test.ts
+++ b/src/tools/folder-tools.test.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+//
+// Route tests for the folder/mailbox MCP tools.
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+//
+// Registers folderTools against a mock McpServer + mock ImapService and
+// asserts every tool is registered and returns the expected JSON payload.
+// Locks the output contract so the clean-room refactors (#166) cannot drift.
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { folderTools } from './folder-tools.js';
+
+interface Registered {
+  spec: any;
+  handler: (args: any) => Promise<any>;
+}
+
+/** Minimal McpServer stand-in that records registered tools. */
+function makeServer() {
+  const tools = new Map<string, Registered>();
+  const server = {
+    registerTool(name: string, spec: any, handler: any) {
+      tools.set(name, { spec, handler });
+    },
+  };
+  return { server, tools };
+}
+
+/** Invoke a registered tool and parse its JSON text payload. */
+async function invoke(tools: Map<string, Registered>, name: string, args: any) {
+  const entry = tools.get(name);
+  if (!entry) throw new Error(`tool not registered: ${name}`);
+  const result = await entry.handler(args);
+  return JSON.parse(result.content[0].text);
+}
+
+function makeImapMock(overrides: Record<string, any> = {}) {
+  return {
+    listFolders: async () => [
+      { name: 'INBOX', delimiter: '/', attributes: ['\\HasNoChildren'], children: [] },
+      { name: 'Archive', delimiter: '/', attributes: ['\\HasChildren'], children: [{ name: 'Archive/2024' }] },
+    ],
+    selectFolder: async () => ({
+      messages: { total: 10, new: 2, unseen: 3 },
+      uidvalidity: 5, uidnext: 11, flags: ['\\Seen'], permanentFlags: ['\\Seen'],
+    }),
+    searchEmails: async (_a: string, name: string) => {
+      if (name === 'BadFolder') throw new Error('\\Noselect');
+      return [{}, {}];
+    },
+    createFolder: async () => {},
+    deleteFolder: async () => {},
+    renameFolder: async () => {},
+    subscribeMailbox: async () => {},
+    unsubscribeMailbox: async () => {},
+    listSubscribedMailboxes: async () => [
+      { name: 'INBOX', delimiter: '/', attributes: [], children: [] },
+    ],
+    getMultipleMailboxStatus: async () => [
+      { mailbox: 'INBOX', messages: 10, unseen: 3, uidNext: 11, uidValidity: 5n, deleted: 0, size: 2 * 1024 * 1024 },
+    ],
+    ...overrides,
+  };
+}
+
+describe('folderTools registration', () => {
+  it('registers all folder/mailbox routes', () => {
+    const { server, tools } = makeServer();
+    folderTools(server as any, makeImapMock() as any, {} as any);
+    expect([...tools.keys()].sort()).toEqual([
+      'imap_create_folder',
+      'imap_delete_folder',
+      'imap_folder_status',
+      'imap_get_mailbox_status',
+      'imap_get_unread_count',
+      'imap_list_folders',
+      'imap_list_subscribed_mailboxes',
+      'imap_rename_folder',
+      'imap_subscribe_mailbox',
+      'imap_unsubscribe_mailbox',
+    ]);
+  });
+});
+
+describe('folderTools route outputs', () => {
+  let tools: Map<string, Registered>;
+  beforeEach(() => {
+    const made = makeServer();
+    tools = made.tools;
+    folderTools(made.server as any, makeImapMock() as any, {} as any);
+  });
+
+  it('imap_list_folders summarizes folders with hasChildren', async () => {
+    const out = await invoke(tools, 'imap_list_folders', { accountId: 'a' });
+    expect(out).toEqual({
+      folders: [
+        { name: 'INBOX', delimiter: '/', attributes: ['\\HasNoChildren'], hasChildren: false },
+        { name: 'Archive', delimiter: '/', attributes: ['\\HasChildren'], hasChildren: true },
+      ],
+    });
+  });
+
+  it('imap_folder_status returns message + uid metadata', async () => {
+    const out = await invoke(tools, 'imap_folder_status', { accountId: 'a', folder: 'INBOX' });
+    expect(out).toEqual({
+      folder: 'INBOX',
+      messages: { total: 10, new: 2, unseen: 3 },
+      uidvalidity: 5, uidnext: 11, flags: ['\\Seen'], permanentFlags: ['\\Seen'],
+    });
+  });
+
+  it('imap_get_unread_count counts per folder and skips unreadable folders as 0', async () => {
+    const out = await invoke(tools, 'imap_get_unread_count', { accountId: 'a', folders: ['INBOX', 'BadFolder'] });
+    expect(out).toEqual({ totalUnread: 2, byFolder: { INBOX: 2, BadFolder: 0 } });
+  });
+
+  it('imap_get_unread_count defaults to all folders when none given', async () => {
+    const out = await invoke(tools, 'imap_get_unread_count', { accountId: 'a' });
+    expect(out.byFolder).toHaveProperty('INBOX');
+    expect(out.byFolder).toHaveProperty('Archive');
+  });
+
+  it('imap_create_folder / delete / rename return success confirmations', async () => {
+    expect(await invoke(tools, 'imap_create_folder', { accountId: 'a', folderName: 'X' }))
+      .toEqual({ success: true, message: 'Folder "X" created successfully' });
+    expect(await invoke(tools, 'imap_delete_folder', { accountId: 'a', folderName: 'X' }))
+      .toEqual({ success: true, message: 'Folder "X" deleted successfully' });
+    expect(await invoke(tools, 'imap_rename_folder', { accountId: 'a', oldName: 'X', newName: 'Y' }))
+      .toEqual({ success: true, message: 'Folder renamed from "X" to "Y" successfully' });
+  });
+
+  it('imap_subscribe / unsubscribe return success confirmations', async () => {
+    expect(await invoke(tools, 'imap_subscribe_mailbox', { accountId: 'a', mailboxName: 'M' }))
+      .toEqual({ success: true, message: 'Subscribed to mailbox "M" successfully' });
+    expect(await invoke(tools, 'imap_unsubscribe_mailbox', { accountId: 'a', mailboxName: 'M' }))
+      .toEqual({ success: true, message: 'Unsubscribed from mailbox "M" successfully' });
+  });
+
+  it('imap_list_subscribed_mailboxes returns summaries + count', async () => {
+    const out = await invoke(tools, 'imap_list_subscribed_mailboxes', { accountId: 'a' });
+    expect(out).toEqual({
+      subscribedMailboxes: [{ name: 'INBOX', delimiter: '/', attributes: [], hasChildren: false }],
+      count: 1,
+    });
+  });
+
+  it('imap_get_mailbox_status aggregates summary and formats sizes', async () => {
+    const out = await invoke(tools, 'imap_get_mailbox_status', { accountId: 'a', mailboxName: 'INBOX' });
+    expect(out.summary).toEqual({ totalMailboxes: 1, totalMessages: 10, totalUnseen: 3, totalSize: '2.00 MB' });
+    expect(out.mailboxes[0]).toEqual({
+      mailbox: 'INBOX', messages: 10, unseen: 3, uidNext: 11, uidValidity: '5', deleted: 0, size: '2.00 MB',
+    });
+  });
+
+  it('imap_get_mailbox_status accepts a single name or an array', async () => {
+    const single = await invoke(tools, 'imap_get_mailbox_status', { accountId: 'a', mailboxName: 'INBOX' });
+    const array = await invoke(tools, 'imap_get_mailbox_status', { accountId: 'a', mailboxName: ['INBOX'] });
+    expect(single).toEqual(array);
+  });
+});

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -1,274 +1,211 @@
+// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+//
+// Folder / mailbox MCP tools.
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+// Part of: IMAP MCP Pro (Temple of Epiphany)
+//
+// Registers the folder-oriented tools: listing, status, unread counts,
+// create/delete/rename, and the RFC 9051 subscription + STATUS commands.
+
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 import { ImapService } from '../services/imap-service.js';
 import { DatabaseService } from '../services/database-service.js';
-import { z } from 'zod';
+import { Folder } from '../types/index.js';
 import { withErrorHandling } from '../utils/error-handler.js';
+
+/** Wrap any payload as a pretty-printed JSON text tool result. */
+function jsonResult(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }] };
+}
+
+/** Shorthand for the `{ success, message }` confirmation result. */
+function confirm(message: string) {
+  return jsonResult({ success: true, message });
+}
+
+/** Flatten a Folder into the summary shape returned by the listing tools. */
+function summarizeFolder(folder: Folder) {
+  return {
+    name: folder.name,
+    delimiter: folder.delimiter,
+    attributes: folder.attributes,
+    hasChildren: Array.isArray(folder.children) && folder.children.length > 0,
+  };
+}
+
+/** Format a byte count as "N.NN MB". */
+function megabytes(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+const accountId = z.string().describe('Account ID');
 
 export function folderTools(
   server: McpServer,
   imapService: ImapService,
   db: DatabaseService
 ): void {
-  // List folders tool
   server.registerTool('imap_list_folders', {
     description: 'List all folders/mailboxes in an IMAP account',
-    inputSchema: {
-      accountId: z.string().describe('Account ID'),
-    }
+    inputSchema: { accountId },
   }, withErrorHandling(async ({ accountId }) => {
     const folders = await imapService.listFolders(accountId);
-    
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          folders: folders.map(folder => ({
-            name: folder.name,
-            delimiter: folder.delimiter,
-            attributes: folder.attributes,
-            hasChildren: !!folder.children && folder.children.length > 0,
-          })),
-        }, null, 2)
-      }]
-    };
+    return jsonResult({ folders: folders.map(summarizeFolder) });
   }));
 
-  // Get folder status tool
   server.registerTool('imap_folder_status', {
     description: 'Get status information about a folder',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      accountId,
       folder: z.string().describe('Folder name'),
-    }
+    },
   }, withErrorHandling(async ({ accountId, folder }) => {
     const box = await imapService.selectFolder(accountId, folder);
-    
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          folder: folder,
-          messages: {
-            total: box.messages.total,
-            new: box.messages.new,
-            unseen: box.messages.unseen || 0,
-          },
-          uidvalidity: box.uidvalidity,
-          uidnext: box.uidnext,
-          flags: box.flags,
-          permanentFlags: box.permanentFlags,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      folder,
+      messages: {
+        total: box.messages.total,
+        new: box.messages.new,
+        unseen: box.messages.unseen || 0,
+      },
+      uidvalidity: box.uidvalidity,
+      uidnext: box.uidnext,
+      flags: box.flags,
+      permanentFlags: box.permanentFlags,
+    });
   }));
 
-  // Get unread count tool
   server.registerTool('imap_get_unread_count', {
     description: 'Get the count of unread emails in specified folders',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      accountId,
       folders: z.array(z.string()).optional().describe('List of folders to check (default: all)'),
-    }
+    },
   }, withErrorHandling(async ({ accountId, folders }) => {
-    const allFolders = await imapService.listFolders(accountId);
-    const foldersToCheck = folders || allFolders.map(f => f.name);
-    
-    const unreadCounts: Record<string, number> = {};
+    const targets = folders ?? (await imapService.listFolders(accountId)).map((f) => f.name);
+
+    const byFolder: Record<string, number> = {};
     let totalUnread = 0;
-    
-    for (const folderName of foldersToCheck) {
+
+    for (const name of targets) {
+      let count = 0;
       try {
-        const unreadMessages = await imapService.searchEmails(accountId, folderName, { seen: false });
-        const count = unreadMessages.length;
-        unreadCounts[folderName] = count;
-        totalUnread += count;
-      } catch (error) {
-        // Skip folders that can't be accessed
-        unreadCounts[folderName] = 0;
+        const unread = await imapService.searchEmails(accountId, name, { seen: false });
+        count = unread.length;
+      } catch {
+        // Folder unreadable (e.g. \Noselect) — report zero rather than failing.
+        count = 0;
       }
+      byFolder[name] = count;
+      totalUnread += count;
     }
-    
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          totalUnread,
-          byFolder: unreadCounts,
-        }, null, 2)
-      }]
-    };
+
+    return jsonResult({ totalUnread, byFolder });
   }));
 
-  // Create folder tool
   server.registerTool('imap_create_folder', {
     description: 'Create a new folder/mailbox in an IMAP account',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      accountId,
       folderName: z.string().describe('Name of the folder to create (use "/" for hierarchy, e.g., "Archive/2024")'),
-    }
+    },
   }, withErrorHandling(async ({ accountId, folderName }) => {
     await imapService.createFolder(accountId, folderName);
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Folder "${folderName}" created successfully`,
-        }, null, 2)
-      }]
-    };
+    return confirm(`Folder "${folderName}" created successfully`);
   }));
 
-  // Delete folder tool
   server.registerTool('imap_delete_folder', {
     description: 'Delete a folder/mailbox from an IMAP account',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      accountId,
       folderName: z.string().describe('Name of the folder to delete'),
-    }
+    },
   }, withErrorHandling(async ({ accountId, folderName }) => {
     await imapService.deleteFolder(accountId, folderName);
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Folder "${folderName}" deleted successfully`,
-        }, null, 2)
-      }]
-    };
+    return confirm(`Folder "${folderName}" deleted successfully`);
   }));
 
-  // Rename folder tool
   server.registerTool('imap_rename_folder', {
     description: 'Rename a folder/mailbox in an IMAP account',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      accountId,
       oldName: z.string().describe('Current name of the folder'),
       newName: z.string().describe('New name for the folder'),
-    }
+    },
   }, withErrorHandling(async ({ accountId, oldName, newName }) => {
     await imapService.renameFolder(accountId, oldName, newName);
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Folder renamed from "${oldName}" to "${newName}" successfully`,
-        }, null, 2)
-      }]
-    };
+    return confirm(`Folder renamed from "${oldName}" to "${newName}" successfully`);
   }));
 
   // RFC 9051: Subscribe to mailbox (Issue #53)
   server.registerTool('imap_subscribe_mailbox', {
     description: 'Subscribe to a mailbox (RFC 9051 SUBSCRIBE command)',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      accountId,
       mailboxName: z.string().describe('Name of the mailbox to subscribe to'),
-    }
+    },
   }, withErrorHandling(async ({ accountId, mailboxName }) => {
     await imapService.subscribeMailbox(accountId, mailboxName);
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Subscribed to mailbox "${mailboxName}" successfully`,
-        }, null, 2)
-      }]
-    };
+    return confirm(`Subscribed to mailbox "${mailboxName}" successfully`);
   }));
 
   // RFC 9051: Unsubscribe from mailbox (Issue #53)
   server.registerTool('imap_unsubscribe_mailbox', {
     description: 'Unsubscribe from a mailbox (RFC 9051 UNSUBSCRIBE command)',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      accountId,
       mailboxName: z.string().describe('Name of the mailbox to unsubscribe from'),
-    }
+    },
   }, withErrorHandling(async ({ accountId, mailboxName }) => {
     await imapService.unsubscribeMailbox(accountId, mailboxName);
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Unsubscribed from mailbox "${mailboxName}" successfully`,
-        }, null, 2)
-      }]
-    };
+    return confirm(`Unsubscribed from mailbox "${mailboxName}" successfully`);
   }));
 
   // RFC 9051: List subscribed mailboxes (Issue #53)
   server.registerTool('imap_list_subscribed_mailboxes', {
     description: 'List all subscribed mailboxes (RFC 9051 LSUB/LIST with SUBSCRIBED)',
-    inputSchema: {
-      accountId: z.string().describe('Account ID'),
-    }
+    inputSchema: { accountId },
   }, withErrorHandling(async ({ accountId }) => {
-    const subscribedFolders = await imapService.listSubscribedMailboxes(accountId);
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          subscribedMailboxes: subscribedFolders.map(folder => ({
-            name: folder.name,
-            delimiter: folder.delimiter,
-            attributes: folder.attributes,
-            hasChildren: !!folder.children && folder.children.length > 0,
-          })),
-          count: subscribedFolders.length,
-        }, null, 2)
-      }]
-    };
+    const subscribed = await imapService.listSubscribedMailboxes(accountId);
+    return jsonResult({
+      subscribedMailboxes: subscribed.map(summarizeFolder),
+      count: subscribed.length,
+    });
   }));
 
   // RFC 9051: Get mailbox status (Issue #56)
   server.registerTool('imap_get_mailbox_status', {
     description: 'Get mailbox statistics without selecting it (RFC 9051 STATUS command) - more efficient than SELECT',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      accountId,
       mailboxName: z.union([z.string(), z.array(z.string())]).describe('Mailbox name or array of mailbox names'),
-    }
+    },
   }, withErrorHandling(async ({ accountId, mailboxName }) => {
-    // Support both single mailbox and multiple mailboxes
     const mailboxes = Array.isArray(mailboxName) ? mailboxName : [mailboxName];
-
     const statuses = await imapService.getMultipleMailboxStatus(accountId, mailboxes);
 
-    // Build human-readable summary
     const totalMessages = statuses.reduce((sum, s) => sum + s.messages, 0);
     const totalUnseen = statuses.reduce((sum, s) => sum + s.unseen, 0);
     const totalSize = statuses.reduce((sum, s) => sum + (s.size || 0), 0);
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          summary: {
-            totalMailboxes: statuses.length,
-            totalMessages,
-            totalUnseen,
-            totalSize: totalSize > 0 ? `${(totalSize / 1024 / 1024).toFixed(2)} MB` : 'N/A',
-          },
-          mailboxes: statuses.map(status => ({
-            mailbox: status.mailbox,
-            messages: status.messages,
-            unseen: status.unseen,
-            uidNext: status.uidNext,
-            uidValidity: status.uidValidity.toString(),
-            deleted: status.deleted,
-            size: status.size ? `${(status.size / 1024 / 1024).toFixed(2)} MB` : undefined,
-          })),
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      summary: {
+        totalMailboxes: statuses.length,
+        totalMessages,
+        totalUnseen,
+        totalSize: totalSize > 0 ? megabytes(totalSize) : 'N/A',
+      },
+      mailboxes: statuses.map((status) => ({
+        mailbox: status.mailbox,
+        messages: status.messages,
+        unseen: status.unseen,
+        uidNext: status.uidNext,
+        uidValidity: status.uidValidity.toString(),
+        deleted: status.deleted,
+        size: status.size ? megabytes(status.size) : undefined,
+      })),
+    });
   }));
 }


### PR DESCRIPTION
Part of #166. Clean-room DRY refactor of the folder/mailbox tools (original list/status/unread were upstream code), preserving every tool name, schema, and output payload exactly. Adds `folder-tools.test.ts` covering all 10 routes against mocks (registration + output contract, incl. unread skip-on-error and single/array status). Build + 97 tests green.

Refs #166