### PR TITLE
refactor(web/server): DRY account routes + HTTP route tests (#166)

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+//
+// HTTP route tests for WebUIServer.
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+//
+// Constructs WebUIServer with injected mock DatabaseService + ImapService,
+// mounts its Express app on an ephemeral port, and exercises the account
+// routes over real HTTP via fetch — no new test dependency required. Locks
+// the route contract that the #166 re-expression touched.
+
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { WebUIServer } from './server.js';
+
+let created: any[] = [];
+let deleted: string[] = [];
+
+function makeDb() {
+  return {
+    getUserByUsername: (username: string) => ({ user_id: 'u1', username, is_active: true }),
+    createUser: (u: any) => u,
+    listDecryptedAccountsForUser: () => [
+      { account_id: 'a1', name: 'Work', username: 'me@x.com', host: 'imap.x.com', port: 993, tls: true,
+        smtp_host: 'smtp.x.com', smtp_port: 465, smtp_secure: true },
+      { account_id: 'a2', name: 'Plain', username: 'p@y.com', host: 'imap.y.com', port: 993, tls: true,
+        smtp_host: undefined },
+    ],
+    createAccount: (input: any) => { created.push(input); return { account_id: 'new-1', ...input }; },
+    deleteAccount: (id: string) => { deleted.push(id); },
+  } as any;
+}
+
+const imap = {
+  connect: async () => {},
+  disconnect: async () => {},
+  listFolders: async () => [],
+} as any;
+
+let server: http.Server;
+let base: string;
+
+beforeAll(async () => {
+  const ui = new WebUIServer({ port: 0, db: makeDb(), imapService: imap });
+  const app = (ui as any).app;
+  server = http.createServer(app);
+  await new Promise<void>((r) => server.listen(0, r));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+beforeEach(() => { created = []; deleted = []; });
+
+describe('WebUIServer /api routes', () => {
+  it('GET /api/providers returns the provider catalog', async () => {
+    const res = await fetch(`${base}/api/providers`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.find((p: any) => p.id === 'gmail')).toBeTruthy();
+  });
+
+  it('GET /api/accounts maps rows to web shape, including SMTP only when configured', async () => {
+    const res = await fetch(`${base}/api/accounts`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body[0]).toEqual({
+      id: 'a1', name: 'Work', user: 'me@x.com', host: 'imap.x.com', port: 993, tls: true,
+      smtp: { host: 'smtp.x.com', port: 465, tls: true },
+    });
+    expect(body[1].smtp).toBeUndefined();
+  });
+
+  it('POST /api/accounts auto-detects IMAP settings from the email domain', async () => {
+    const res = await fetch(`${base}/api/accounts`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'G', email: 'me@gmail.com', password: 'pw' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.account).toEqual({ id: 'new-1', name: 'G', user: 'me@gmail.com', host: 'imap.gmail.com', port: 993, tls: true });
+    expect(created[0]).toMatchObject({ host: 'imap.gmail.com', port: 993, username: 'me@gmail.com', tls: true });
+  });
+
+  it('POST /api/accounts honors an explicit host over auto-detect', async () => {
+    const res = await fetch(`${base}/api/accounts`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Custom', email: 'me@corp.com', password: 'pw', host: 'mail.corp.com', port: 143, tls: false }),
+    });
+    const body = await res.json();
+    expect(body.account.host).toBe('mail.corp.com');
+    expect(created[0]).toMatchObject({ host: 'mail.corp.com', port: 143, tls: false });
+  });
+
+  it('DELETE /api/accounts/:id disconnects and deletes', async () => {
+    const res = await fetch(`${base}/api/accounts/a1`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(deleted).toEqual(['a1']);
+  });
+});

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -17,6 +17,18 @@ import { dnsProviders } from '../providers/dns-providers.js';
 import { ImapAccount } from '../types/index.js';
 import crypto from 'crypto';
 
+/** Project a decrypted DB account row into the web UI's account shape. */
+function toWebAccount(acc: any) {
+  return {
+    id: acc.account_id,
+    name: acc.name,
+    user: acc.username,
+    host: acc.host,
+    port: acc.port,
+    tls: acc.tls,
+  };
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -165,19 +177,12 @@ export class WebUIServer {
     this.app.get('/api/accounts', (req, res) => {
       try {
         const accounts = this.db.listDecryptedAccountsForUser(this.defaultUserId);
-        // Convert to web UI format (use username instead of user field)
+        // Convert to web UI format (adds SMTP block when configured).
         const webAccounts = accounts.map(acc => ({
-          id: acc.account_id,
-          name: acc.name,
-          user: acc.username,
-          host: acc.host,
-          port: acc.port,
-          tls: acc.tls,
-          smtp: acc.smtp_host ? {
-            host: acc.smtp_host,
-            port: acc.smtp_port,
-            tls: acc.smtp_secure
-          } : undefined
+          ...toWebAccount(acc),
+          smtp: acc.smtp_host
+            ? { host: acc.smtp_host, port: acc.smtp_port, tls: acc.smtp_secure }
+            : undefined,
         }));
         res.json(webAccounts);
       } catch (error) {
@@ -190,18 +195,16 @@ export class WebUIServer {
       try {
         const { name, email, password, host, port, tls, smtp } = req.body;
 
-        // Auto-detect provider if not specified
+        // Auto-detect IMAP settings from the email domain when host is omitted.
         let imapHost = host;
         let imapPort = port;
         let useTls = tls;
 
-        if (!host && email) {
-          const provider = getProviderByEmail(email);
-          if (provider) {
-            imapHost = provider.imapHost;
-            imapPort = provider.imapPort;
-            useTls = provider.imapSecurity !== 'STARTTLS';
-          }
+        const detected = !host && email ? getProviderByEmail(email) : undefined;
+        if (detected) {
+          imapHost = detected.imapHost;
+          imapPort = detected.imapPort;
+          useTls = detected.imapSecurity !== 'STARTTLS';
         }
 
         const account = this.db.createAccount({
@@ -220,14 +223,7 @@ export class WebUIServer {
           is_active: true
         });
 
-        res.json({ success: true, account: {
-          id: account.account_id,
-          name: account.name,
-          user: account.username,
-          host: account.host,
-          port: account.port,
-          tls: account.tls
-        }});
+        res.json({ success: true, account: toWebAccount(account) });
       } catch (error) {
         res.status(400).json({
           success: false,
@@ -360,14 +356,7 @@ export class WebUIServer {
           return;
         }
 
-        res.json({ success: true, account: {
-          id: account.account_id,
-          name: account.name,
-          user: account.username,
-          host: account.host,
-          port: account.port,
-          tls: account.tls
-        }});
+        res.json({ success: true, account: toWebAccount(account) });
       } catch (error) {
         res.status(400).json({
           success: false,


### PR DESCRIPTION
Part of #166. Re-express the original web account routes via a `toWebAccount` helper (DRY across GET/POST/PUT) + tidy the auto-detect block — behavior preserved. Adds `web/server.test.ts`: a no-new-dependency HTTP harness (ephemeral `http` listener + `fetch` + injected mock db/imapService) covering `/api/providers` and `/api/accounts` GET/POST/DELETE. Establishes the web route-test pattern. Build + 127 tests green.

Refs #166