### PR TITLE
feat(email): imap_extract_attachments — save attachments to disk (#170)

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -1011,6 +1011,38 @@ export class ImapService {
     }, `getRawMessages(${folderName}, ${uids.length} uids)`);
   }
 
+  /**
+   * Fetch and decode the file attachments of a set of UIDs. Parses each raw
+   * source with mailparser and returns the decoded content buffers + metadata.
+   * Used by imap_extract_attachments to save attachments to disk.
+   */
+  async getAttachments(
+    accountId: string,
+    folderName: string,
+    uids: number[]
+  ): Promise<Array<{ uid: number; filename: string; content: Buffer; contentType: string; size: number; inline: boolean; cid?: string }>> {
+    const raws = await this.getRawMessages(accountId, folderName, uids);
+    const out: Array<{ uid: number; filename: string; content: Buffer; contentType: string; size: number; inline: boolean; cid?: string }> = [];
+    for (const r of raws) {
+      const parsed = await simpleParser(r.source);
+      let idx = 0;
+      for (const att of parsed.attachments ?? []) {
+        const content = att.content as Buffer;
+        out.push({
+          uid: r.uid,
+          filename: att.filename || `attachment-${r.uid}-${idx}`,
+          content,
+          contentType: att.contentType || 'application/octet-stream',
+          size: content?.length ?? att.size ?? 0,
+          inline: att.contentDisposition === 'inline' || !!att.related,
+          cid: att.cid,
+        });
+        idx++;
+      }
+    }
+    return out;
+  }
+
   private buildImapFlowSearchQuery(criteria: SearchCriteria): any {
     const query: any = {};
 

--- a/src/services/message-export-service.test.ts
+++ b/src/services/message-export-service.test.ts
@@ -94,3 +94,38 @@ describe('MessageExportService.exportEml', () => {
     expect(res).toMatchObject({ count: 0, totalBytes: 0, files: [] });
   });
 });
+
+describe('MessageExportService.writeAttachments', () => {
+  let dir: string;
+  const svc = new MessageExportService();
+  beforeEach(async () => { dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mexport-att-')); });
+  afterEach(async () => { await fs.rm(dir, { recursive: true, force: true }); });
+
+  it('writes attachments UID-prefixed with verbatim bytes', async () => {
+    const out = path.join(dir, 'att');
+    const res = await svc.writeAttachments(out, [
+      { uid: 5, filename: 'report.pdf', content: Buffer.from('PDFBYTES'), contentType: 'application/pdf' },
+    ]);
+    expect(res.count).toBe(1);
+    expect(res.files[0].savedAs).toBe('uid5_report.pdf');
+    expect((await fs.readFile(res.files[0].path)).toString()).toBe('PDFBYTES');
+  });
+
+  it('disambiguates duplicate filenames within the same UID', async () => {
+    const res = await svc.writeAttachments(path.join(dir, 'att2'), [
+      { uid: 9, filename: 'a.txt', content: Buffer.from('one'), contentType: 'text/plain' },
+      { uid: 9, filename: 'a.txt', content: Buffer.from('two'), contentType: 'text/plain' },
+    ]);
+    const names = res.files.map((f) => f.savedAs);
+    expect(new Set(names).size).toBe(2);          // no collision
+    expect(names).toContain('uid9_a.txt');
+  });
+
+  it('sanitizes unsafe attachment names and falls back when empty', async () => {
+    const res = await svc.writeAttachments(path.join(dir, 'att3'), [
+      { uid: 1, filename: '../../etc/passwd', content: Buffer.from('x'), contentType: 'text/plain' },
+    ]);
+    expect(res.files[0].savedAs).not.toMatch(/[\\/]/);
+    expect(res.files[0].savedAs.startsWith('uid1_')).toBe(true);
+  });
+});

--- a/src/services/message-export-service.ts
+++ b/src/services/message-export-service.ts
@@ -37,6 +37,15 @@ export interface ExportResult {
   files: ExportedFile[];
 }
 
+export interface AttachmentFile {
+  uid: number;
+  filename: string;   // original attachment name
+  savedAs: string;    // collision-safe on-disk name
+  path: string;
+  contentType: string;
+  bytes: number;
+}
+
 /** Collapse a string to a filesystem-safe slug (letters/digits/_/-). */
 function slug(input: string, max = 40): string {
   const s = (input || '')
@@ -98,6 +107,35 @@ export class MessageExportService {
       await fs.writeFile(fullPath, item.source);
       files.push({ uid: item.uid, filename, path: fullPath, bytes: item.source.length });
       totalBytes += item.source.length;
+    }
+
+    return { outputDir, count: files.length, totalBytes, files };
+  }
+
+  /**
+   * Write decoded attachment buffers to `outputDir`. Filenames are sanitized
+   * and made collision-safe by prefixing the source UID (and a counter on
+   * duplicates within the same UID).
+   */
+  async writeAttachments(
+    outputDir: string,
+    items: Array<{ uid: number; filename: string; content: Buffer; contentType: string }>,
+  ): Promise<{ outputDir: string; count: number; totalBytes: number; files: AttachmentFile[] }> {
+    await fs.mkdir(outputDir, { recursive: true, mode: 0o700 });
+
+    const files: AttachmentFile[] = [];
+    const used = new Set<string>();
+    let totalBytes = 0;
+    for (const a of items) {
+      const base = sanitizeFilename(a.filename || 'attachment').replace(/[\\/]/g, '') || 'attachment';
+      let savedAs = `uid${a.uid}_${base}`;
+      for (let n = 1; used.has(savedAs); n++) savedAs = `uid${a.uid}_${n}_${base}`;
+      used.add(savedAs);
+
+      const fullPath = path.join(outputDir, savedAs);
+      await fs.writeFile(fullPath, a.content);
+      files.push({ uid: a.uid, filename: a.filename, savedAs, path: fullPath, contentType: a.contentType, bytes: a.content.length });
+      totalBytes += a.content.length;
     }
 
     return { outputDir, count: files.length, totalBytes, files };

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -69,6 +69,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_export_email':                 READ_REMOTE,
   'imap_export_folder':                READ_REMOTE,
   'imap_export_account':               READ_REMOTE,
+  'imap_extract_attachments':          READ_REMOTE,
   'imap_get_unsubscribe_links_for':    READ_REMOTE,
   'imap_get_unread_count':             READ_REMOTE,
   'imap_bulk_get_emails':              READ_REMOTE,

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -533,6 +533,49 @@ export function emailTools(
     });
   }));
 
+  // Extract file attachments from a block of messages to disk (#170)
+  server.registerTool('imap_extract_attachments', {
+    description:
+      'Extract file attachments from a block of messages and save them to disk under the per-user outbox ' +
+      '(exports/attachments/[subfolder]/). Skips inline images by default; optionally filter by minSizeBytes ' +
+      'and by file extension. Filenames are sanitized and UID-prefixed to avoid collisions. Local only.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder containing the messages (default: INBOX)'),
+      uids: z.array(z.number()).min(1).describe('UIDs of the messages to extract attachments from'),
+      includeInline: z.boolean().optional().default(false).describe('Include inline images/related parts (default false)'),
+      minSizeBytes: z.number().optional().describe('Only extract attachments at least this many bytes'),
+      extensions: z.array(z.string()).optional().describe('Only extract these file extensions (e.g. ["pdf","docx"]); omit for all'),
+      subfolder: z.string().optional().describe('Optional subfolder under exports/attachments/ to group the files'),
+    }
+  }, withErrorHandling(async ({ accountId, folder, uids, includeInline, minSizeBytes, extensions, subfolder }) => {
+    const userId = resolveUserId(db) ?? 'default';
+    let attachments = await imapService.getAttachments(accountId, folder, uids);
+
+    if (!includeInline) attachments = attachments.filter((a) => !a.inline);
+    if (minSizeBytes != null) attachments = attachments.filter((a) => a.size >= minSizeBytes);
+    if (extensions && extensions.length > 0) {
+      const exts = new Set(extensions.map((e) => e.toLowerCase().replace(/^\./, '')));
+      attachments = attachments.filter((a) => exts.has(path.extname(a.filename).slice(1).toLowerCase()));
+    }
+
+    const seg = subfolder ? sanitizeFilename(subfolder).replace(/[\\/]/g, '') : '';
+    const outputDir = path.join(getOutboxDir(userId), 'exports', 'attachments', seg);
+    const result = await new MessageExportService().writeAttachments(outputDir, attachments);
+
+    return jsonResult({
+      success: true,
+      folder,
+      outputDir: result.outputDir,
+      count: result.count,
+      totalBytes: result.totalBytes,
+      totalSize: humanBytes(result.totalBytes),
+      files: result.files.map((f) => ({
+        uid: f.uid, filename: f.filename, savedAs: f.savedAs, contentType: f.contentType, size: humanBytes(f.bytes),
+      })),
+    });
+  }));
+
   // Bulk delete emails tool
   // AUTO-CHUNKING: Automatically uses chunked processing for >50 UIDs
   server.registerTool('imap_bulk_delete_emails', {


### PR DESCRIPTION
## Summary
Adds attachment-only extraction (#170): **`imap_extract_attachments`** saves the file attachments of a block of messages to disk.

- `ImapService.getAttachments()` — fetch + mailparser-decode attachment buffers (filename, content, contentType, size, inline flag, cid).
- `MessageExportService.writeAttachments()` — write to `exports/attachments/[subfolder]/`, sanitized + UID-prefixed (dedupe counter on same-UID duplicate names).
- Tool filters: skips inline images by default (`includeInline`), `minSizeBytes`, and `extensions` (e.g. `["pdf","docx"]`). READ_REMOTE; writes confined to the per-user outbox; sizes human-readable.

## Test Plan
- [x] `writeAttachments` (3): verbatim bytes, duplicate-name disambiguation, unsafe-name sanitization (`../../etc/passwd` → `uid1_passwd`).
- [x] Build + lint green; tools 104 → 105; full suite **161**.

## Checklist
- [x] No secrets; writes confined to the outbox; no path traversal (basename + UID prefix)

Refs #170 (remaining: arbitrary `outputDir` w/ allow-list, optional `.mbox`, Web UI)
