### PR TITLE
fix(sent-folder): robust detection + honor auto-create config (#190)

### DIFF
--- a/src/services/sent-folder-service.test.ts
+++ b/src/services/sent-folder-service.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+import { describe, expect, it, vi } from 'vitest';
+import { SentFolderService } from './sent-folder-service.js';
+
+const stmt = { run: () => {}, get: () => undefined }; // no cache hit
+function makeSvc(folders: any[], host = 'imap.example.com', createFolder = vi.fn(async () => {})) {
+  const db: any = { getAccount: () => ({ host }), getDb: () => ({ prepare: () => stmt }) };
+  const imap: any = { listFolders: async () => folders, createFolder };
+  return { svc: new SentFolderService(db, imap), createFolder };
+}
+const folder = (name: string, attributes: string[] = []) => ({ name, delimiter: '/', attributes, children: [] });
+
+describe('SentFolderService.resolveSentFolder — detection', () => {
+  it('resolves via RFC 6154 \\Sent SPECIAL-USE', async () => {
+    const { svc } = makeSvc([folder('INBOX'), folder('Verzonden', ['\\Sent'])]);
+    const r = await svc.resolveSentFolder('a');
+    expect(r).toMatchObject({ folderName: 'Verzonden', method: 'special_use' });
+  });
+
+  it('resolves a namespaced "INBOX.Sent" by leaf name', async () => {
+    const { svc } = makeSvc([folder('INBOX'), folder('INBOX.Sent')]);
+    const r = await svc.resolveSentFolder('a');
+    expect(r).toMatchObject({ folderName: 'INBOX.Sent', method: 'fallback' });
+  });
+
+  it('resolves a localized Sent folder (Enviados)', async () => {
+    const { svc } = makeSvc([folder('INBOX'), folder('Enviados')]);
+    const r = await svc.resolveSentFolder('a');
+    expect(r.folderName).toBe('Enviados');
+  });
+
+  it('resolves case-insensitively ("sent items")', async () => {
+    const { svc } = makeSvc([folder('INBOX'), folder('sent items')]);
+    const r = await svc.resolveSentFolder('a');
+    expect(r.folderName).toBe('sent items');
+  });
+
+  it('honors an explicit override', async () => {
+    const { svc } = makeSvc([folder('INBOX')]);
+    const r = await svc.resolveSentFolder('a', { override: 'Archive/Sent' });
+    expect(r).toMatchObject({ folderName: 'Archive/Sent', method: 'override' });
+  });
+
+  it('fails with folderName=null and lists available folders when no Sent folder exists', async () => {
+    const { svc } = makeSvc([folder('INBOX'), folder('Drafts'), folder('Junk')]);
+    const r = await svc.resolveSentFolder('a');
+    expect(r.folderName).toBeNull();
+    expect(r.method).toBe('failed');
+    expect(r.availableFolders).toEqual(['INBOX', 'Drafts', 'Junk']);
+  });
+
+  it('auto-creates "Sent" only when autoCreate is enabled', async () => {
+    const { svc, createFolder } = makeSvc([folder('INBOX'), folder('Drafts')]);
+    const r = await svc.resolveSentFolder('a', { autoCreate: true });
+    expect(createFolder).toHaveBeenCalledWith('a', 'Sent');
+    expect(r).toMatchObject({ folderName: 'Sent', method: 'auto_created' });
+  });
+});

--- a/src/services/sent-folder-service.ts
+++ b/src/services/sent-folder-service.ts
@@ -40,6 +40,8 @@ export interface ResolvedSentFolder {
   cacheHit: boolean;
   /** True for accounts where APPEND should be skipped under default settings (Gmail) */
   gmailAutoSkip: boolean;
+  /** When resolution failed, the account's folder names (so callers can hint a `sentFolderOverride`). */
+  availableFolders?: string[];
 }
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
@@ -67,8 +69,29 @@ const PROVIDER_PRESETS: Array<{ match: RegExp; folder: string }> = [
   { match: /(^|\.)protonmail\./i,        folder: 'Sent' },
 ];
 
-/** Names to probe via LIST when nothing else matched. */
-const FALLBACK_NAMES = ['Sent', 'Sent Items', 'Sent Messages', '[Gmail]/Sent Mail', 'INBOX.Sent'];
+/**
+ * Leaf folder names (lower-cased) that denote a Sent folder, including common
+ * localizations. Matched against the LAST path segment so namespaced names
+ * (`INBOX.Sent`, `INBOX/Sent Items`, `[Gmail]/Sent Mail`) resolve too.
+ */
+const SENT_LEAF_NAMES = new Set([
+  'sent', 'sent items', 'sent messages', 'sent mail',
+  'enviados', 'elementos enviados', 'enviadas', 'itens enviados',   // es / pt
+  'gesendet', 'gesendete', 'gesendete objekte', 'gesendete elemente', // de
+  'envoyés', 'éléments envoyés', 'messages envoyés',                 // fr
+  'inviata', 'posta inviata',                                        // it
+  'verzonden', 'verzonden items',                                    // nl
+  'skickat', 'skickade',                                             // sv
+  'wysłane',                                                          // pl
+  'отправленные',                                                     // ru
+  '已发送', '已发送邮件',                                               // zh
+]);
+
+/** Last path segment of an IMAP folder name (handles `/` and `.` hierarchy separators). */
+function leafName(name: string): string {
+  const parts = name.split(/[/.]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : name;
+}
 
 /** Hosts where Gmail-style server-side Sent copy makes APPEND a duplicate. */
 function isGmailHost(host: string): boolean {
@@ -129,11 +152,11 @@ export class SentFolderService {
       return { folderName: preset.folder, method: 'preset', cacheHit: false, gmailAutoSkip };
     }
 
-    // 4. Fallback names
-    for (const name of FALLBACK_NAMES) {
-      if (folderNames.has(name)) {
-        this.writeCache(accountId, name, 'fallback');
-        return { folderName: name, method: 'fallback', cacheHit: false, gmailAutoSkip };
+    // 4. Leaf-name match — case-insensitive, namespaced + localized aware.
+    for (const f of folders) {
+      if (SENT_LEAF_NAMES.has(leafName(f.name).toLowerCase())) {
+        this.writeCache(accountId, f.name, 'fallback');
+        return { folderName: f.name, method: 'fallback', cacheHit: false, gmailAutoSkip };
       }
     }
 
@@ -148,8 +171,14 @@ export class SentFolderService {
       }
     }
 
-    // 6. Failed
-    return { folderName: null, method: 'failed', cacheHit: false, gmailAutoSkip };
+    // 6. Failed — surface the folder list so the caller can hint sentFolderOverride.
+    return {
+      folderName: null,
+      method: 'failed',
+      cacheHit: false,
+      gmailAutoSkip,
+      availableFolders: [...folderNames],
+    };
   }
 
   /** Force a re-resolution on next call (e.g. when folder list changes). */

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -966,7 +966,9 @@ export function emailTools(
     try {
       resolved = await sentFolder.resolveSentFolder(accountId, {
         override: sentFolderOverride,
-        autoCreate: false,
+        // Honor IMAP_MCP_AUTO_CREATE_SENT_FOLDER / the "Auto-Create Sent Folder"
+        // user_config (previously hardcoded false, so the setting was ignored).
+        autoCreate: process.env.IMAP_MCP_AUTO_CREATE_SENT_FOLDER === 'true',
       });
     } catch (e: any) {
       return {
@@ -1005,6 +1007,9 @@ export function emailTools(
             result: 'sent_not_archived',
             archiveSkipped: 'no-sent-folder-found',
             resolutionMethod: resolved.method,
+            availableFolders: resolved.availableFolders,
+            hint: 'No Sent folder detected. Re-send with sentFolderOverride set to one of availableFolders, ' +
+              'or set IMAP_MCP_AUTO_CREATE_SENT_FOLDER=true to create a "Sent" folder automatically.',
           }, null, 2)
         }]
       };


### PR DESCRIPTION
## Summary
Remediates #190 — SMTP-sent messages not appearing in the IMAP Sent folder.

- **Detection robustness:** the exact-match fallback is replaced by a **leaf-name, case-insensitive, localization-aware** matcher. Resolves namespaced (`INBOX.Sent`), case-variant (`sent items`), and non-English (`Enviados`, `Gesendete Objekte`, `Envoyés`, …) Sent folders. SPECIAL-USE `\Sent` and provider presets still take precedence.
- **Auto-create config honored:** the send flow now passes `autoCreate` from `IMAP_MCP_AUTO_CREATE_SENT_FOLDER` (the "Auto-Create Sent Folder" user_config). It was hardcoded `false`, so the setting was a no-op.
- **Diagnosable failure:** on no-sent-folder-found, the response includes `availableFolders` + a `hint` to re-send with `sentFolderOverride` or enable auto-create.

## Test Plan
- [x] `sent-folder-service.test.ts` (7): special-use, namespaced, localized, case-insensitive, override, failure-with-folder-list, auto-create.
- [x] Build green; full suite 151 tests.

## Checklist
- [x] No secrets committed
- [x] Behavior preserved for already-working accounts (special-use/preset paths unchanged)

Fixes #190
