### PR TITLE
feat(unsubscribe): read-only bulk extractor + recipient; fix List-Unsubscribe header parsing (#194)

### DIFF
--- a/src/services/unsubscribe-service.test.ts
+++ b/src/services/unsubscribe-service.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+import { describe, expect, it } from 'vitest';
+import { UnsubscribeService } from './unsubscribe-service.js';
+
+const svc = new UnsubscribeService({} as any); // extractWithMeta doesn't touch the DB
+
+function raw(headers: Record<string, string>, body: string, contentType = 'text/plain'): string {
+  const lines = Object.entries(headers).map(([k, v]) => `${k}: ${v}`);
+  lines.push(`Content-Type: ${contentType}`, '', body, '');
+  return lines.join('\r\n');
+}
+
+describe('UnsubscribeService.extractWithMeta', () => {
+  it('extracts header links + sender + recipient + subject', async () => {
+    const source = raw({
+      From: 'Acme News <news@acme.com>',
+      To: 'me@example.com',
+      Subject: 'Weekly Digest',
+      'List-Unsubscribe': '<https://acme.com/unsub?id=1>, <mailto:unsub@acme.com>',
+    }, 'hello');
+
+    const r = await svc.extractWithMeta(source);
+    expect(r.from).toBe('news@acme.com');
+    expect(r.to).toBe('me@example.com');          // recipient captured (#194)
+    expect(r.subject).toBe('Weekly Digest');
+    expect(r.info.unsubscribe_method).toBe('both');
+    expect(r.info.unsubscribe_link).toBe('https://acme.com/unsub?id=1');
+    expect(r.info.list_unsubscribe_header).toContain('mailto:unsub@acme.com');
+  });
+
+  it('falls back to a body link when no header is present', async () => {
+    const source = raw(
+      { From: 'a@x.com', To: 'b@x.com', Subject: 'Promo' },
+      '<html><body><a href="https://x.com/unsubscribe?u=9">Unsubscribe</a></body></html>',
+      'text/html',
+    );
+    const r = await svc.extractWithMeta(source);
+    expect(r.to).toBe('b@x.com');
+    expect(r.info.unsubscribe_link).toContain('unsubscribe');
+    expect(r.info.unsubscribe_method).toBe('http');
+  });
+
+  it('reports no link for a plain message', async () => {
+    const source = raw({ From: 'a@x.com', To: 'b@x.com', Subject: 'Hi' }, 'just a note');
+    const r = await svc.extractWithMeta(source);
+    expect(r.info.unsubscribe_link).toBeUndefined();
+    expect(r.info.list_unsubscribe_header).toBeUndefined();
+    expect(r.to).toBe('b@x.com');
+  });
+
+  it('captures multiple recipients as a comma-joined string', async () => {
+    const source = raw({ From: 'a@x.com', To: 'b@x.com, c@x.com', Subject: 'Hi' }, 'note');
+    const r = await svc.extractWithMeta(source);
+    expect(r.to).toBe('b@x.com, c@x.com');
+  });
+});

--- a/src/services/unsubscribe-service.ts
+++ b/src/services/unsubscribe-service.ts
@@ -32,6 +32,31 @@ export interface EmailUnsubscribeData {
   unsubscribe_info: ExtractedUnsubscribeInfo;
 }
 
+/**
+ * Read a raw header value. mailparser groups `List-*` headers under a single
+ * `list` object, so `headers.get('list-unsubscribe')` is always undefined — the
+ * verbatim value (with the `<...>` link brackets we need) only survives in
+ * `headerLines`. Fall back to the headers Map for ordinary headers.
+ */
+function rawHeaderValue(parsed: ParsedMail, key: string): string | undefined {
+  const lower = key.toLowerCase();
+  const line = parsed.headerLines?.find((h) => h.key === lower);
+  if (line?.line) {
+    const idx = line.line.indexOf(':');
+    return (idx >= 0 ? line.line.slice(idx + 1) : line.line).trim();
+  }
+  const v = parsed.headers.get(lower);
+  return v != null ? String(v) : undefined;
+}
+
+/** Comma-joined address list from a mailparser AddressObject (or undefined). */
+function addressText(a?: AddressObject | AddressObject[]): string | undefined {
+  if (!a) return undefined;
+  const objs = Array.isArray(a) ? a : [a];
+  const addrs = objs.flatMap((o) => (o.value || []).map((v) => v.address).filter(Boolean));
+  return addrs.length ? addrs.join(', ') : undefined;
+}
+
 export class UnsubscribeService {
   private db: DatabaseService;
 
@@ -53,13 +78,33 @@ export class UnsubscribeService {
   }
 
   /**
+   * Read-only one-pass extraction: parse the raw source and return the
+   * unsubscribe info (header + body links) together with sender, recipient,
+   * and subject. Used by the bulk read-only tool — no DB write.
+   */
+  async extractWithMeta(source: string | Buffer): Promise<{
+    from?: string;
+    to?: string;
+    subject?: string;
+    info: ExtractedUnsubscribeInfo;
+  }> {
+    const parsed = await simpleParser(source);
+    return {
+      from: addressText(parsed.from),
+      to: addressText(parsed.to),
+      subject: parsed.subject,
+      info: this.extractFromParsedEmail(parsed),
+    };
+  }
+
+  /**
    * Extract unsubscribe information from parsed email
    */
   extractFromParsedEmail(parsed: ParsedMail): ExtractedUnsubscribeInfo {
     const result: ExtractedUnsubscribeInfo = {};
 
     // 1. Check List-Unsubscribe header (RFC 2369)
-    const listUnsubHeader = parsed.headers.get('list-unsubscribe');
+    const listUnsubHeader = rawHeaderValue(parsed, 'list-unsubscribe');
     if (listUnsubHeader) {
       result.list_unsubscribe_header = String(listUnsubHeader);
 
@@ -81,7 +126,7 @@ export class UnsubscribeService {
     }
 
     // 2. Check List-Unsubscribe-Post header (RFC 8058 - One-Click Unsubscribe)
-    const listUnsubPost = parsed.headers.get('list-unsubscribe-post');
+    const listUnsubPost = rawHeaderValue(parsed, 'list-unsubscribe-post');
     if (listUnsubPost && !result.unsubscribe_link) {
       // This header indicates one-click unsubscribe support
       // The List-Unsubscribe header contains the URL

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -69,6 +69,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_export_email':                 READ_REMOTE,
   'imap_export_folder':                READ_REMOTE,
   'imap_export_account':               READ_REMOTE,
+  'imap_get_unsubscribe_links_for':    READ_REMOTE,
   'imap_get_unread_count':             READ_REMOTE,
   'imap_bulk_get_emails':              READ_REMOTE,
   'imap_bulk_get_emails_chunked':      READ_REMOTE,

--- a/src/tools/subscription-tools.ts
+++ b/src/tools/subscription-tools.ts
@@ -31,6 +31,62 @@ export function registerSubscriptionTools(
   const executorService = new UnsubscribeExecutorService(smtpService);
 
   /**
+   * Read-only bulk extractor: for a block of messages, return links + sender +
+   * recipient + subject without writing to the subscriptions DB (#194).
+   */
+  server.registerTool('imap_get_unsubscribe_links_for', {
+    description:
+      'Read-only: for a block of messages (explicit UIDs, or a folder scan up to `limit`), return per ' +
+      'message the unsubscribe links found in BOTH the List-Unsubscribe header and the body, along with ' +
+      'sender, recipient, and subject. Does NOT write to the subscriptions database or send anything — ' +
+      'use imap_extract_unsubscribe_links for the stored/managed flow, or imap_execute_unsubscribe to act.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder name (default: INBOX)'),
+      uids: z.array(z.number()).optional().describe('Specific UIDs to inspect; omit to scan the folder'),
+      limit: z.number().optional().default(100).describe('When scanning a folder, max messages to inspect (default 100)'),
+    }
+  }, withErrorHandling(async ({ accountId, folder, uids, limit }: {
+    accountId: string; folder: string; uids?: number[]; limit?: number;
+  }) => {
+    let targetUids = uids;
+    if (!targetUids || targetUids.length === 0) {
+      const msgs = await imapService.searchEmails(accountId, folder, {});
+      targetUids = msgs.map((m) => m.uid).slice(0, limit ?? 100);
+    }
+
+    const raws = await imapService.getRawMessages(accountId, folder, targetUids);
+    const messages = [];
+    for (const r of raws) {
+      const meta = await unsubscribeService.extractWithMeta(r.source);
+      const hasUnsubscribe = !!meta.info.unsubscribe_link || !!meta.info.list_unsubscribe_header;
+      messages.push({
+        uid: r.uid,
+        from: sanitizeText(meta.from || r.from || ''),
+        to: sanitizeText(meta.to || ''),
+        subject: sanitizeText(meta.subject || r.subject || ''),
+        hasUnsubscribe,
+        unsubscribeLink: meta.info.unsubscribe_link ? sanitizeUrl(meta.info.unsubscribe_link) : undefined,
+        method: meta.info.unsubscribe_method,
+        listUnsubscribeHeader: meta.info.list_unsubscribe_header
+          ? sanitizeText(meta.info.list_unsubscribe_header) : undefined,
+      });
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          folder,
+          scanned: messages.length,
+          withUnsubscribe: messages.filter((m) => m.hasUnsubscribe).length,
+          messages,
+        }, null, 2)
+      }]
+    };
+  }));
+
+  /**
    * Extract unsubscribe links from emails in a folder
    */
   server.registerTool('imap_extract_unsubscribe_links', {


### PR DESCRIPTION
## Summary
Closes #194 — read-only bulk unsubscribe extraction with **recipient**, plus a latent header-parsing bug fix.

- **`imap_get_unsubscribe_links_for`** — pass explicit `uids` (or scan a folder up to `limit`); returns per message `uid`, `from`, **`to` (recipient)**, `subject`, `hasUnsubscribe`, `unsubscribeLink`, `method`, and `listUnsubscribeHeader`. No DB write / no send (use `imap_extract_unsubscribe_links` for the stored flow, `imap_execute_unsubscribe` to act).
- **`UnsubscribeService.extractWithMeta()`** — one-pass parse → links + from + **to** + subject (recipient was never surfaced before).

## Bug fix (found while building)
mailparser groups `List-*` headers under a single `list` key, so `headers.get('list-unsubscribe')` was **always undefined** — header-based extraction never fired; only body links were found. Now reads the verbatim value from `headerLines`. **This also repairs the header path in the existing `imap_extract_unsubscribe_links`.**

## Test Plan
- [x] `unsubscribe-service.test.ts` (4): header link + recipient, body fallback, none, multi-recipient.
- [x] Build + lint green; tools 103 → 104; full suite **158**.

## Checklist
- [x] No secrets; read-only (no DB write); links/text sanitized via existing helpers

Closes #194
