### PR TITLE
feat(email): imap_get_email_sizes + human-readable byte displays (#169)

### DIFF
--- a/src/services/attachment-validator.ts
+++ b/src/services/attachment-validator.ts
@@ -24,6 +24,7 @@ import os from 'os';
 import path from 'path';
 import { lookup as mimeLookup } from 'mime-types';
 import { DatabaseService } from './database-service.js';
+import { humanBytes } from '../utils/human-bytes.js';
 
 /**
  * Per-user attachment outbox directory (#148). Server-managed sanctioned
@@ -368,9 +369,9 @@ export function formatValidationErrors(errors: ValidationFailure[]): string[] {
           'allow-list and completes in one round-trip.'
         );
       case 'size-exceeds-per-attachment':
-        return `Attachment exceeds per-file limit: ${e.path} (${e.sizeBytes} bytes > ${e.limitBytes})`;
+        return `Attachment exceeds per-file limit: ${e.path} (${humanBytes(e.sizeBytes)} > ${humanBytes(e.limitBytes)})`;
       case 'aggregate-size-exceeds':
-        return `Aggregate attachments exceed limit at ${e.pendingPath}: ${e.totalBytes} bytes > ${e.limitBytes}`;
+        return `Aggregate attachments exceed limit at ${e.pendingPath}: ${humanBytes(e.totalBytes)} > ${humanBytes(e.limitBytes)}`;
       case 'no-allowed-dirs-configured':
         return (
           'No allowed attachment directories configured for path-based attachments — including ' +

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -41,6 +41,26 @@ import { LRUCache } from '../utils/memory-manager.js';
 import { WorkerPool } from '../utils/worker-pool.js';
 import { ContextReductionConfig as Cfg } from '../config/context-reduction.js';
 
+/** Per-message size + light envelope info from a RFC822.SIZE fetch (no body). */
+export interface EmailSizeInfo {
+  uid: number;
+  size: number;           // RFC822.SIZE in bytes (headers + body + encoded attachments)
+  subject: string;
+  from: string;
+  date: Date;
+  hasAttachments: boolean;
+}
+
+/** Best-effort: does a fetched bodyStructure contain an attachment disposition? */
+function bodyStructureHasAttachment(node: any): boolean {
+  if (!node) return false;
+  const disp = (node.disposition || '').toString().toLowerCase();
+  if (disp === 'attachment') return true;
+  const children = node.childNodes || node.children;
+  if (Array.isArray(children)) return children.some(bodyStructureHasAttachment);
+  return false;
+}
+
 export class ImapService {
   private activeConnections: Map<string, ImapFlow> = new Map();
   private connectionMetadata: Map<string, ConnectionMetadata> = new Map();
@@ -907,6 +927,52 @@ export class ImapService {
 
       return messages;
     }, `searchEmails(${folderName})`);
+  }
+
+  /**
+   * Fetch per-message sizes (RFC822.SIZE) plus light envelope info for a folder
+   * or an explicit UID set. No message bodies are downloaded — size, envelope,
+   * and bodyStructure are all metadata-only FETCH items, so this is cheap even
+   * across large folders. Used by imap_get_email_sizes to find large messages.
+   */
+  async getEmailSizes(
+    accountId: string,
+    folderName: string,
+    options?: { uids?: number[] }
+  ): Promise<EmailSizeInfo[]> {
+    return this.withRetry(accountId, async () => {
+      const client = this.getConnection(accountId);
+      await client.mailboxOpen(folderName);
+
+      // Range: explicit UIDs, or every message in the folder.
+      let range: any;
+      if (options?.uids && options.uids.length > 0) {
+        range = options.uids.join(',');
+      } else {
+        const all = await client.search({ all: true }, { uid: true });
+        if (!all || all.length === 0) return [];
+        range = all;
+      }
+
+      const sizes: EmailSizeInfo[] = [];
+      for await (const msg of client.fetch(range, {
+        uid: true,
+        size: true,
+        envelope: true,
+        bodyStructure: true
+      }, { uid: true })) {
+        sizes.push({
+          uid: msg.uid,
+          size: msg.size ?? 0,
+          subject: msg.envelope?.subject || '',
+          from: msg.envelope?.from?.[0]?.address || '',
+          date: msg.envelope?.date || new Date(),
+          hasAttachments: bodyStructureHasAttachment(msg.bodyStructure)
+        });
+      }
+
+      return sizes;
+    }, `getEmailSizes(${folderName})`);
   }
 
   private buildImapFlowSearchQuery(criteria: SearchCriteria): any {

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -65,6 +65,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_search_emails':                READ_REMOTE,
   'imap_get_email':                    READ_REMOTE,
   'imap_get_latest_emails':            READ_REMOTE,
+  'imap_get_email_sizes':              READ_REMOTE,
   'imap_get_unread_count':             READ_REMOTE,
   'imap_bulk_get_emails':              READ_REMOTE,
   'imap_bulk_get_emails_chunked':      READ_REMOTE,

--- a/src/tools/email-tools.test.ts
+++ b/src/tools/email-tools.test.ts
@@ -43,6 +43,11 @@ function makeImap(overrides: Record<string, any> = {}) {
     markAsRead: async () => {},
     markAsUnread: async () => {},
     deleteEmail: async () => {},
+    getEmailSizes: async () => [
+      { uid: 1, size: 2048, subject: 'small', from: 'a@x.com', date: new Date('2026-01-01'), hasAttachments: false },
+      { uid: 2, size: 15 * 1024 * 1024, subject: 'big', from: 'b@x.com', date: new Date('2026-01-02'), hasAttachments: true },
+      { uid: 3, size: 5 * 1024 * 1024, subject: 'medium', from: 'c@x.com', date: new Date('2026-01-03'), hasAttachments: true },
+    ],
     ...overrides,
   };
 }
@@ -126,6 +131,26 @@ describe('emailTools core routes', () => {
     const out = await invoke(tools, 'imap_get_latest_emails', { accountId: 'a', folder: 'INBOX', count: 1 });
     expect(out.messages).toHaveLength(1);
     expect(out.messages[0].uid).toBe(2); // 2026-01-02 is newer than 2026-01-01
+  });
+
+  it('imap_get_email_sizes returns largest-first with human-readable sizes + uids', async () => {
+    const out = await invoke(tools, 'imap_get_email_sizes', { accountId: 'a', folder: 'INBOX' });
+    expect(out.scanned).toBe(3);
+    expect(out.messages.map((m: any) => m.uid)).toEqual([2, 3, 1]); // size desc
+    expect(out.messages[0]).toMatchObject({ uid: 2, size: 15 * 1024 * 1024, sizeHuman: '15.00 MB', hasAttachments: true });
+    expect(out.messages[2].sizeHuman).toBe('2.00 KB');
+    expect(out.uids).toEqual([2, 3, 1]); // ready for bulk delete/move
+    expect(out.totalMatchedHuman).toBe('20.00 MB');
+  });
+
+  it('imap_get_email_sizes filters by minSizeBytes and respects limit + asc order', async () => {
+    const big = await invoke(tools, 'imap_get_email_sizes', { accountId: 'a', folder: 'INBOX', minSizeBytes: 10 * 1024 * 1024 });
+    expect(big.matched).toBe(1);
+    expect(big.messages.map((m: any) => m.uid)).toEqual([2]);
+
+    const asc = await invoke(tools, 'imap_get_email_sizes', { accountId: 'a', folder: 'INBOX', order: 'asc', limit: 2 });
+    expect(asc.returned).toBe(2);
+    expect(asc.messages.map((m: any) => m.uid)).toEqual([1, 3]); // smallest first, capped
   });
 });
 

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -7,6 +7,7 @@ import { WorkerPool } from '../utils/worker-pool.js';
 import { z } from 'zod';
 import { withErrorHandling, AccountNotFoundError } from '../utils/error-handler.js';
 import { ImapAccount } from '../types/index.js';
+import { humanBytes } from '../utils/human-bytes.js';
 import {
   maybeStoreAsHandle,
   ResponseModeSchema,
@@ -136,6 +137,7 @@ function jsonResult(payload: unknown) {
 function clip(text: string | undefined, max = 10000): string | undefined {
   return text?.substring(0, max);
 }
+
 
 /** Convert a decrypted DB account row into the ImapAccount shape the services expect. */
 function toImapAccount(dbAccount: any): ImapAccount {
@@ -326,6 +328,48 @@ export function emailTools(
   }, withErrorHandling(async ({ accountId, folder, uid }) => {
     await imapService.deleteEmail(accountId, folder, uid);
     return jsonResult({ success: true, message: `Email ${uid} deleted` });
+  }));
+
+  // Get email sizes — find large messages via RFC822.SIZE, no body download (#169)
+  server.registerTool('imap_get_email_sizes', {
+    description:
+      'List messages by size to find large emails — uses RFC822.SIZE (no body download, cheap even on big folders). ' +
+      'Scan a whole folder or a specific UID set, optionally filter with minSizeBytes, sorted largest-first. ' +
+      'The returned `uids` array can be passed straight to imap_bulk_delete_emails or imap_bulk_move_emails to clear space.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder to scan (default: INBOX)'),
+      uids: z.array(z.number()).optional().describe('Specific UIDs to size; omit to scan the whole folder'),
+      minSizeBytes: z.number().optional().describe('Only return messages at least this many bytes (e.g. 10485760 = 10 MiB)'),
+      limit: z.number().optional().default(100).describe('Max messages to return, largest first (default 100)'),
+      order: z.enum(['desc', 'asc']).optional().default('desc').describe("Sort by size: 'desc' = largest first (default), 'asc' = smallest first"),
+    }
+  }, withErrorHandling(async ({ accountId, folder, uids, minSizeBytes, limit, order }) => {
+    const all = await imapService.getEmailSizes(accountId, folder, { uids });
+    const matched = minSizeBytes != null ? all.filter(m => m.size >= minSizeBytes) : all.slice();
+    matched.sort((a, b) => (order === 'asc' ? a.size - b.size : b.size - a.size));
+    const limited = matched.slice(0, limit ?? 100);
+    const matchedBytes = matched.reduce((sum, m) => sum + m.size, 0);
+
+    return jsonResult({
+      folder,
+      scanned: all.length,
+      matched: matched.length,
+      returned: limited.length,
+      totalMatchedBytes: matchedBytes,
+      totalMatchedHuman: humanBytes(matchedBytes),
+      messages: limited.map(m => ({
+        uid: m.uid,
+        size: m.size,
+        sizeHuman: humanBytes(m.size),
+        subject: m.subject,
+        from: m.from,
+        date: toIsoDate(m.date),
+        hasAttachments: m.hasAttachments,
+      })),
+      // Convenience: ready to pass to imap_bulk_delete_emails / imap_bulk_move_emails.
+      uids: limited.map(m => m.uid),
+    });
   }));
 
   // Bulk delete emails tool
@@ -645,11 +689,11 @@ export function emailTools(
             continue;
           }
           if (contentBuf.length > maxBytes) {
-            inlineErrors.push({ kind: 'size-exceeds-per-attachment', detail: `Inline attachment '${cleanName}' is ${contentBuf.length} bytes, exceeds per-attachment cap of ${maxBytes} bytes (override IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES).` });
+            inlineErrors.push({ kind: 'size-exceeds-per-attachment', detail: `Inline attachment '${cleanName}' is ${humanBytes(contentBuf.length)}, exceeds per-attachment cap of ${humanBytes(maxBytes)} (override IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES).` });
             continue;
           }
           if (runningTotalBytes + contentBuf.length > maxTotalBytes) {
-            inlineErrors.push({ kind: 'aggregate-size-exceeds', detail: `Inline attachment '${cleanName}' would push aggregate size to ${runningTotalBytes + contentBuf.length} bytes, exceeds total cap of ${maxTotalBytes} bytes (override IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES, or move large files to imap_attachment_stage_*).` });
+            inlineErrors.push({ kind: 'aggregate-size-exceeds', detail: `Inline attachment '${cleanName}' would push aggregate size to ${humanBytes(runningTotalBytes + contentBuf.length)}, exceeds total cap of ${humanBytes(maxTotalBytes)} (override IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES, or move large files to imap_attachment_stage_*).` });
             continue;
           }
           runningTotalBytes += contentBuf.length;
@@ -681,7 +725,7 @@ export function emailTools(
           }
           for (const a of result.attachments) {
             if (runningTotalBytes + a.sizeBytes > maxTotalBytes) {
-              inlineErrors.push({ kind: 'aggregate-size-exceeds', detail: `Inline path attachment '${a.filename}' would push aggregate size to ${runningTotalBytes + a.sizeBytes} bytes, exceeds total cap of ${maxTotalBytes} bytes (override IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES).` });
+              inlineErrors.push({ kind: 'aggregate-size-exceeds', detail: `Inline path attachment '${a.filename}' would push aggregate size to ${humanBytes(runningTotalBytes + a.sizeBytes)}, exceeds total cap of ${humanBytes(maxTotalBytes)} (override IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES).` });
               continue;
             }
             runningTotalBytes += a.sizeBytes;
@@ -767,11 +811,11 @@ export function emailTools(
         }
         const stagedSize = f.size;
         if (stagedSize > maxBytes) {
-          stagedErrors.push({ kind: 'size-exceeds-per-attachment', detail: `Staged attachment '${cleanName}' is ${stagedSize} bytes, exceeds per-attachment cap of ${maxBytes} (override IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES).` });
+          stagedErrors.push({ kind: 'size-exceeds-per-attachment', detail: `Staged attachment '${cleanName}' is ${humanBytes(stagedSize)}, exceeds per-attachment cap of ${humanBytes(maxBytes)} (override IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES).` });
           continue;
         }
         if (runningTotalBytes + stagedSize > maxTotalBytes) {
-          stagedErrors.push({ kind: 'aggregate-size-exceeds', detail: `Staged attachment '${cleanName}' would push aggregate size to ${runningTotalBytes + stagedSize} bytes, exceeds total cap of ${maxTotalBytes} (override IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES).` });
+          stagedErrors.push({ kind: 'aggregate-size-exceeds', detail: `Staged attachment '${cleanName}' would push aggregate size to ${humanBytes(runningTotalBytes + stagedSize)}, exceeds total cap of ${humanBytes(maxTotalBytes)} (override IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES).` });
           continue;
         }
         runningTotalBytes += stagedSize;

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -14,6 +14,7 @@ import { ImapService } from '../services/imap-service.js';
 import { DatabaseService } from '../services/database-service.js';
 import { Folder } from '../types/index.js';
 import { withErrorHandling } from '../utils/error-handler.js';
+import { humanBytes } from '../utils/human-bytes.js';
 
 /** Wrap any payload as a pretty-printed JSON text tool result. */
 function jsonResult(payload: unknown) {
@@ -33,11 +34,6 @@ function summarizeFolder(folder: Folder) {
     attributes: folder.attributes,
     hasChildren: Array.isArray(folder.children) && folder.children.length > 0,
   };
-}
-
-/** Format a byte count as "N.NN MB". */
-function megabytes(bytes: number): string {
-  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
 }
 
 const accountId = z.string().describe('Account ID');
@@ -195,7 +191,7 @@ export function folderTools(
         totalMailboxes: statuses.length,
         totalMessages,
         totalUnseen,
-        totalSize: totalSize > 0 ? megabytes(totalSize) : 'N/A',
+        totalSize: totalSize > 0 ? humanBytes(totalSize) : 'N/A',
       },
       mailboxes: statuses.map((status) => ({
         mailbox: status.mailbox,
@@ -204,7 +200,7 @@ export function folderTools(
         uidNext: status.uidNext,
         uidValidity: status.uidValidity.toString(),
         deleted: status.deleted,
-        size: status.size ? megabytes(status.size) : undefined,
+        size: status.size ? humanBytes(status.size) : undefined,
       })),
     });
   }));

--- a/src/tools/result-tools.ts
+++ b/src/tools/result-tools.ts
@@ -17,6 +17,7 @@ import { DatabaseService } from '../services/database-service.js';
 import { ResultsService } from '../services/results-service.js';
 import { withErrorHandling } from '../utils/error-handler.js';
 import { withUserAuthorization } from './tool-context.js';
+import { humanBytes } from '../utils/human-bytes.js';
 
 export function resultTools(
   server: McpServer,
@@ -141,6 +142,7 @@ export function resultTools(
                       filename: a.filename,
                       contentType: a.content_type,
                       sizeBytes: a.size_bytes,
+                      sizeHuman: humanBytes(a.size_bytes),
                       checksumSha256: a.checksum_sha256,
                       skipped: !!a.skipped,
                     });

--- a/src/utils/human-bytes.test.ts
+++ b/src/utils/human-bytes.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+import { describe, expect, it } from 'vitest';
+import { humanBytes } from './human-bytes.js';
+
+describe('humanBytes', () => {
+  it('renders sub-KB as whole bytes', () => {
+    expect(humanBytes(0)).toBe('0 B');
+    expect(humanBytes(512)).toBe('512 B');
+    expect(humanBytes(1023)).toBe('1023 B');
+  });
+
+  it('steps adaptively through KB/MB/GB/TB', () => {
+    expect(humanBytes(1024)).toBe('1.00 KB');
+    expect(humanBytes(10 * 1024)).toBe('10.00 KB');
+    expect(humanBytes(10 * 1024 * 1024)).toBe('10.00 MB');
+    expect(humanBytes(2 * 1024 * 1024 * 1024)).toBe('2.00 GB');
+    expect(humanBytes(3 * 1024 ** 4)).toBe('3.00 TB');
+  });
+
+  it('does not surface raw byte counts for large values', () => {
+    expect(humanBytes(10_000_000_000)).toBe('9.31 GB');
+    expect(humanBytes(10_000_000_000)).not.toMatch(/\d{6,} B/);
+  });
+
+  it('clamps invalid/negative input to 0 B', () => {
+    expect(humanBytes(-5)).toBe('0 B');
+    expect(humanBytes(NaN)).toBe('0 B');
+    expect(humanBytes(Infinity)).toBe('0 B');
+  });
+});

--- a/src/utils/human-bytes.ts
+++ b/src/utils/human-bytes.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Human-readable byte formatting.
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+// Part of: IMAP MCP Pro (Temple of Epiphany)
+//
+// Single source of truth for rendering byte counts to users — adaptive units
+// (B / KB / MB / GB / TB / PB) so nothing surfaces a raw "10000000000 bytes".
+
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const;
+
+/**
+ * Format a byte count as an adaptive human-readable string.
+ *   512        -> "512 B"
+ *   10240      -> "10.00 KB"
+ *   10485760   -> "10.00 MB"
+ *   2147483648 -> "2.00 GB"
+ *
+ * Uses binary (1024) steps. Values below 1 KB render as whole bytes; larger
+ * values use two decimals. Negative/NaN inputs clamp to "0 B".
+ */
+export function humanBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return `${value.toFixed(2)} ${UNITS[unit]}`;
+}


### PR DESCRIPTION
**#169** — `imap_get_email_sizes`: find large messages via RFC822.SIZE (no body download), filter by `minSizeBytes`, largest-first, returns sizes (raw + human), aggregate total, and a `uids` array ready for `imap_bulk_delete_emails`/`imap_bulk_move_emails`.

**Human-readable bytes everywhere** (per request): new shared `human-bytes` util (adaptive B/KB/MB/GB/TB) used by the size tool, mailbox-status (was MB-only), attachment-size errors, and result attachment listings. No more raw `10000000000 bytes`.

Tests 132 → 138. Build green.

Refs #169