### PR TITLE
refactor(email-tools): re-express core handlers + route tests (#166)

### DIFF
--- a/src/tools/email-tools.test.ts
+++ b/src/tools/email-tools.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+//
+// Route tests for the core email MCP tools (search / get / mark / delete).
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+//
+// These handlers were materially reworked for bulk actions + IMAP4rev2; this
+// suite locks the inline-response contract that the #166 re-expression touched.
+// emailTools is registered with no ResultsService so search uses the inline
+// path (the handle/file path is exercised elsewhere).
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { emailTools } from './email-tools.js';
+
+interface Registered { spec: any; handler: (args: any) => Promise<any>; }
+
+function makeServer() {
+  const tools = new Map<string, Registered>();
+  const server = { registerTool: (name: string, spec: any, handler: any) => tools.set(name, { spec, handler }) };
+  return { server, tools };
+}
+
+async function invoke(tools: Map<string, Registered>, name: string, args: any) {
+  const entry = tools.get(name);
+  if (!entry) throw new Error(`tool not registered: ${name}`);
+  return JSON.parse((await entry.handler(args)).content[0].text);
+}
+
+function makeImap(overrides: Record<string, any> = {}) {
+  return {
+    lastCriteria: undefined as any,
+    searchEmails: async function (this: any, _a: string, _f: string, criteria: any) {
+      this.lastCriteria = criteria;
+      return [
+        { uid: 1, subject: 'Hello', from: 'a@x.com', to: ['me@x.com'], date: new Date('2026-01-01'), flags: ['\\Seen'] },
+        { uid: 2, subject: 'Re: Hello', from: 'b@x.com', to: ['me@x.com'], date: new Date('2026-01-02'), flags: [] },
+      ];
+    },
+    getEmailContent: async () => ({
+      uid: 1, subject: 'Hello', from: 'a@x.com',
+      textContent: 'T'.repeat(20000), htmlContent: 'H'.repeat(20000),
+    }),
+    markAsRead: async () => {},
+    markAsUnread: async () => {},
+    deleteEmail: async () => {},
+    ...overrides,
+  };
+}
+
+function register(imap: any) {
+  const { server, tools } = makeServer();
+  // results/workerPool/etc. omitted → search uses the inline path.
+  emailTools(server as any, imap as any, {} as any, {} as any);
+  return tools;
+}
+
+describe('emailTools core routes', () => {
+  let imap: any;
+  let tools: Map<string, Registered>;
+  beforeEach(() => { imap = makeImap(); tools = register(imap); });
+
+  it('registers the core email routes', () => {
+    for (const name of ['imap_search_emails', 'imap_get_email', 'imap_mark_as_read', 'imap_mark_as_unread', 'imap_delete_email']) {
+      expect(tools.has(name)).toBe(true);
+    }
+  });
+
+  it('imap_search_emails returns the inline result shape', async () => {
+    const out = await invoke(tools, 'imap_search_emails', { accountId: 'a', folder: 'INBOX', limit: 50 });
+    expect(out.totalFound).toBe(2);
+    expect(out.returned).toBe(2);
+    expect(out.messages).toHaveLength(2);
+    expect(out.warnings).toBeUndefined();
+  });
+
+  it('imap_search_emails maps only provided criteria and parses dates locally', async () => {
+    await invoke(tools, 'imap_search_emails', { accountId: 'a', folder: 'INBOX', from: 'x@y.com', subject: 'hi', since: '2026-04-01', unreadOnly: true });
+    expect(imap.lastCriteria).toMatchObject({ from: 'x@y.com', subject: 'hi', unreadOnly: true });
+    expect(imap.lastCriteria).not.toHaveProperty('to');
+    expect(imap.lastCriteria).not.toHaveProperty('flagged');
+    // YYYY-MM-DD parsed as local midnight (not UTC) — Issue #91
+    expect(imap.lastCriteria.since.getFullYear()).toBe(2026);
+    expect(imap.lastCriteria.since.getMonth()).toBe(3);
+    expect(imap.lastCriteria.since.getDate()).toBe(1);
+    expect(imap.lastCriteria.since.getHours()).toBe(0);
+  });
+
+  it('imap_search_emails warns and truncates when results exceed the limit', async () => {
+    const many = Array.from({ length: 5 }, (_, i) => ({ uid: i, subject: 's', from: 'f', to: [], date: new Date(), flags: [] }));
+    const t = register(makeImap({ searchEmails: async () => many }));
+    const out = await invoke(t, 'imap_search_emails', { accountId: 'a', folder: 'INBOX', limit: 2 });
+    expect(out.returned).toBe(2);
+    expect(out.totalFound).toBe(5);
+    expect(out.warnings?.some((w: string) => w.includes('returning only'))).toBe(true);
+  });
+
+  it('imap_get_email clips text and html bodies to 10000 chars', async () => {
+    const out = await invoke(tools, 'imap_get_email', { accountId: 'a', folder: 'INBOX', uid: 1 });
+    expect(out.email.textContent).toHaveLength(10000);
+    expect(out.email.htmlContent).toHaveLength(10000);
+    expect(out.email.subject).toBe('Hello');
+  });
+
+  it('imap_mark_as_read / mark_as_unread / delete_email return confirmations', async () => {
+    expect(await invoke(tools, 'imap_mark_as_read', { accountId: 'a', folder: 'INBOX', uid: 7 }))
+      .toEqual({ success: true, message: 'Email 7 marked as read' });
+    expect(await invoke(tools, 'imap_mark_as_unread', { accountId: 'a', folder: 'INBOX', uid: 7 }))
+      .toEqual({ success: true, message: 'Email 7 marked as unread' });
+    expect(await invoke(tools, 'imap_delete_email', { accountId: 'a', folder: 'INBOX', uid: 7 }))
+      .toEqual({ success: true, message: 'Email 7 deleted' });
+  });
+});

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -126,6 +126,30 @@ function parseDateOnly(input: string): Date {
   return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
 }
 
+/** Wrap any payload as a pretty-printed JSON text tool result. */
+function jsonResult(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }] };
+}
+
+/** Cap a possibly-undefined body string to keep responses within budget. */
+function clip(text: string | undefined, max = 10000): string | undefined {
+  return text?.substring(0, max);
+}
+
+/** Translate the search tool's flat params into an ImapService SearchCriteria. */
+function buildSearchCriteria(raw: Record<string, any>): Record<string, any> {
+  const criteria: Record<string, any> = {};
+  for (const key of ['from', 'to', 'subject', 'body'] as const) {
+    if (raw[key]) criteria[key] = raw[key];
+  }
+  if (raw.since) criteria.since = parseDateOnly(raw.since);
+  if (raw.before) criteria.before = parseDateOnly(raw.before);
+  if (raw.unreadOnly !== undefined) criteria.unreadOnly = raw.unreadOnly; // Issue #82
+  if (raw.seen !== undefined) criteria.seen = raw.seen;
+  if (raw.flagged !== undefined) criteria.flagged = raw.flagged;
+  return criteria;
+}
+
 export function emailTools(
   server: McpServer,
   imapService: ImapService,
@@ -163,18 +187,8 @@ export function emailTools(
       storageType: StorageTypeSchema,
     }
   }, withErrorHandling(async ({ accountId, folder, limit, responseMode, storageType, ...searchCriteria }) => {
-    const criteria: any = {};
     const effectiveLimit = capLimit(limit, 50, responseMode);
-
-    if (searchCriteria.from) criteria.from = searchCriteria.from;
-    if (searchCriteria.to) criteria.to = searchCriteria.to;
-    if (searchCriteria.subject) criteria.subject = searchCriteria.subject;
-    if (searchCriteria.body) criteria.body = searchCriteria.body;
-    if (searchCriteria.since) criteria.since = parseDateOnly(searchCriteria.since);
-    if (searchCriteria.before) criteria.before = parseDateOnly(searchCriteria.before);
-    if (searchCriteria.unreadOnly !== undefined) criteria.unreadOnly = searchCriteria.unreadOnly;  // Issue #82
-    if (searchCriteria.seen !== undefined) criteria.seen = searchCriteria.seen;
-    if (searchCriteria.flagged !== undefined) criteria.flagged = searchCriteria.flagged;
+    const criteria = buildSearchCriteria(searchCriteria);
 
     const messages = await imapService.searchEmails(accountId, folder, criteria);
     const limitedMessages = messages.slice(0, effectiveLimit);
@@ -225,17 +239,12 @@ export function emailTools(
       warnings.push(`Large folder detected (${messages.length} emails). Consider responseMode='file' for very large sets.`);
     }
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          totalFound: messages.length,
-          returned: limitedMessages.length,
-          warnings: warnings.length > 0 ? warnings : undefined,
-          messages: limitedMessages,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      totalFound: messages.length,
+      returned: limitedMessages.length,
+      warnings: warnings.length > 0 ? warnings : undefined,
+      messages: limitedMessages,
+    });
   }));
 
   // Get email content tool
@@ -250,18 +259,13 @@ export function emailTools(
   }, withErrorHandling(async ({ accountId, folder, uid, headersOnly }) => {
     const email = await imapService.getEmailContent(accountId, folder, uid, headersOnly);
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          email: {
-            ...email,
-            textContent: email.textContent?.substring(0, 10000), // Limit text content
-            htmlContent: email.htmlContent?.substring(0, 10000), // Limit HTML content
-          },
-        }, null, 2)
-      }]
-    };
+    return jsonResult({
+      email: {
+        ...email,
+        textContent: clip(email.textContent),
+        htmlContent: clip(email.htmlContent),
+      },
+    });
   }));
 
   // Mark email as read tool
@@ -274,16 +278,7 @@ export function emailTools(
     }
   }, withErrorHandling(async ({ accountId, folder, uid }) => {
     await imapService.markAsRead(accountId, folder, uid);
-    
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Email ${uid} marked as read`,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({ success: true, message: `Email ${uid} marked as read` });
   }));
 
   // Mark email as unread tool
@@ -296,16 +291,7 @@ export function emailTools(
     }
   }, withErrorHandling(async ({ accountId, folder, uid }) => {
     await imapService.markAsUnread(accountId, folder, uid);
-    
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Email ${uid} marked as unread`,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({ success: true, message: `Email ${uid} marked as unread` });
   }));
 
   // Delete email tool
@@ -318,16 +304,7 @@ export function emailTools(
     }
   }, withErrorHandling(async ({ accountId, folder, uid }) => {
     await imapService.deleteEmail(accountId, folder, uid);
-
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          message: `Email ${uid} deleted`,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({ success: true, message: `Email ${uid} deleted` });
   }));
 
   // Bulk delete emails tool


### PR DESCRIPTION
Part of #166. Re-express the search/get/mark/delete handlers (already reworked for bulk + IMAP4rev2; residual blame was trivial scaffolding) via jsonResult/clip/buildSearchCriteria helpers — behavior preserved. Adds `email-tools.test.ts` (6 inline-path route tests). Build + 122 tests green.

Refs #166