### PR TITLE
feat(email): imap_export_email — download & save messages as .eml (#170)

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -975,6 +975,42 @@ export class ImapService {
     }, `getEmailSizes(${folderName})`);
   }
 
+  /**
+   * Fetch the raw RFC822 source (plus light envelope info for filename
+   * construction) for a set of UIDs in one pass. Used by the .eml export
+   * tools — the source buffer IS the on-disk .eml (lossless; attachments and
+   * inline images preserved exactly as received).
+   */
+  async getRawMessages(
+    accountId: string,
+    folderName: string,
+    uids: number[]
+  ): Promise<Array<{ uid: number; source: Buffer; subject: string; from: string; date: Date }>> {
+    return this.withRetry(accountId, async () => {
+      const out: Array<{ uid: number; source: Buffer; subject: string; from: string; date: Date }> = [];
+      if (uids.length === 0) return out;
+
+      const client = this.getConnection(accountId);
+      await client.mailboxOpen(folderName);
+
+      for await (const msg of client.fetch(uids.join(','), {
+        uid: true,
+        source: true,
+        envelope: true
+      }, { uid: true })) {
+        if (!msg.source) continue;
+        out.push({
+          uid: msg.uid,
+          source: msg.source as Buffer,
+          subject: msg.envelope?.subject || '',
+          from: msg.envelope?.from?.[0]?.address || '',
+          date: msg.envelope?.date || new Date()
+        });
+      }
+      return out;
+    }, `getRawMessages(${folderName}, ${uids.length} uids)`);
+  }
+
   private buildImapFlowSearchQuery(criteria: SearchCriteria): any {
     const query: any = {};
 

--- a/src/services/message-export-service.test.ts
+++ b/src/services/message-export-service.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { MessageExportService, ExportItem } from './message-export-service.js';
+
+function item(overrides: Partial<ExportItem> = {}): ExportItem {
+  return {
+    uid: 7,
+    source: Buffer.from('From: a@x.com\r\nSubject: Hi\r\n\r\nbody\r\n'),
+    subject: 'Quarterly Report',
+    from: 'sender@example.com',
+    date: new Date('2026-03-04T12:00:00'),
+    ...overrides,
+  };
+}
+
+describe('MessageExportService.buildFilename', () => {
+  const svc = new MessageExportService();
+
+  it('builds a date_from_subject_uid .eml name', () => {
+    expect(svc.buildFilename(item())).toBe('2026-03-04_sender_Quarterly-Report_uid7.eml');
+  });
+
+  it('sanitizes unsafe characters and slashes', () => {
+    const name = svc.buildFilename(item({ subject: 'Re: invoice / 2026 *final*', from: 'a/b@x.com', uid: 12 }));
+    expect(name.endsWith('_uid12.eml')).toBe(true);
+    expect(name).not.toMatch(/[\\/*]/);
+  });
+
+  it('falls back to "untitled" for empty subject/from', () => {
+    const name = svc.buildFilename(item({ subject: '', from: '', uid: 3 }));
+    expect(name).toBe('2026-03-04_untitled_untitled_uid3.eml');
+  });
+});
+
+describe('MessageExportService.exportEml', () => {
+  let dir: string;
+  const svc = new MessageExportService();
+  beforeEach(async () => { dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mexport-')); });
+  afterEach(async () => { await fs.rm(dir, { recursive: true, force: true }); });
+
+  it('writes each message as a .eml file with verbatim source and returns a manifest', async () => {
+    const out = path.join(dir, 'exports');
+    const items = [
+      item({ uid: 1, source: Buffer.from('RAW-ONE') }),
+      item({ uid: 2, source: Buffer.from('RAW-TWO-LONGER') }),
+    ];
+    const res = await svc.exportEml(out, items);
+
+    expect(res.count).toBe(2);
+    expect(res.totalBytes).toBe(Buffer.from('RAW-ONE').length + Buffer.from('RAW-TWO-LONGER').length);
+    expect(res.files).toHaveLength(2);
+
+    for (const f of res.files) {
+      const onDisk = await fs.readFile(f.path);
+      const original = items.find(i => i.uid === f.uid)!.source;
+      expect(onDisk.equals(original)).toBe(true); // lossless, verbatim
+      expect(f.path.startsWith(out)).toBe(true);
+      expect(f.filename.endsWith('.eml')).toBe(true);
+    }
+  });
+
+  it('creates the output directory if missing', async () => {
+    const nested = path.join(dir, 'a', 'b', 'exports');
+    const res = await svc.exportEml(nested, [item()]);
+    expect(res.count).toBe(1);
+    await expect(fs.stat(nested)).resolves.toBeTruthy();
+  });
+
+  it('returns an empty manifest for no items', async () => {
+    const res = await svc.exportEml(path.join(dir, 'empty'), []);
+    expect(res).toMatchObject({ count: 0, totalBytes: 0, files: [] });
+  });
+});

--- a/src/services/message-export-service.ts
+++ b/src/services/message-export-service.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// MessageExportService — write messages to disk as standard .eml files.
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+// Part of: IMAP MCP Pro (Temple of Epiphany)
+//
+// .eml is the raw RFC822 source written verbatim: lossless, portable, and
+// attachments + inline images + all headers are inherently preserved (they ARE
+// the bytes). This service only handles the local-filesystem side; fetching the
+// raw source is ImapService.getRawMessages(). All processing is local.
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { sanitizeFilename } from './attachment-validator.js';
+
+/** One message to write: raw RFC822 source + envelope bits for the filename. */
+export interface ExportItem {
+  uid: number;
+  source: Buffer;
+  subject: string;
+  from: string;
+  date: Date;
+}
+
+export interface ExportedFile {
+  uid: number;
+  filename: string;
+  path: string;
+  bytes: number;
+}
+
+export interface ExportResult {
+  outputDir: string;
+  count: number;
+  totalBytes: number;
+  files: ExportedFile[];
+}
+
+/** Collapse a string to a filesystem-safe slug (letters/digits/_/-). */
+function slug(input: string, max = 40): string {
+  const s = (input || '')
+    .normalize('NFKD')
+    .replace(/[^\w.-]+/g, '-')   // non-word → dash
+    .replace(/-+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, max);
+  return s || 'untitled';
+}
+
+/** Local-date stamp (YYYY-MM-DD) for the filename. */
+function dateStamp(d: Date): string {
+  if (!(d instanceof Date) || isNaN(d.getTime())) return '0000-00-00';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export class MessageExportService {
+  /**
+   * Build a deterministic, collision-safe `.eml` filename for a message:
+   *   YYYY-MM-DD_<from-slug>_<subject-slug>_uid<uid>.eml
+   * The trailing UID guarantees uniqueness even for identical subjects/senders.
+   */
+  buildFilename(item: ExportItem): string {
+    const fromLocal = (item.from || '').split('@')[0];
+    const name = `${dateStamp(item.date)}_${slug(fromLocal, 24)}_${slug(item.subject, 48)}_uid${item.uid}.eml`;
+    return sanitizeFilename(name);
+  }
+
+  /**
+   * Write each item's raw source as a `.eml` file into `outputDir` (created if
+   * needed, mode 0700). Returns a manifest of what was written.
+   */
+  async exportEml(outputDir: string, items: ExportItem[]): Promise<ExportResult> {
+    await fs.mkdir(outputDir, { recursive: true, mode: 0o700 });
+
+    const files: ExportedFile[] = [];
+    let totalBytes = 0;
+    for (const item of items) {
+      const filename = this.buildFilename(item);
+      const fullPath = path.join(outputDir, filename);
+      await fs.writeFile(fullPath, item.source);
+      files.push({ uid: item.uid, filename, path: fullPath, bytes: item.source.length });
+      totalBytes += item.source.length;
+    }
+
+    return { outputDir, count: files.length, totalBytes, files };
+  }
+}

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -66,6 +66,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_get_email':                    READ_REMOTE,
   'imap_get_latest_emails':            READ_REMOTE,
   'imap_get_email_sizes':              READ_REMOTE,
+  'imap_export_email':                 READ_REMOTE,
   'imap_get_unread_count':             READ_REMOTE,
   'imap_bulk_get_emails':              READ_REMOTE,
   'imap_bulk_get_emails_chunked':      READ_REMOTE,

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -15,6 +15,9 @@ import {
 } from './result-envelope.js';
 import { getToolContext } from './tool-context.js';
 import { ContextReductionConfig as Cfg } from '../config/context-reduction.js';
+import { getOutboxDir, sanitizeFilename } from '../services/attachment-validator.js';
+import { MessageExportService } from '../services/message-export-service.js';
+import path from 'path';
 
 type ResponseModeOpt = 'auto' | 'inline' | 'handle' | 'file' | undefined;
 type StorageTypeOpt = 'temp' | 'persistent' | undefined;
@@ -369,6 +372,48 @@ export function emailTools(
       })),
       // Convenience: ready to pass to imap_bulk_delete_emails / imap_bulk_move_emails.
       uids: limited.map(m => m.uid),
+    });
+  }));
+
+  // Export messages to standard .eml files on disk — download & save (#170)
+  server.registerTool('imap_export_email', {
+    description:
+      'Export one or more messages to standard .eml files on the server host (download & save). ' +
+      '.eml is the raw RFC822 source — lossless, opens in Outlook/Thunderbird/Apple Mail, with attachments ' +
+      'and inline images preserved. Files are written under the per-user outbox ' +
+      '(~/.imap-mcp/users/{userId}/outbox/exports/), optionally grouped in a named subfolder. All processing is local.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder containing the messages (default: INBOX)'),
+      uids: z.array(z.number()).min(1).describe('UIDs of the messages to export'),
+      subfolder: z.string().optional().describe('Optional subfolder name under exports/ to group the files (sanitized to a single path segment)'),
+    }
+  }, withErrorHandling(async ({ accountId, folder, uids, subfolder }) => {
+    const userId = resolveUserId(db) ?? 'default';
+    const messages = await imapService.getRawMessages(accountId, folder, uids);
+    if (messages.length === 0) {
+      return jsonResult({ success: false, message: 'No messages found for the given UIDs', folder, requestedUids: uids });
+    }
+
+    // Output dir lives under the per-user outbox (always allow-listed). The
+    // optional subfolder is reduced to a single sanitized segment so it cannot
+    // escape the outbox via path traversal.
+    const seg = subfolder ? sanitizeFilename(subfolder).replace(/[\\/]/g, '') : '';
+    const outputDir = path.join(getOutboxDir(userId), 'exports', seg);
+
+    const result = await new MessageExportService().exportEml(outputDir, messages);
+
+    return jsonResult({
+      success: true,
+      format: 'eml',
+      folder,
+      outputDir: result.outputDir,
+      count: result.count,
+      totalBytes: result.totalBytes,
+      totalSize: humanBytes(result.totalBytes),
+      files: result.files.map(f => ({ uid: f.uid, filename: f.filename, path: f.path, size: humanBytes(f.bytes) })),
+      requestedUids: uids,
+      missingUids: uids.filter(u => !messages.some(m => m.uid === u)),
     });
   }));
 


### PR DESCRIPTION
## Summary
Implements the core of #170 — **download & save** messages to standard `.eml` files locally.

- `ImapService.getRawMessages(accountId, folder, uids)` — one-pass fetch of raw RFC822 `source` + light envelope (subject/from/date). The source buffer IS the `.eml`.
- `MessageExportService` — writes each message's raw source verbatim (lossless: attachments + inline images preserved), deterministic collision-safe filenames `YYYY-MM-DD_<from>_<subject>_uid<N>.eml`.
- `imap_export_email` tool — export 1+ UIDs to `.eml` under the per-user outbox (`outbox/exports/[subfolder]`). Optional sanitized single-segment subfolder; returns a manifest (paths + human-readable sizes + missing UIDs). READ_REMOTE.

## Scope / follow-ups (under #170)
Folder + whole-mailbox (chunked) with structure mirroring, attachment-only extraction, arbitrary `outputDir` with allow-list validation, optional `.mbox`.

## Test Plan
- [x] `message-export-service.test.ts` (6): filename build/sanitize/untitled; verbatim write + manifest; mkdir; empty set.
- [x] Build green; tools 99 → 101; full suite 144 tests pass.

## Checklist
- [x] No secrets committed
- [x] Writes confined to the per-user outbox (no path traversal)
- [x] Byte sizes human-readable

Closes #170
