### PR TITLE
feat(email): folder + whole-mailbox .eml export (#170)

### DIFF
--- a/src/services/message-export-service.test.ts
+++ b/src/services/message-export-service.test.ts
@@ -35,6 +35,26 @@ describe('MessageExportService.buildFilename', () => {
   });
 });
 
+describe('MessageExportService.folderToDiskPath', () => {
+  const svc = new MessageExportService();
+  const sep = path.sep;
+
+  it('mirrors a namespaced folder hierarchy to nested dirs', () => {
+    expect(svc.folderToDiskPath('INBOX.Archive.2026')).toBe(['INBOX', 'Archive', '2026'].join(sep));
+    expect(svc.folderToDiskPath('INBOX/Sent Items')).toBe(['INBOX', 'Sent Items'].join(sep));
+  });
+
+  it('handles a single-segment folder', () => {
+    expect(svc.folderToDiskPath('Sent')).toBe('Sent');
+  });
+
+  it('neutralizes traversal and drops empty segments', () => {
+    // split-on-"." turns ".." into empty segments, which are filtered out.
+    expect(svc.folderToDiskPath('A/../weird')).toBe(['A', 'weird'].join(sep));
+    expect(svc.folderToDiskPath('//Sent//')).toBe('Sent');
+  });
+});
+
 describe('MessageExportService.exportEml', () => {
   let dir: string;
   const svc = new MessageExportService();

--- a/src/services/message-export-service.ts
+++ b/src/services/message-export-service.ts
@@ -70,6 +70,20 @@ export class MessageExportService {
   }
 
   /**
+   * Map an IMAP folder name to a relative on-disk path, mirroring the mailbox
+   * hierarchy. Each segment (split on `/` or `.`) is sanitized independently so
+   * a folder like `INBOX.Archive.2026` becomes `INBOX/Archive/2026` on disk.
+   * Returns '' for the implicit root so callers can join safely.
+   */
+  folderToDiskPath(folder: string): string {
+    const segments = (folder || '')
+      .split(/[/.]/)
+      .map((s) => sanitizeFilename(s.trim()).replace(/[\\/]/g, ''))
+      .filter(Boolean);
+    return segments.join(path.sep);
+  }
+
+  /**
    * Write each item's raw source as a `.eml` file into `outputDir` (created if
    * needed, mode 0700). Returns a manifest of what was written.
    */

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -67,6 +67,8 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_get_latest_emails':            READ_REMOTE,
   'imap_get_email_sizes':              READ_REMOTE,
   'imap_export_email':                 READ_REMOTE,
+  'imap_export_folder':                READ_REMOTE,
+  'imap_export_account':               READ_REMOTE,
   'imap_get_unread_count':             READ_REMOTE,
   'imap_bulk_get_emails':              READ_REMOTE,
   'imap_bulk_get_emails_chunked':      READ_REMOTE,

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -176,6 +176,60 @@ function buildSearchCriteria(raw: Record<string, any>): Record<string, any> {
   return criteria;
 }
 
+/** Summary returned by the folder/account export helpers (no per-file list — could be huge). */
+interface FolderExportSummary {
+  folder: string;
+  outputDir: string;
+  totalInFolder: number;
+  exported: number;
+  truncated: boolean;
+  totalBytes: number;
+  totalSize: string;
+}
+
+/**
+ * Export up to `limit` messages of one folder to .eml on disk, mirroring the
+ * folder hierarchy under `{outbox}/exports/[subfolder]/{folder path}/`. Raw
+ * sources are fetched in chunks of 100 to keep memory and the IMAP fetch bounded.
+ */
+async function exportFolderToDisk(
+  imapService: ImapService,
+  exporter: MessageExportService,
+  userId: string,
+  accountId: string,
+  folder: string,
+  limit: number,
+  subfolder?: string,
+  // Return type is inferred (FolderExportSummary) — an explicit Promise<…>
+  // annotation here trips the angle-bracket description lint's approximate scanner.
+) {
+  const all = await imapService.searchEmails(accountId, folder, {});
+  const uids = all.map((m) => m.uid);
+  const selected = uids.slice(0, limit);
+
+  const seg = subfolder ? sanitizeFilename(subfolder).replace(/[\\/]/g, '') : '';
+  const outputDir = path.join(getOutboxDir(userId), 'exports', seg, exporter.folderToDiskPath(folder));
+
+  let exported = 0;
+  let totalBytes = 0;
+  for (let i = 0; i < selected.length; i += 100) {
+    const items = await imapService.getRawMessages(accountId, folder, selected.slice(i, i + 100));
+    const res = await exporter.exportEml(outputDir, items);
+    exported += res.count;
+    totalBytes += res.totalBytes;
+  }
+
+  return {
+    folder,
+    outputDir,
+    totalInFolder: uids.length,
+    exported,
+    truncated: uids.length > selected.length,
+    totalBytes,
+    totalSize: humanBytes(totalBytes),
+  };
+}
+
 export function emailTools(
   server: McpServer,
   imapService: ImapService,
@@ -414,6 +468,68 @@ export function emailTools(
       files: result.files.map(f => ({ uid: f.uid, filename: f.filename, path: f.path, size: humanBytes(f.bytes) })),
       requestedUids: uids,
       missingUids: uids.filter(u => !messages.some(m => m.uid === u)),
+    });
+  }));
+
+  // Export a whole folder to .eml files, mirroring the folder name on disk (#170)
+  server.registerTool('imap_export_folder', {
+    description:
+      'Export all messages in a folder to standard .eml files on the server host, mirroring the folder ' +
+      'hierarchy under the per-user outbox (exports/[subfolder]/{folder path}/). Capped by `limit` ' +
+      '(default 1000; `truncated` flags when the folder held more). Lossless raw-source write. Local only.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder to export (default: INBOX)'),
+      limit: z.number().optional().default(1000).describe('Maximum messages to export (default 1000)'),
+      subfolder: z.string().optional().describe('Optional top-level subfolder under exports/ to group this export'),
+    }
+  }, withErrorHandling(async ({ accountId, folder, limit, subfolder }) => {
+    const userId = resolveUserId(db) ?? 'default';
+    const summary = await exportFolderToDisk(
+      imapService, new MessageExportService(), userId, accountId, folder, limit ?? 1000, subfolder,
+    );
+    return jsonResult({ success: true, format: 'eml', ...summary });
+  }));
+
+  // Export every folder of the account, mirroring the full mailbox structure (#170)
+  server.registerTool('imap_export_account', {
+    description:
+      'Export the entire account to .eml files, mirroring the full mailbox folder structure under ' +
+      'exports/[subfolder]/. Skips non-selectable folders (\\Noselect). Each folder is capped by ' +
+      '`perFolderLimit` (default 1000). Fetched in chunks. Local only — can be large.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      perFolderLimit: z.number().optional().default(1000).describe('Max messages to export per folder (default 1000)'),
+      subfolder: z.string().optional().describe('Optional top-level subfolder under exports/ to group this export'),
+    }
+  }, withErrorHandling(async ({ accountId, perFolderLimit, subfolder }) => {
+    const userId = resolveUserId(db) ?? 'default';
+    const exporter = new MessageExportService();
+    const folders = await imapService.listFolders(accountId);
+    const selectable = folders.filter(
+      (f) => !f.attributes?.some((a: unknown) => /^\\(Noselect|NonExistent)$/i.test(String(a))),
+    );
+
+    const perFolder: FolderExportSummary[] = [];
+    for (const f of selectable) {
+      try {
+        perFolder.push(await exportFolderToDisk(imapService, exporter, userId, accountId, f.name, perFolderLimit ?? 1000, subfolder));
+      } catch (e: any) {
+        perFolder.push({ folder: f.name, outputDir: '', totalInFolder: 0, exported: 0, truncated: false, totalBytes: 0, totalSize: e?.message ?? 'export failed' });
+      }
+    }
+
+    const totalExported = perFolder.reduce((s, p) => s + p.exported, 0);
+    const totalBytes = perFolder.reduce((s, p) => s + p.totalBytes, 0);
+    return jsonResult({
+      success: true,
+      format: 'eml',
+      foldersExported: perFolder.length,
+      totalExported,
+      totalBytes,
+      totalSize: humanBytes(totalBytes),
+      baseDir: path.join(getOutboxDir(userId), 'exports', subfolder ? sanitizeFilename(subfolder).replace(/[\\/]/g, '') : ''),
+      folders: perFolder.map((p) => ({ folder: p.folder, exported: p.exported, truncated: p.truncated, size: p.totalSize })),
     });
   }));
 


### PR DESCRIPTION
## Summary
Extends #170 from single/multiple-UID export to **folder** and **whole-mailbox** modes with on-disk structure mirroring.

- `MessageExportService.folderToDiskPath()` — mirrors the IMAP hierarchy to nested dirs (`INBOX.Archive.2026` → `INBOX/Archive/2026`), each segment sanitized; traversal neutralized.
- **`imap_export_folder`** — export all messages in a folder (capped by `limit`, default 1000, `truncated` flag) to `exports/[subfolder]/{folder path}/`; raw source fetched in chunks of 100.
- **`imap_export_account`** — iterate all **selectable** folders (skips `\Noselect`/`\NonExistent`), export each (per-folder cap), mirror the full mailbox; returns a compact per-folder summary (no giant file list).

## Test Plan
- [x] `folderToDiskPath` tests (mirroring / traversal / single-segment).
- [x] Build + lint green; tools 101 → 103; full suite **154**.

## Checklist
- [x] No secrets; writes confined to the per-user outbox
- [x] Byte sizes human-readable

Refs #170 (remaining: attachment-only extraction, arbitrary `outputDir` w/ allow-list, optional `.mbox`, Web UI)
