### PR TITLE
fix(registry): shorten server.json description to <=100 chars

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Temple-of-Epiphany/imap-mcp-pro",
   "title": "IMAP MCP Pro",
-  "description": "Production-grade IMAP & SMTP integration for Claude. Connect any IMAP account, search and triage at scale, send messages with attachments, and run spam/domain checks via the UserCheck integration.",
+  "description": "Production IMAP & SMTP for Claude: multi-account email search, triage, send, and spam checks.",
   "version": "2.17.16",
   "repository": {
     "url": "https://github.com/Temple-of-Epiphany/imap-mcp-pro",


### PR DESCRIPTION
The MCP Registry's `ServerDetail.description` has `maxLength: 100`; our description was ~195 chars, causing the v2.18.0 `mcp-publisher publish` to fail with a 422. Trimmed to 93 chars. (OIDC auth + the `io.github.Temple-of-Epiphany` namespace validated fine.)