### PR TITLE
refactor(email-tools + web/server): chip remaining logic pockets (#166)

### DIFF
--- a/src/tools/email-tools.test.ts
+++ b/src/tools/email-tools.test.ts
@@ -47,11 +47,23 @@ function makeImap(overrides: Record<string, any> = {}) {
   };
 }
 
-function register(imap: any) {
+function register(imap: any, db: any = {}, smtp: any = {}) {
   const { server, tools } = makeServer();
   // results/workerPool/etc. omitted → search uses the inline path.
-  emailTools(server as any, imap as any, {} as any, {} as any);
+  emailTools(server as any, imap as any, db as any, smtp as any);
   return tools;
+}
+
+function dbWithAccount(overrides: Record<string, any> = {}) {
+  return {
+    getDecryptedAccount: () => ({
+      account_id: 'acc-1', name: 'Me', host: 'imap.x.com', port: 993,
+      username: 'me@x.com', password: 'pw', tls: true,
+      smtp_host: 'smtp.x.com', smtp_port: 465, smtp_secure: true,
+      smtp_username: 'me@x.com', smtp_password: 'pw',
+    }),
+    ...overrides,
+  };
 }
 
 describe('emailTools core routes', () => {
@@ -108,5 +120,57 @@ describe('emailTools core routes', () => {
       .toEqual({ success: true, message: 'Email 7 marked as unread' });
     expect(await invoke(tools, 'imap_delete_email', { accountId: 'a', folder: 'INBOX', uid: 7 }))
       .toEqual({ success: true, message: 'Email 7 deleted' });
+  });
+
+  it('imap_get_latest_emails returns newest-first, capped to count', async () => {
+    const out = await invoke(tools, 'imap_get_latest_emails', { accountId: 'a', folder: 'INBOX', count: 1 });
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].uid).toBe(2); // 2026-01-02 is newer than 2026-01-01
+  });
+});
+
+describe('emailTools send/reply/forward', () => {
+  it('imap_reply_to_email builds Re: subject, threads, and reply-all recipients', async () => {
+    let sent: any;
+    const smtp = { sendEmail: async (_a: string, _acc: any, composer: any) => { sent = composer; return '<msg@x>'; } };
+    const imap = makeImap({
+      getEmailContent: async () => ({ uid: 5, subject: 'Status', from: 'boss@x.com', to: ['me@x.com', 'peer@x.com'], messageId: '<orig@x>' }),
+    });
+    const tools = register(imap, dbWithAccount(), smtp);
+    const out = await invoke(tools, 'imap_reply_to_email', { accountId: 'a', folder: 'INBOX', uid: 5, text: 'ok', replyAll: true });
+    expect(out).toEqual({ success: true, messageId: '<msg@x>', message: 'Reply sent successfully' });
+    expect(sent.subject).toBe('Re: Status');
+    expect(sent.inReplyTo).toBe('<orig@x>');
+    expect(sent.references).toBe('<orig@x>');
+    // reply-all includes original recipients except self
+    expect(sent.to).toEqual(['boss@x.com', 'peer@x.com']);
+  });
+
+  it('imap_reply_to_email keeps an existing Re: prefix and excludes self on reply-all', async () => {
+    let sent: any;
+    const smtp = { sendEmail: async (_a: string, _acc: any, c: any) => { sent = c; return '<m>'; } };
+    const imap = makeImap({
+      getEmailContent: async () => ({ uid: 5, subject: 'Re: Hi', from: 'a@x.com', to: ['me@x.com'], messageId: '<o>' }),
+    });
+    const tools = register(imap, dbWithAccount(), smtp);
+    await invoke(tools, 'imap_reply_to_email', { accountId: 'a', folder: 'INBOX', uid: 5, text: 'y', replyAll: true });
+    expect(sent.subject).toBe('Re: Hi');
+    expect(sent.to).toEqual(['a@x.com']); // 'me@x.com' (self) filtered out
+  });
+
+  it('imap_forward_email builds Fwd: subject and a forwarded-message header', async () => {
+    let sent: any;
+    const smtp = { sendEmail: async (_a: string, _acc: any, c: any) => { sent = c; return '<f>'; } };
+    const imap = makeImap({
+      getEmailContent: async () => ({ uid: 9, subject: 'Doc', from: 'a@x.com', to: ['b@x.com'], date: new Date('2026-01-01T00:00:00Z'), messageId: '<o>', textContent: 'BODY' }),
+    });
+    const tools = register(imap, dbWithAccount(), smtp);
+    const out = await invoke(tools, 'imap_forward_email', { accountId: 'a', folder: 'INBOX', uid: 9, to: 'c@x.com', text: 'FYI' });
+    expect(out).toEqual({ success: true, messageId: '<f>', message: 'Email forwarded successfully' });
+    expect(sent.subject).toBe('Fwd: Doc');
+    expect(sent.to).toBe('c@x.com');
+    expect(sent.text).toContain('FYI');
+    expect(sent.text).toContain('Forwarded message');
+    expect(sent.text).toContain('BODY');
   });
 });

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -6,6 +6,7 @@ import { ResultsService, StoredResultRowSummary } from '../services/results-serv
 import { WorkerPool } from '../utils/worker-pool.js';
 import { z } from 'zod';
 import { withErrorHandling, AccountNotFoundError } from '../utils/error-handler.js';
+import { ImapAccount } from '../types/index.js';
 import {
   maybeStoreAsHandle,
   ResponseModeSchema,
@@ -134,6 +135,26 @@ function jsonResult(payload: unknown) {
 /** Cap a possibly-undefined body string to keep responses within budget. */
 function clip(text: string | undefined, max = 10000): string | undefined {
   return text?.substring(0, max);
+}
+
+/** Convert a decrypted DB account row into the ImapAccount shape the services expect. */
+function toImapAccount(dbAccount: any): ImapAccount {
+  return {
+    id: dbAccount.account_id,
+    name: dbAccount.name,
+    host: dbAccount.host,
+    port: dbAccount.port,
+    user: dbAccount.username,
+    password: dbAccount.password,
+    tls: dbAccount.tls,
+    smtp: dbAccount.smtp_host ? {
+      host: dbAccount.smtp_host,
+      port: dbAccount.smtp_port!,
+      secure: dbAccount.smtp_secure || false,
+      user: dbAccount.smtp_username,
+      password: dbAccount.smtp_password,
+    } : undefined,
+  };
 }
 
 /** Translate the search tool's flat params into an ImapService SearchCriteria. */
@@ -420,14 +441,7 @@ export function emailTools(
       });
     }
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          messages: sortedMessages,
-        }, null, 2)
-      }]
-    };
+    return jsonResult({ messages: sortedMessages });
   }));
 
   // Send email tool
@@ -522,22 +536,7 @@ export function emailTools(
       throw new AccountNotFoundError(accountId);
     }
 
-    const account = {
-      id: dbAccount.account_id,
-      name: dbAccount.name,
-      host: dbAccount.host,
-      port: dbAccount.port,
-      user: dbAccount.username,
-      password: dbAccount.password,
-      tls: dbAccount.tls,
-      smtp: dbAccount.smtp_host ? {
-        host: dbAccount.smtp_host,
-        port: dbAccount.smtp_port!,
-        secure: dbAccount.smtp_secure || false,
-        user: dbAccount.smtp_username,
-        password: dbAccount.smtp_password
-      } : undefined
-    };
+    const account = toImapAccount(dbAccount);
 
     // ---- shared attachment policy (applies to inline, path-based, staged) ----
     const {
@@ -1272,23 +1271,7 @@ export function emailTools(
       throw new AccountNotFoundError(accountId);
     }
 
-    // Convert database account to ImapAccount format
-    const account = {
-      id: dbAccount.account_id,
-      name: dbAccount.name,
-      host: dbAccount.host,
-      port: dbAccount.port,
-      user: dbAccount.username,
-      password: dbAccount.password,
-      tls: dbAccount.tls,
-      smtp: dbAccount.smtp_host ? {
-        host: dbAccount.smtp_host,
-        port: dbAccount.smtp_port!,
-        secure: dbAccount.smtp_secure || false,
-        user: dbAccount.smtp_username,
-        password: dbAccount.smtp_password
-      } : undefined
-    };
+    const account = toImapAccount(dbAccount);
 
     // Get original email
     const originalEmail = await imapService.getEmailContent(accountId, folder, uid);
@@ -1317,16 +1300,7 @@ export function emailTools(
 
     const messageId = await smtpService.sendEmail(accountId, account, emailComposer);
     
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          messageId,
-          message: 'Reply sent successfully',
-        }, null, 2)
-      }]
-    };
+    return jsonResult({ success: true, messageId, message: 'Reply sent successfully' });
   }));
 
   // Forward email tool
@@ -1346,23 +1320,7 @@ export function emailTools(
       throw new AccountNotFoundError(accountId);
     }
 
-    // Convert database account to ImapAccount format
-    const account = {
-      id: dbAccount.account_id,
-      name: dbAccount.name,
-      host: dbAccount.host,
-      port: dbAccount.port,
-      user: dbAccount.username,
-      password: dbAccount.password,
-      tls: dbAccount.tls,
-      smtp: dbAccount.smtp_host ? {
-        host: dbAccount.smtp_host,
-        port: dbAccount.smtp_port!,
-        secure: dbAccount.smtp_secure || false,
-        user: dbAccount.smtp_username,
-        password: dbAccount.smtp_password
-      } : undefined
-    };
+    const account = toImapAccount(dbAccount);
 
     // Get original email
     const originalEmail = await imapService.getEmailContent(accountId, folder, uid);
@@ -1381,16 +1339,7 @@ export function emailTools(
 
     const messageId = await smtpService.sendEmail(accountId, account, emailComposer);
 
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          messageId,
-          message: 'Email forwarded successfully',
-        }, null, 2)
-      }]
-    };
+    return jsonResult({ success: true, messageId, message: 'Email forwarded successfully' });
   }));
 
   // Level 2: Bulk get emails tool

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -16,6 +16,7 @@ import { WebUIServer } from './server.js';
 
 let created: any[] = [];
 let deleted: string[] = [];
+let updated: { id: string; updates: any }[] = [];
 
 function makeDb() {
   return {
@@ -29,6 +30,8 @@ function makeDb() {
     ],
     createAccount: (input: any) => { created.push(input); return { account_id: 'new-1', ...input }; },
     deleteAccount: (id: string) => { deleted.push(id); },
+    updateAccount: (id: string, updates: any) => { updated.push({ id, updates }); },
+    getAccount: (id: string) => ({ account_id: id, name: 'Renamed', username: 'me@x.com', host: 'imap.x.com', port: 993, tls: true }),
   } as any;
 }
 
@@ -53,7 +56,7 @@ afterAll(async () => {
   await new Promise<void>((r) => server.close(() => r()));
 });
 
-beforeEach(() => { created = []; deleted = []; });
+beforeEach(() => { created = []; deleted = []; updated = []; });
 
 describe('WebUIServer /api routes', () => {
   it('GET /api/providers returns the provider catalog', async () => {
@@ -97,6 +100,22 @@ describe('WebUIServer /api routes', () => {
     const body = await res.json();
     expect(body.account.host).toBe('mail.corp.com');
     expect(created[0]).toMatchObject({ host: 'mail.corp.com', port: 143, tls: false });
+  });
+
+  it('PUT /api/accounts/:id sends only defined fields and maps email→username', async () => {
+    const res = await fetch(`${base}/api/accounts/a1`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed', email: 'me@x.com' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(updated).toHaveLength(1);
+    expect(updated[0]).toEqual({ id: 'a1', updates: { name: 'Renamed', username: 'me@x.com' } });
+    // undefined fields (password/host/port/tls) are omitted, not nulled
+    expect(updated[0].updates).not.toHaveProperty('password');
+    expect(updated[0].updates).not.toHaveProperty('host');
   });
 
   it('DELETE /api/accounts/:id disconnects and deletes', async () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -17,6 +17,11 @@ import { dnsProviders } from '../providers/dns-providers.js';
 import { ImapAccount } from '../types/index.js';
 import crypto from 'crypto';
 
+/** Return a copy of `obj` with all `undefined`-valued keys removed. */
+function pickDefined(obj: Record<string, any>): Record<string, any> {
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined));
+}
+
 /** Project a decrypted DB account row into the web UI's account shape. */
 function toWebAccount(acc: any) {
   return {
@@ -319,13 +324,7 @@ export class WebUIServer {
       try {
         const { name, email, password, host, port, tls, smtp } = req.body;
 
-        const updates: any = {};
-        if (name !== undefined) updates.name = name;
-        if (email !== undefined) updates.username = email;
-        if (password !== undefined) updates.password = password;
-        if (host !== undefined) updates.host = host;
-        if (port !== undefined) updates.port = port;
-        if (tls !== undefined) updates.tls = tls;
+        const updates: any = pickDefined({ name, username: email, password, host, port, tls });
 
         // Handle SMTP configuration
         if ('smtp' in req.body) {


### PR DESCRIPTION
Part of #166. Genuine DRY re-expression of the two remaining logic pockets, behavior preserved:

**email-tools** — `toImapAccount()` extracts the 3× duplicated dbAccount→ImapAccount conversion (send/reply/forward); get_latest/reply/forward returns via `jsonResult`. +4 route tests (Re:/Fwd: handling, reply-all self-exclusion, threading, forward header).

**web/server** — `pickDefined()` replaces the repeated PUT update field-mapping (email→username preserved; SMTP block untouched). +1 route test.

Build + 132 tests green.

Refs #166