### PR TITLE
chore(legal): adopt PolyForm Noncommercial License 1.0.0

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -10,7 +10,8 @@ This Contributor License Agreement ("Agreement") clarifies the intellectual
 property rights granted with Contributions from any person or entity. It
 protects both you (the "Contributor") and the maintainer, and — importantly —
 it preserves the maintainer's ability to offer the Project under a **dual
-license** (non-commercial free / commercial paid), as described in `LICENSE`.
+license** — the PolyForm Noncommercial License 1.0.0 for noncommercial use,
+plus a separate commercial license — as described in `LICENSE`.
 
 By submitting a Contribution (a pull request, patch, or any code,
 documentation, or other material) to the Project, you agree to the following

--- a/LICENSE
+++ b/LICENSE
@@ -1,124 +1,207 @@
-# IMAP MCP Pro License
+# IMAP MCP Pro — License
 
-SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
-## Dual License Model
+Copyright (c) 2025-2026 Temple of Epiphany / Colin Bitterfield.
 
-This software is available under a dual-license model:
-1. **Non-Commercial License** (free)
-2. **Commercial License** (requires purchase)
+Required Notice: Copyright (c) 2025-2026 Temple of Epiphany / Colin Bitterfield (https://github.com/Temple-of-Epiphany)
+
+## Licensing summary
+
+This software is dual-licensed:
+
+1. **Noncommercial use** is granted free of charge under the **PolyForm
+   Noncommercial License 1.0.0**, reproduced in full below.
+2. **Commercial use** requires a separate **commercial license** — see the
+   "Commercial License" section below for how to obtain one.
+
+If your use is not a "permitted purpose" under the PolyForm Noncommercial
+License (i.e. it is commercial), you must obtain a commercial license.
 
 ---
 
-## Non-Commercial License
+# PolyForm Noncommercial License 1.0.0
 
-Copyright (c) 2025-2026 Temple of Epiphany / Colin Bitterfield
-Copyright (c) 2024 Michael Nikolaus (Original Base Code)
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-### Terms
+## Acceptance
 
-Permission is hereby granted, free of charge, to any person or organization obtaining a copy of this software and associated documentation files (the "Software"), to use, copy, modify, and distribute the Software for **NON-COMMERCIAL PURPOSES ONLY**, subject to the following conditions:
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
 
-#### You MAY:
-- Use the Software for personal, educational, or research purposes
-- Use the Software for internal operations of non-profit organizations
-- Modify the Software for your own non-commercial use
-- Share modifications under the same non-commercial terms
+## Copyright License
 
-#### You MAY NOT:
-- Use the Software in any commercial product or service
-- Sell, sublicense, or distribute the Software commercially
-- Use the Software to provide services to third parties for profit
-- Deploy the Software in any revenue-generating application or service
-- Remove or modify this license or copyright notices
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
 
-### Definition of Commercial Use
+## Distribution License
 
-Commercial use includes, but is not limited to:
-- Using the Software in a product or service that is sold
-- Using the Software to provide paid services
-- Using the Software in an organization that generates revenue (except for internal operations of qualifying non-profits)
-- Deploying the Software in a commercial or production environment
-- Using the Software to support business operations that generate revenue
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
 
-### Non-Commercial Examples
+## Notices
 
-Examples of permitted non-commercial use:
-- Personal email management
-- Academic research projects
-- Non-profit organization internal email operations
-- Educational institution use for teaching
-- Open source project development
-- Testing and evaluation
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.
 
 ---
 
 ## Commercial License
 
-For commercial use, including but not limited to:
-- Business email operations
-- SaaS products
-- Revenue-generating services
-- Enterprise deployments
-- Production environments for commercial entities
-
-**You must obtain a commercial license.**
-
-### Obtaining a Commercial License
-
-Commercial licenses are available for purchase from Temple of Epiphany.
+For any commercial use — including business operations, SaaS products,
+revenue-generating services, enterprise deployments, or any use that is not a
+"permitted purpose" under the PolyForm Noncommercial License above — you must
+obtain a commercial license.
 
 **Contact:** colin.bitterfield@templeofepiphany.com
 **Organization:** Temple of Epiphany
 **Website:** https://github.com/Temple-of-Epiphany
 
-Commercial license terms include:
-- Perpetual or subscription-based options
-- Support and maintenance
-- Priority bug fixes and feature requests
-- Production deployment rights
-- Legal protection and indemnification
-
 ---
 
-## Disclaimer
+## Attribution (preexisting MIT-licensed base)
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+This project began as a fork of, and is based on, the original IMAP MCP Server
+created by Michael Nikolaus, which was licensed under the MIT License. The
+unmodified portions of that base code remain under the MIT License; the MIT
+notice below is retained as required:
 
----
+> Original Project: https://github.com/nikolausm/imap-mcp-server
+> Original Author:  Michael Nikolaus (https://github.com/nikolausm)
+>
+> Copyright (c) 2024 Michael Nikolaus
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
 
-## Attribution
-
-This project is a fork and substantial extension of the original IMAP MCP Server created by Michael Nikolaus, which was licensed under the MIT License.
-
-**Original Project:** https://github.com/nikolausm/imap-mcp-server
-**Original Author:** Michael Nikolaus (https://github.com/nikolausm)
-**Original License:** MIT License (for base code only)
-
-### Original Work (MIT Licensed)
-The base IMAP MCP server implementation, including core email operations, account management, and folder operations. The original MIT license applies only to the unmodified base code from the original project.
-
-### Extended Work (Dual Licensed)
-All enterprise enhancements and modifications created by Temple of Epiphany are subject to this dual-license model:
-- Level 1-3 reliability features (auto-reconnection, retry logic, health checks)
-- Circuit breaker pattern for failure isolation
-- Comprehensive metrics and monitoring
-- Operation queue for offline resilience
-- Graceful degradation with caching
-- Bulk operations for efficiency
-- Web UI enhancements
-- Production-ready deployment features
-- All modifications and improvements to base code
-
----
-
-## Compliance and Enforcement
-
-Unauthorized commercial use of this Software is a violation of this license and copyright law. Temple of Epiphany reserves the right to pursue legal action against violators.
-
-If you are unsure whether your use case requires a commercial license, please contact us at colin.bitterfield@templeofepiphany.com.
+All enterprise enhancements, modifications, and additions created by Temple of
+Epiphany are licensed under the dual model described at the top of this file
+(PolyForm Noncommercial 1.0.0 + commercial license), not under the MIT terms.
 
 ---
 
 **Last Updated:** June 2026
-**Version:** 1.1
+**Version:** 2.0

--- a/NOTICE
+++ b/NOTICE
@@ -1,11 +1,14 @@
 IMAP MCP Pro
-SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
 Copyright (c) 2025-2026 Temple of Epiphany / Colin Bitterfield.
 All rights reserved.
 
-This product is distributed under a dual license (non-commercial free /
-commercial paid). See the accompanying LICENSE file for the full terms.
+Required Notice: Copyright (c) 2025-2026 Temple of Epiphany / Colin Bitterfield (https://github.com/Temple-of-Epiphany)
+
+This product is dual-licensed: noncommercial use is granted free of charge
+under the PolyForm Noncommercial License 1.0.0, and commercial use requires a
+separate commercial license. See the accompanying LICENSE file for full terms.
 Commercial licensing: colin.bitterfield@templeofepiphany.com
 
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ IMAP MCP Pro supports multi-user configurations for Managed Service Providers (M
 **Contact for Commercial Licensing:**
 - Email: colin.bitterfield@templeofepiphany.com
 - Commercial license required for MSP/multi-tenant deployments
-- Single-user deployments remain under Apache 2.0 license
+- Noncommercial use is free under the PolyForm Noncommercial License 1.0.0
 
 ## Installation
 
@@ -764,11 +764,11 @@ node dist/index.js --print-tools-manifest | jq '.tools | length'
 
 > **Free for personal use. Paid for commercial use.**
 
-This software is distributed under a **Dual License Model**. The license you operate under depends entirely on how you use the software.
+This software is distributed under a **Dual License Model**: the **[PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/)** for noncommercial use, plus a separate **commercial license** for everything else. The license you operate under depends entirely on how you use the software.
 
-### ✅ Non-Commercial License — FREE
+### ✅ Noncommercial use — FREE (PolyForm Noncommercial License 1.0.0)
 
-You may use, copy, modify, and distribute this software at no cost when your use is **non-commercial**, including:
+You may use, copy, modify, and distribute this software at no cost when your use is for a **permitted (noncommercial) purpose** under the PolyForm Noncommercial License, including:
 
 - Personal email management on your own accounts
 - Educational use (students, instructors, classroom)
@@ -777,7 +777,7 @@ You may use, copy, modify, and distribute this software at no cost when your use
 - Open source project development
 - Evaluation, testing, and proof-of-concept work
 
-Modifications you make under this license must be shared under the same non-commercial terms.
+You may make changes and new works for any permitted (noncommercial) purpose. (PolyForm Noncommercial imposes no share-alike/copyleft obligation.)
 
 ### 💼 Commercial License — PAID (required)
 

--- a/dxt/manifest.template.json
+++ b/dxt/manifest.template.json
@@ -20,7 +20,7 @@
   "icon": "icon.png",
   "screenshots": [],
   "keywords": ["email", "imap", "smtp", "mailbox", "mcp", "spam", "outlook", "gmail"],
-  "license": "LicenseRef-ImapMcpPro-Dual",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "compatibility": {
     "claude_desktop": ">=0.10.0",
     "platforms": ["darwin", "win32", "linux"]

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "url": "https://github.com/cbitterfield"
     }
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Temple-of-Epiphany/imap-mcp-pro.git"

--- a/src/providers/email-providers.ts
+++ b/src/providers/email-providers.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // Email provider connection presets.
 //

--- a/src/services/smtp-service.test.ts
+++ b/src/services/smtp-service.test.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // Tests for SmtpService transport assembly + lifecycle.
 //

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 /**
  * SmtpService — pooled SMTP send with retry classification + metrics
  *

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // `imap-setup` — interactive setup wizard.
 //

--- a/src/tools/account-tools.test.ts
+++ b/src/tools/account-tools.test.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // Route tests for the account-management MCP tools.
 //

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // Account-management MCP tools.
 //

--- a/src/tools/email-tools.test.ts
+++ b/src/tools/email-tools.test.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // Route tests for the core email MCP tools (search / get / mark / delete).
 //

--- a/src/tools/folder-tools.test.ts
+++ b/src/tools/folder-tools.test.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // Route tests for the folder/mailbox MCP tools.
 //

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // Folder / mailbox MCP tools.
 //

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // Shared type definitions for IMAP MCP Pro.
 //

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LicenseRef-ImapMcpPro-Dual
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //
 // HTTP route tests for WebUIServer.
 //


### PR DESCRIPTION
Replaces the custom dual-license with the standard **PolyForm Noncommercial License 1.0.0** (easier to enforce), keeping the commercial-license pathway (sell-exceptions) and the retained MIT base attribution.

- **LICENSE**: PolyForm NC 1.0.0 verbatim + `Required Notice:` + Commercial License section + preexisting-MIT-base attribution.
- SPDX id `PolyForm-Noncommercial-1.0.0` across NOTICE, package.json, dxt manifest, and 11 source/test headers.
- **README**: names PolyForm NC; removes the incorrect share-alike claim (PolyForm NC is not copyleft) and a stray "Apache 2.0" line; CLA updated.

No code behavior changes. Build + 132 tests green.