### PR TITLE
fix: honor configured IMAP_MCP_DATABASE_PATH / Data Directory (#187)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,12 @@ const {
     // 3. Database (auto-migrations run here; ledger v1.7.0 in usual case)
     let db: DatabaseService;
     try {
-      db = new DatabaseService();
+      // Honor the configured database path (IMAP_MCP_DATABASE_PATH →
+      // config.database.path), e.g. Claude Desktop's "Data Directory"
+      // user_config. Previously this was constructed with no args, so the
+      // configured path was silently ignored and every install used the
+      // default ~/.imap-mcp/data.db.
+      db = new DatabaseService({ dbPath: config.database.path });
     } catch (e: any) {
       logEvent('[startup]', { stage: 'pre-handshake', outcome: 'error', component: 'DatabaseService', error: e?.message });
       process.exit(EXIT_CODES.DATABASE_ERROR);


### PR DESCRIPTION
`index.ts` constructed `new DatabaseService()` with no args → the configured DB path (`IMAP_MCP_DATABASE_PATH` → `config.database.path`, incl. Claude Desktop's "Data Directory") was **silently ignored**; every install used `~/.imap-mcp/data.db`. Found while sandbox-testing the v2.18.0 install. Fix passes the resolved path through. Verified sandbox redirect works and production is untouched; 132 tests green.

Fixes #187