### PR TITLE
refactor(account-tools + smtp-service): clean-room logic + route tests (#166)

### DIFF
--- a/src/services/smtp-service.test.ts
+++ b/src/services/smtp-service.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+//
+// Tests for SmtpService transport assembly + lifecycle.
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+//
+// nodemailer is mocked so we can assert the transport config SmtpService
+// derives (default-config heuristic, auth fallback), transporter caching,
+// and disconnect behavior without opening a real SMTP socket.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const created: any[] = [];
+const closed: string[] = [];
+
+vi.mock('nodemailer', () => {
+  return {
+    default: {
+      createTransport: (cfg: any) => {
+        const transporter = {
+          cfg,
+          verify: async () => true,
+          close: () => closed.push(cfg.host),
+          sendMail: async () => ({ messageId: '<id@test>' }),
+        };
+        created.push(transporter);
+        return transporter;
+      },
+    },
+  };
+});
+
+import { SmtpService } from './smtp-service.js';
+
+function account(overrides: Record<string, any> = {}) {
+  return {
+    id: 'acc-1', name: 'A', host: 'imap.example.com', port: 993,
+    user: 'me@example.com', password: 'secret', tls: true,
+    ...overrides,
+  } as any;
+}
+
+describe('SmtpService.createTransporter', () => {
+  beforeEach(() => { created.length = 0; closed.length = 0; });
+
+  it('maps a known IMAP host to its documented submission server', async () => {
+    const svc = new SmtpService({ pool: { healthCheck: false } });
+    await svc.createTransporter(account({ host: 'imap.gmail.com' }));
+    expect(created[0].cfg).toMatchObject({ host: 'smtp.gmail.com', port: 587, secure: false });
+  });
+
+  it('derives an SMTP host from the IMAP host for unknown providers', async () => {
+    const svc = new SmtpService({ pool: { healthCheck: false } });
+    await svc.createTransporter(account({ host: 'imap.example.com', tls: true, port: 993 }));
+    expect(created[0].cfg).toMatchObject({ host: 'smtp.example.com', port: 465, secure: true });
+  });
+
+  it('falls back to IMAP credentials when SMTP auth is unset', async () => {
+    const svc = new SmtpService({ pool: { healthCheck: false } });
+    await svc.createTransporter(account());
+    expect(created[0].cfg.auth).toEqual({ user: 'me@example.com', pass: 'secret' });
+  });
+
+  it('honors explicit account.smtp settings over the default heuristic', async () => {
+    const svc = new SmtpService({ pool: { healthCheck: false } });
+    await svc.createTransporter(account({ smtp: { host: 'smtp.custom.tld', port: 2525, secure: false, user: 'u', password: 'p' } }));
+    expect(created[0].cfg).toMatchObject({ host: 'smtp.custom.tld', port: 2525 });
+    expect(created[0].cfg.auth).toEqual({ user: 'u', pass: 'p' });
+  });
+
+  it('caches one transporter per account', async () => {
+    const svc = new SmtpService({ pool: { healthCheck: false } });
+    const a = await svc.createTransporter(account());
+    const b = await svc.createTransporter(account());
+    expect(a).toBe(b);
+    expect(created.length).toBe(1);
+    expect(svc.getPoolStats()).toEqual({ configured: 1 });
+  });
+});
+
+describe('SmtpService lifecycle', () => {
+  beforeEach(() => { created.length = 0; closed.length = 0; });
+
+  it('disconnect closes and drops a single account transporter', async () => {
+    const svc = new SmtpService({ pool: { healthCheck: false } });
+    await svc.createTransporter(account({ host: 'imap.gmail.com' }));
+    svc.disconnect('acc-1');
+    expect(closed).toEqual(['smtp.gmail.com']);
+    expect(svc.getPoolStats()).toEqual({ configured: 0 });
+    expect(() => svc.disconnect('acc-1')).not.toThrow();
+  });
+
+  it('disconnectAll closes every transporter and clears the pool', async () => {
+    const svc = new SmtpService({ pool: { healthCheck: false } });
+    await svc.createTransporter(account({ id: 'a1', host: 'imap.gmail.com' }));
+    await svc.createTransporter(account({ id: 'a2', host: 'imap.mail.yahoo.com' }));
+    svc.disconnectAll();
+    expect(closed.sort()).toEqual(['smtp.gmail.com', 'smtp.mail.yahoo.com']);
+    expect(svc.getPoolStats()).toEqual({ configured: 0 });
+  });
+
+  it('verifySmtpConnection returns true on success', async () => {
+    const svc = new SmtpService({ pool: { healthCheck: false } });
+    expect(await svc.verifySmtpConnection(account())).toBe(true);
+  });
+});

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
 /**
  * SmtpService — pooled SMTP send with retry classification + metrics
  *
@@ -134,27 +135,27 @@ export class SmtpService {
   // ---------- transport / pool ----------
 
   async createTransporter(account: ImapAccount): Promise<nodemailer.Transporter> {
-    const existing = this.transporters.get(account.id);
-    if (existing) return existing;
+    const cached = this.transporters.get(account.id);
+    if (cached) return cached;
 
-    const smtpConfig = account.smtp || this.getDefaultSmtpConfig(account);
+    const smtp = account.smtp ?? this.getDefaultSmtpConfig(account);
 
     const transporter = nodemailer.createTransport({
-      host: smtpConfig.host,
-      port: smtpConfig.port,
-      secure: smtpConfig.secure,
+      host: smtp.host,
+      port: smtp.port,
+      secure: smtp.secure,
       auth: {
-        user: smtpConfig.user || account.user,
-        pass: smtpConfig.password || account.password,
+        user: smtp.user || account.user,
+        pass: smtp.password || account.password,
       },
-      tls: smtpConfig.tls,
+      tls: smtp.tls,
       pool: true,
       maxConnections: this.poolOptions.maxConnections,
-      // pool-idle: SMTP servers commonly drop after ~60-300s; keep our
-      // pool's idle below that to avoid surprise EOFs on send.
+      // Bound message reuse and keep the idle window under the ~60-300s
+      // window after which servers tend to drop the socket, so a pooled
+      // connection is not reaped mid-send.
       maxMessages: 100,
       socketTimeout: this.poolOptions.idleTimeoutSeconds * 1000,
-      // Health-check via NOOP-equivalent: nodemailer's verify() runs an EHLO.
     });
 
     if (this.poolOptions.healthCheck) {
@@ -165,16 +166,21 @@ export class SmtpService {
     return transporter;
   }
 
+  // Best-effort submission endpoint for accounts added without explicit SMTP
+  // settings: known IMAP hosts map to their documented submission server; any
+  // other host is derived from the IMAP hostname.
   private getDefaultSmtpConfig(account: ImapAccount): SmtpConfig {
-    const presets: { [key: string]: SmtpConfig } = {
-      'imap.gmail.com':       { host: 'smtp.gmail.com',           port: 587, secure: false },
-      'outlook.office365.com':{ host: 'smtp.office365.com',       port: 587, secure: false },
-      'imap-mail.outlook.com':{ host: 'smtp-mail.outlook.com',    port: 587, secure: false },
-      'imap.mail.yahoo.com':  { host: 'smtp.mail.yahoo.com',      port: 587, secure: false },
-      'imap.aol.com':         { host: 'smtp.aol.com',             port: 587, secure: false },
-      'imap.fastmail.com':    { host: 'smtp.fastmail.com',        port: 587, secure: false },
+    const submissionByImapHost: Record<string, SmtpConfig> = {
+      'imap.gmail.com':        { host: 'smtp.gmail.com',        port: 587, secure: false },
+      'outlook.office365.com': { host: 'smtp.office365.com',    port: 587, secure: false },
+      'imap-mail.outlook.com': { host: 'smtp-mail.outlook.com', port: 587, secure: false },
+      'imap.mail.yahoo.com':   { host: 'smtp.mail.yahoo.com',   port: 587, secure: false },
+      'imap.aol.com':          { host: 'smtp.aol.com',          port: 587, secure: false },
+      'imap.fastmail.com':     { host: 'smtp.fastmail.com',     port: 587, secure: false },
     };
-    if (presets[account.host]) return presets[account.host];
+
+    const known = submissionByImapHost[account.host];
+    if (known) return known;
 
     return {
       host: account.host.replace('imap.', 'smtp.').replace('imap-', 'smtp-'),
@@ -225,10 +231,10 @@ export class SmtpService {
 
   // ---------- send ----------
 
-  /** Backward-compat shim — returns just the messageId. */
+  /** Backward-compatible helper that returns only the Message-ID. */
   async sendEmail(accountId: string, account: ImapAccount, email: EmailComposer): Promise<string> {
-    const outcome = await this.sendEmailWithCopy(accountId, account, email);
-    return outcome.messageId;
+    const { messageId } = await this.sendEmailWithCopy(accountId, account, email);
+    return messageId;
   }
 
   /**
@@ -470,16 +476,15 @@ export class SmtpService {
   // ---------- shutdown ----------
 
   disconnect(accountId: string): void {
-    const t = this.transporters.get(accountId);
-    if (t) {
-      t.close();
-      this.transporters.delete(accountId);
-    }
+    const transporter = this.transporters.get(accountId);
+    if (!transporter) return;
+    transporter.close();
+    this.transporters.delete(accountId);
   }
 
   disconnectAll(): void {
-    for (const [, t] of this.transporters) {
-      try { t.close(); } catch {}
+    for (const transporter of this.transporters.values()) {
+      try { transporter.close(); } catch {}
     }
     this.transporters.clear();
   }

--- a/src/tools/account-tools.test.ts
+++ b/src/tools/account-tools.test.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+//
+// Route tests for the account-management MCP tools.
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+//
+// Registers accountTools against mock DatabaseService + ImapService and
+// asserts every route registers and returns the expected payload, including
+// the provider-preset onboarding paths and error handling. Locks the output
+// contract so the clean-room refactor (#166) cannot drift.
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { accountTools } from './account-tools.js';
+
+interface Registered { spec: any; handler: (args: any) => Promise<any>; }
+
+function makeServer() {
+  const tools = new Map<string, Registered>();
+  const server = { registerTool: (name: string, spec: any, handler: any) => tools.set(name, { spec, handler }) };
+  return { server, tools };
+}
+
+async function invoke(tools: Map<string, Registered>, name: string, args: any = {}) {
+  const entry = tools.get(name);
+  if (!entry) throw new Error(`tool not registered: ${name}`);
+  return JSON.parse((await entry.handler(args)).content[0].text);
+}
+
+function makeDb(overrides: Record<string, any> = {}) {
+  const created: any[] = [];
+  const db: any = {
+    created,
+    getUserByUsername: (username: string) => ({ user_id: 'u1', username, is_active: true }),
+    createAccount: (input: any) => { created.push(input); return { account_id: 'acc-1' }; },
+    listDecryptedAccountsForUser: () => [
+      { account_id: 'acc-1', name: 'Work', host: 'imap.example.com', port: 993, username: 'me', tls: true },
+    ],
+    deleteAccount: () => {},
+    getDecryptedAccount: (id: string) =>
+      id === 'missing' ? undefined
+        : { account_id: id, user_id: 'u1', name: 'Work', host: 'h', port: 993, username: 'me', password: 'secret', tls: true },
+    ...overrides,
+  };
+  return db;
+}
+
+function makeImap(overrides: Record<string, any> = {}) {
+  return {
+    connect: async () => {},
+    disconnect: async () => {},
+    testConnection: async () => ({ ok: true, folderCount: 5, inboxMessageCount: 3, durationMs: 12 }),
+    ...overrides,
+  };
+}
+
+describe('accountTools', () => {
+  beforeEach(() => { process.env.MCP_USER_ID = 'tester'; });
+  afterEach(() => { delete process.env.MCP_USER_ID; });
+
+  it('registers all account routes', () => {
+    const { server, tools } = makeServer();
+    accountTools(server as any, makeDb() as any, makeImap() as any);
+    expect([...tools.keys()].sort()).toEqual([
+      'imap_add_account',
+      'imap_add_account_auto',
+      'imap_add_account_with_provider',
+      'imap_connect',
+      'imap_disconnect',
+      'imap_get_outbox_dir',
+      'imap_list_accounts',
+      'imap_list_providers',
+      'imap_remove_account',
+      'imap_test_account',
+    ]);
+  });
+
+  it('imap_add_account stores account and reports SMTP disabled by default', async () => {
+    const db = makeDb();
+    const { server, tools } = makeServer();
+    accountTools(server as any, db as any, makeImap() as any);
+    const out = await invoke(tools, 'imap_add_account', { name: 'Work', host: 'h', port: 993, user: 'me', password: 'p', tls: true });
+    expect(out.success).toBe(true);
+    expect(out.accountId).toBe('acc-1');
+    expect(out.smtp).toEqual({ enabled: false });
+    expect(db.created[0]).toMatchObject({ user_id: 'u1', name: 'Work', host: 'h', username: 'me', smtp_host: undefined });
+  });
+
+  it('imap_add_account enables SMTP and defaults smtp user/pass to IMAP creds', async () => {
+    const db = makeDb();
+    const { server, tools } = makeServer();
+    accountTools(server as any, db as any, makeImap() as any);
+    const out = await invoke(tools, 'imap_add_account', { name: 'W', host: 'h', port: 993, user: 'me', password: 'p', tls: true, smtpHost: 'smtp.h' });
+    expect(out.smtp).toEqual({ enabled: true, host: 'smtp.h', port: 587, secure: false });
+    expect(db.created[0]).toMatchObject({ smtp_host: 'smtp.h', smtp_username: 'me', smtp_password: 'p' });
+  });
+
+  it('imap_list_accounts maps stored accounts for the user', async () => {
+    const { server, tools } = makeServer();
+    accountTools(server as any, makeDb() as any, makeImap() as any);
+    const out = await invoke(tools, 'imap_list_accounts', {});
+    expect(out.user).toBe('tester');
+    expect(out.accounts).toEqual([{ id: 'acc-1', name: 'Work', host: 'imap.example.com', port: 993, user: 'me', tls: true }]);
+  });
+
+  it('imap_remove_account / disconnect return confirmations', async () => {
+    const { server, tools } = makeServer();
+    accountTools(server as any, makeDb() as any, makeImap() as any);
+    expect(await invoke(tools, 'imap_remove_account', { accountId: 'acc-1' }))
+      .toEqual({ success: true, message: 'Account acc-1 removed successfully' });
+    expect(await invoke(tools, 'imap_disconnect', { accountId: 'acc-1' }))
+      .toEqual({ success: true, message: 'Disconnected from account acc-1' });
+  });
+
+  it('imap_connect connects a known account and errors on a missing one', async () => {
+    const { server, tools } = makeServer();
+    accountTools(server as any, makeDb() as any, makeImap() as any);
+    const ok = await invoke(tools, 'imap_connect', { accountId: 'acc-1' });
+    expect(ok).toMatchObject({ success: true, accountId: 'acc-1' });
+    const err = await invoke(tools, 'imap_connect', { accountId: 'missing' });
+    expect(JSON.stringify(err)).toContain('missing');
+  });
+
+  it('imap_list_providers returns the preset catalog', async () => {
+    const { server, tools } = makeServer();
+    accountTools(server as any, makeDb() as any, makeImap() as any);
+    const out = await invoke(tools, 'imap_list_providers', {});
+    expect(out.success).toBe(true);
+    expect(out.count).toBeGreaterThan(0);
+    expect(out.providers.find((p: any) => p.id === 'gmail')).toBeTruthy();
+  });
+
+  it('imap_add_account_with_provider fills IMAP/SMTP from the preset', async () => {
+    const db = makeDb();
+    const { server, tools } = makeServer();
+    accountTools(server as any, db as any, makeImap() as any);
+    const out = await invoke(tools, 'imap_add_account_with_provider', { providerId: 'gmail', name: 'G', email: 'me@gmail.com', password: 'app-pw', smtpEnabled: true });
+    expect(out.success).toBe(true);
+    expect(out.settings.imap).toEqual({ host: 'imap.gmail.com', port: 993, security: 'SSL' });
+    expect(out.settings.smtp).toEqual({ host: 'smtp.gmail.com', port: 465, security: 'SSL' });
+    expect(db.created[0]).toMatchObject({ host: 'imap.gmail.com', port: 993, tls: true, smtp_host: 'smtp.gmail.com', smtp_username: 'me@gmail.com' });
+  });
+
+  it('imap_add_account_with_provider uses imapUsername override and rejects unknown providers', async () => {
+    const db = makeDb();
+    const { server, tools } = makeServer();
+    accountTools(server as any, db as any, makeImap() as any);
+    await invoke(tools, 'imap_add_account_with_provider', { providerId: 'gmail', name: 'G', email: 'me@gmail.com', password: 'p', smtpEnabled: false, imapUsername: 'DOMAIN\\me' });
+    expect(db.created[0].username).toBe('DOMAIN\\me');
+    const err = await invoke(tools, 'imap_add_account_with_provider', { providerId: 'nope', name: 'G', email: 'x@y.com', password: 'p', smtpEnabled: false });
+    expect(JSON.stringify(err)).toContain('Unknown provider');
+  });
+
+  it('imap_add_account_auto detects provider by domain and errors when unknown', async () => {
+    const db = makeDb();
+    const { server, tools } = makeServer();
+    accountTools(server as any, db as any, makeImap() as any);
+    const out = await invoke(tools, 'imap_add_account_auto', { name: 'G', email: 'me@gmail.com', password: 'p', smtpEnabled: false });
+    expect(out.autoDetected).toBe(true);
+    expect(out.settings.imap.host).toBe('imap.gmail.com');
+    const err = await invoke(tools, 'imap_add_account_auto', { name: 'G', email: 'me@no-such-domain-xyz.example', password: 'p', smtpEnabled: false });
+    expect(JSON.stringify(err)).toContain('auto-detect');
+  });
+
+  it('imap_test_account handles found / not-found / not-owned', async () => {
+    const { server, tools } = makeServer();
+    accountTools(server as any, makeDb() as any, makeImap() as any);
+    expect(await invoke(tools, 'imap_test_account', { accountId: 'acc-1' })).toMatchObject({ success: true, folderCount: 5, inboxMessageCount: 3 });
+    expect(await invoke(tools, 'imap_test_account', { accountId: 'missing' })).toMatchObject({ success: false, result: 'account_not_found' });
+
+    const otherDb = makeDb({ getDecryptedAccount: (id: string) => ({ account_id: id, user_id: 'someone-else', name: 'X', host: 'h', port: 993, username: 'u', password: 'p', tls: true }) });
+    const s2 = makeServer();
+    accountTools(s2.server as any, otherDb as any, makeImap() as any);
+    expect(await invoke(s2.tools, 'imap_test_account', { accountId: 'acc-1' })).toMatchObject({ success: false, result: 'account_not_owned_by_caller' });
+  });
+});

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -1,17 +1,97 @@
+// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+//
+// Account-management MCP tools.
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+// Part of: IMAP MCP Pro (Temple of Epiphany)
+//
+// Registers account add/list/remove/connect/disconnect, the provider-preset
+// onboarding tools, the per-user outbox path, and the connectivity probe.
+
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 import { DatabaseService } from '../services/database-service.js';
 import { ImapService } from '../services/imap-service.js';
-import { z } from 'zod';
-import { withErrorHandling, AccountNotFoundError, validateOneOf } from '../utils/error-handler.js';
+import { EmailProvider } from '../providers/email-providers.js';
+import { withErrorHandling, AccountNotFoundError } from '../utils/error-handler.js';
 import { withUserAuthorization } from './tool-context.js';
 import { emailProviders, getProviderById, getProviderByEmail } from '../providers/email-providers.js';
+
+/** Wrap any payload as a pretty-printed JSON text tool result. */
+function jsonResult(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }] };
+}
+
+/** True when a security mode means an implicit-TLS connection. */
+function isImplicitTls(security: EmailProvider['imapSecurity']): boolean {
+  return security === 'SSL' || security === 'TLS';
+}
+
+/**
+ * Build the createAccount payload shared by the provider-preset onboarding
+ * tools (with-provider and auto-detect). SMTP fields are only populated when
+ * the caller opts in and the provider advertises an SMTP endpoint.
+ */
+function providerAccountInput(
+  userId: string,
+  name: string,
+  loginUsername: string,
+  password: string,
+  provider: EmailProvider,
+  smtpEnabled: boolean,
+) {
+  const withSmtp = smtpEnabled && !!provider.smtpHost;
+  return {
+    user_id: userId,
+    name,
+    host: provider.imapHost,
+    port: provider.imapPort,
+    username: loginUsername,
+    password,
+    tls: isImplicitTls(provider.imapSecurity),
+    is_active: true,
+    smtp_host: withSmtp ? provider.smtpHost : undefined,
+    smtp_port: withSmtp ? provider.smtpPort : undefined,
+    smtp_secure: withSmtp && provider.smtpSecurity ? isImplicitTls(provider.smtpSecurity) : undefined,
+    smtp_username: smtpEnabled ? loginUsername : undefined,
+    smtp_password: smtpEnabled ? password : undefined,
+  };
+}
+
+/** Append the app-password and help-URL hints a provider may carry. */
+function withProviderHints(message: string, provider: EmailProvider): string {
+  let out = message;
+  if (provider.requiresAppPassword) {
+    out += ` ⚠️ NOTE: ${provider.notes || 'This provider requires an app-specific password.'}`;
+  }
+  if (provider.helpUrl) {
+    out += ` See: ${provider.helpUrl}`;
+  }
+  return out;
+}
+
+/** The IMAP/SMTP settings block echoed back by the provider onboarding tools. */
+function providerSettings(provider: EmailProvider, smtpEnabled: boolean) {
+  return {
+    imap: {
+      host: provider.imapHost,
+      port: provider.imapPort,
+      security: provider.imapSecurity,
+    },
+    smtp: smtpEnabled && provider.smtpHost ? {
+      host: provider.smtpHost,
+      port: provider.smtpPort,
+      security: provider.smtpSecurity,
+    } : undefined,
+  };
+}
 
 export function accountTools(
   server: McpServer,
   db: DatabaseService,
   imapService: ImapService
 ): void {
-  // Add account tool with SMTP support
+  // Add account (manual host/port + optional SMTP)
   server.registerTool('imap_add_account', {
     description: 'Add a new IMAP account with optional SMTP configuration for current user (from MCP_USER_ID environment variable)',
     inputSchema: {
@@ -20,8 +100,8 @@ export function accountTools(
       port: z.number().default(993).describe('IMAP server port (default: 993)'),
       user: z.string().describe('Username for authentication'),
       password: z.string().describe('Password for authentication'),
-      tls: z.boolean().default(true).describe('Use TLS/SSL (default: true)'),
       // SMTP Configuration (optional)
+      tls: z.boolean().default(true).describe('Use TLS/SSL (default: true)'),
       smtpHost: z.string().optional().describe('SMTP server hostname (optional, for sending emails)'),
       smtpPort: z.number().optional().describe('SMTP server port (default: 587 for STARTTLS, 465 for SSL)'),
       smtpSecure: z.boolean().optional().describe('Use SSL/TLS for SMTP (default: false, uses STARTTLS)'),
@@ -29,7 +109,6 @@ export function accountTools(
       smtpPassword: z.string().optional().describe('SMTP password (defaults to IMAP password if not provided)'),
     }
   }, withErrorHandling(withUserAuthorization(db, async ({ name, host, port, user, password, tls, smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword }, context) => {
-    // Create account for the authenticated user from context
     const account = db.createAccount({
       user_id: context.userId,
       name,
@@ -39,7 +118,6 @@ export function accountTools(
       password,
       tls,
       is_active: true,
-      // SMTP configuration if provided
       smtp_host: smtpHost,
       smtp_port: smtpPort,
       smtp_secure: smtpSecure,
@@ -52,60 +130,44 @@ export function accountTools(
       message += ` with SMTP enabled (${smtpHost}:${smtpPort || 587})`;
     }
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          user: context.username,
-          accountId: account.account_id,
-          message,
-          smtp: smtpHost ? {
-            enabled: true,
-            host: smtpHost,
-            port: smtpPort || 587,
-            secure: smtpSecure || false,
-          } : {
-            enabled: false
-          },
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      success: true,
+      user: context.username,
+      accountId: account.account_id,
+      message,
+      smtp: smtpHost
+        ? { enabled: true, host: smtpHost, port: smtpPort || 587, secure: smtpSecure || false }
+        : { enabled: false },
+    });
   })));
 
-  // List accounts tool
+  // List accounts for the current user
   server.registerTool('imap_list_accounts', {
     description: 'List all IMAP accounts for current user (from MCP_USER_ID environment variable)',
     inputSchema: {}
-  }, withErrorHandling(withUserAuthorization(db, async (params, context) => {
-    // Get accounts for the authenticated user from context
+  }, withErrorHandling(withUserAuthorization(db, async (_params, context) => {
     const accounts = db.listDecryptedAccountsForUser(context.userId);
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          user: context.username,
-          accounts: accounts.map(acc => ({
-            id: acc.account_id,
-            name: acc.name,
-            host: acc.host,
-            port: acc.port,
-            user: acc.username,
-            tls: acc.tls,
-          })),
-          usage:
-            "Each entry's `id` (UUID) is the value to pass as `accountId` to imap_send_email, " +
-            'imap_search_emails, imap_get_email, imap_test_account, imap_connect, etc. ' +
-            'imap_test_account is the cheapest way to verify connectivity without warming the ' +
-            'connection pool. The IMAP `user`/`host`/`port` fields are diagnostic-only — do not ' +
-            'pass them anywhere; the server resolves them from the stored account row.',
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      user: context.username,
+      accounts: accounts.map(acc => ({
+        id: acc.account_id,
+        name: acc.name,
+        host: acc.host,
+        port: acc.port,
+        user: acc.username,
+        tls: acc.tls,
+      })),
+      usage:
+        "Each entry's `id` (UUID) is the value to pass as `accountId` to imap_send_email, " +
+        'imap_search_emails, imap_get_email, imap_test_account, imap_connect, etc. ' +
+        'imap_test_account is the cheapest way to verify connectivity without warming the ' +
+        'connection pool. The IMAP `user`/`host`/`port` fields are diagnostic-only — do not ' +
+        'pass them anywhere; the server resolves them from the stored account row.',
+    });
   })));
 
-  // Remove account tool
+  // Remove an account
   server.registerTool('imap_remove_account', {
     description: 'Remove an IMAP account from database',
     inputSchema: {
@@ -114,19 +176,10 @@ export function accountTools(
   }, withErrorHandling(async ({ accountId }) => {
     await imapService.disconnect(accountId);
     db.deleteAccount(accountId);
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Account ${accountId} removed successfully`,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({ success: true, message: `Account ${accountId} removed successfully` });
   }));
 
-  // Connect to account tool
+  // Connect to an account (warms the pool)
   server.registerTool('imap_connect', {
     description: 'Connect to an IMAP account',
     inputSchema: {
@@ -134,12 +187,10 @@ export function accountTools(
     }
   }, withErrorHandling(async ({ accountId }) => {
     const account = db.getDecryptedAccount(accountId);
-
     if (!account) {
       throw new AccountNotFoundError(accountId);
     }
 
-    // Convert database account to ImapAccount format
     await imapService.connect({
       id: account.account_id,
       name: account.name,
@@ -147,22 +198,17 @@ export function accountTools(
       port: account.port,
       user: account.username,
       password: account.password,
-      tls: account.tls
+      tls: account.tls,
     });
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Connected to account "${account.name}"`,
-          accountId: account.account_id,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      success: true,
+      message: `Connected to account "${account.name}"`,
+      accountId: account.account_id,
+    });
   }));
 
-  // Disconnect from account tool
+  // Disconnect from an account
   server.registerTool('imap_disconnect', {
     description: 'Disconnect from an IMAP account',
     inputSchema: {
@@ -170,19 +216,10 @@ export function accountTools(
     }
   }, withErrorHandling(async ({ accountId }) => {
     await imapService.disconnect(accountId);
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Disconnected from account ${accountId}`,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({ success: true, message: `Disconnected from account ${accountId}` });
   }));
 
-  // List email provider presets tool
+  // List built-in provider presets
   server.registerTool('imap_list_providers', {
     description: 'List all available email provider presets (Gmail, Outlook, Yahoo, etc.) with pre-configured IMAP/SMTP settings',
     inputSchema: {}
@@ -204,27 +241,22 @@ export function accountTools(
       notes: p.notes,
     }));
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          count: providers.length,
-          providers,
-          usage:
-            "Pass an entry's `id` as `providerId` to imap_add_account_with_provider. If " +
-            '`requiresAppPassword` is true, the user must generate a provider-specific app ' +
-            'password before adding the account (Gmail, iCloud, Yahoo, Outlook with 2FA all ' +
-            'require this). `oauth2Supported` is informational; OAuth2 onboarding flows are not ' +
-            'yet wired into this server. For Exchange-style accounts where the IMAP login is ' +
-            'a non-email form (e.g., DOMAIN\\\\user), pass the `imapUsername` parameter to ' +
-            'imap_add_account_with_provider to override the default (which uses the email).',
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      success: true,
+      count: providers.length,
+      providers,
+      usage:
+        "Pass an entry's `id` as `providerId` to imap_add_account_with_provider. If " +
+        '`requiresAppPassword` is true, the user must generate a provider-specific app ' +
+        'password before adding the account (Gmail, iCloud, Yahoo, Outlook with 2FA all ' +
+        'require this). `oauth2Supported` is informational; OAuth2 onboarding flows are not ' +
+        'yet wired into this server. For Exchange-style accounts where the IMAP login is ' +
+        'a non-email form (e.g., DOMAIN\\\\user), pass the `imapUsername` parameter to ' +
+        'imap_add_account_with_provider to override the default (which uses the email).',
+    });
   }));
 
-  // Add account using provider preset tool
+  // Add account using a named provider preset
   server.registerTool('imap_add_account_with_provider', {
     description: 'Add a new IMAP account using a provider preset (auto-fills IMAP/SMTP settings). Use imap_list_providers to see available providers.',
     inputSchema: {
@@ -241,66 +273,32 @@ export function accountTools(
       ),
     }
   }, withErrorHandling(withUserAuthorization(db, async ({ providerId, name, email, password, smtpEnabled, imapUsername }, context) => {
-    // Get provider preset
     const provider = getProviderById(providerId);
     if (!provider) {
       throw new Error(`Unknown provider: ${providerId}. Use imap_list_providers to see available providers.`);
     }
 
     const loginUsername = imapUsername ?? email;
+    const account = db.createAccount(
+      providerAccountInput(context.userId, name, loginUsername, password, provider, smtpEnabled),
+    );
 
-    // Create account with provider settings
-    const account = db.createAccount({
-      user_id: context.userId,
-      name,
-      host: provider.imapHost,
-      port: provider.imapPort,
-      username: loginUsername,
-      password,
-      tls: provider.imapSecurity === 'SSL' || provider.imapSecurity === 'TLS',
-      is_active: true,
-      smtp_host: smtpEnabled && provider.smtpHost ? provider.smtpHost : undefined,
-      smtp_port: smtpEnabled && provider.smtpPort ? provider.smtpPort : undefined,
-      smtp_secure: smtpEnabled && provider.smtpSecurity ? (provider.smtpSecurity === 'SSL' || provider.smtpSecurity === 'TLS') : undefined,
-      smtp_username: smtpEnabled ? loginUsername : undefined,
-      smtp_password: smtpEnabled ? password : undefined,
+    const message = withProviderHints(
+      `Account "${name}" added successfully for ${provider.displayName}`,
+      provider,
+    );
+
+    return jsonResult({
+      success: true,
+      user: context.username,
+      accountId: account.account_id,
+      provider: provider.displayName,
+      message,
+      settings: providerSettings(provider, smtpEnabled),
     });
-
-    let message = `Account "${name}" added successfully for ${provider.displayName}`;
-    if (provider.requiresAppPassword) {
-      message += ` ⚠️ NOTE: ${provider.notes || 'This provider requires an app-specific password.'}`;
-    }
-    if (provider.helpUrl) {
-      message += ` See: ${provider.helpUrl}`;
-    }
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          user: context.username,
-          accountId: account.account_id,
-          provider: provider.displayName,
-          message,
-          settings: {
-            imap: {
-              host: provider.imapHost,
-              port: provider.imapPort,
-              security: provider.imapSecurity,
-            },
-            smtp: smtpEnabled && provider.smtpHost ? {
-              host: provider.smtpHost,
-              port: provider.smtpPort,
-              security: provider.smtpSecurity,
-            } : undefined,
-          },
-        }, null, 2)
-      }]
-    };
   })));
 
-  // Auto-detect provider from email and add account tool
+  // Add account by auto-detecting the provider from the email domain
   server.registerTool('imap_add_account_auto', {
     description: 'Add a new IMAP account by auto-detecting provider from email address (e.g., @gmail.com → Gmail preset)',
     inputSchema: {
@@ -315,64 +313,30 @@ export function accountTools(
       ),
     }
   }, withErrorHandling(withUserAuthorization(db, async ({ name, email, password, smtpEnabled, imapUsername }, context) => {
-    // Auto-detect provider from email
     const provider = getProviderByEmail(email);
     if (!provider) {
       throw new Error(`Could not auto-detect provider for ${email}. Use imap_add_account for manual configuration or imap_add_account_with_provider with a specific provider.`);
     }
 
     const loginUsername = imapUsername ?? email;
+    const account = db.createAccount(
+      providerAccountInput(context.userId, name, loginUsername, password, provider, smtpEnabled),
+    );
 
-    // Create account with auto-detected provider settings
-    const account = db.createAccount({
-      user_id: context.userId,
-      name,
-      host: provider.imapHost,
-      port: provider.imapPort,
-      username: loginUsername,
-      password,
-      tls: provider.imapSecurity === 'SSL' || provider.imapSecurity === 'TLS',
-      is_active: true,
-      smtp_host: smtpEnabled && provider.smtpHost ? provider.smtpHost : undefined,
-      smtp_port: smtpEnabled && provider.smtpPort ? provider.smtpPort : undefined,
-      smtp_secure: smtpEnabled && provider.smtpSecurity ? (provider.smtpSecurity === 'SSL' || provider.smtpSecurity === 'TLS') : undefined,
-      smtp_username: smtpEnabled ? loginUsername : undefined,
-      smtp_password: smtpEnabled ? password : undefined,
+    const message = withProviderHints(
+      `Account "${name}" added successfully (auto-detected: ${provider.displayName})`,
+      provider,
+    );
+
+    return jsonResult({
+      success: true,
+      user: context.username,
+      accountId: account.account_id,
+      provider: provider.displayName,
+      autoDetected: true,
+      message,
+      settings: providerSettings(provider, smtpEnabled),
     });
-
-    let message = `Account "${name}" added successfully (auto-detected: ${provider.displayName})`;
-    if (provider.requiresAppPassword) {
-      message += ` ⚠️ NOTE: ${provider.notes || 'This provider requires an app-specific password.'}`;
-    }
-    if (provider.helpUrl) {
-      message += ` See: ${provider.helpUrl}`;
-    }
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          user: context.username,
-          accountId: account.account_id,
-          provider: provider.displayName,
-          autoDetected: true,
-          message,
-          settings: {
-            imap: {
-              host: provider.imapHost,
-              port: provider.imapPort,
-              security: provider.imapSecurity,
-            },
-            smtp: smtpEnabled && provider.smtpHost ? {
-              host: provider.smtpHost,
-              port: provider.smtpPort,
-              security: provider.smtpSecurity,
-            } : undefined,
-          },
-        }, null, 2)
-      }]
-    };
   })));
 
   // imap_get_outbox_dir (#148): return the per-user attachment outbox path.
@@ -393,20 +357,15 @@ export function accountTools(
   }, withErrorHandling(withUserAuthorization(db, async (_args, context) => {
     const { getOutboxDir } = await import('../services/attachment-validator.js');
     const outboxDir = getOutboxDir(context.userId);
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          outboxDir,
-          userId: context.userId,
-          username: context.username,
-          usage:
-            'Write attachment files to this directory, then reference them via attachmentPaths ' +
-            'in imap_send_email. Same dotfile / size / filename rules apply as for any allow-listed dir.',
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      success: true,
+      outboxDir,
+      userId: context.userId,
+      username: context.username,
+      usage:
+        'Write attachment files to this directory, then reference them via attachmentPaths ' +
+        'in imap_send_email. Same dotfile / size / filename rules apply as for any allow-listed dir.',
+    });
   })));
 
   // imap_test_account (#90): one-shot connectivity probe against an existing
@@ -429,29 +388,15 @@ export function accountTools(
   }, withErrorHandling(withUserAuthorization(db, async ({ accountId }, context) => {
     const dbAccount = db.getDecryptedAccount(accountId);
     if (!dbAccount) {
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            success: false,
-            result: 'account_not_found',
-            accountId,
-          }, null, 2)
-        }]
-      };
+      return jsonResult({ success: false, result: 'account_not_found', accountId });
     }
     if (dbAccount.user_id !== context.userId) {
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            success: false,
-            result: 'account_not_owned_by_caller',
-            accountId,
-            hint: 'The accountId belongs to a different user. Pass an accountId returned by imap_list_accounts for the current MCP_USER_ID.',
-          }, null, 2)
-        }]
-      };
+      return jsonResult({
+        success: false,
+        result: 'account_not_owned_by_caller',
+        accountId,
+        hint: 'The accountId belongs to a different user. Pass an accountId returned by imap_list_accounts for the current MCP_USER_ID.',
+      });
     }
 
     const account = {
@@ -466,22 +411,17 @@ export function accountTools(
 
     const result = await imapService.testConnection(account);
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: result.ok,
-          accountId,
-          accountName: dbAccount.name,
-          host: dbAccount.host,
-          port: dbAccount.port,
-          tls: dbAccount.tls,
-          folderCount: result.folderCount,
-          inboxMessageCount: result.inboxMessageCount,
-          error: result.error,
-          durationMs: result.durationMs,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      success: result.ok,
+      accountId,
+      accountName: dbAccount.name,
+      host: dbAccount.host,
+      port: dbAccount.port,
+      tls: dbAccount.tls,
+      folderCount: result.folderCount,
+      inboxMessageCount: result.inboxMessageCount,
+      error: result.error,
+      durationMs: result.durationMs,
+    });
   })));
 }


### PR DESCRIPTION
Part of #166. Genuine (non-cosmetic) re-expression of two logic files, behavior preserved, now covered by tests.

**account-tools.ts** — `jsonResult()` helper replaces the repeated content/JSON wrapper; the two near-duplicate provider-onboarding tools share new helpers; unused import dropped. +`account-tools.test.ts` (11 tests).

**smtp-service.ts** — re-expressed `createTransporter`/`getDefaultSmtpConfig`/shutdown helpers (behavior identical; factual SMTP-host table kept). +`smtp-service.test.ts` (8 tests, nodemailer mocked).

Build + 116 tests green.

Refs #166