### PR TITLE
feat(quota): imap_get_quota — account storage via IMAP QUOTA (#192)

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -794,6 +794,23 @@ export class ImapService {
   }
 
   /**
+   * Account storage quota via the IMAP QUOTA extension (RFC 9208 / RFC 2087).
+   * Returns null when the server does not advertise QUOTA (or the path has no
+   * quota root). `storage` figures are in bytes.
+   */
+  async getQuota(
+    accountId: string,
+    path: string = 'INBOX'
+  ): Promise<{ path: string; storage?: { used: number; limit: number }; messages?: { used: number; limit: number } } | null> {
+    return this.withRetry(accountId, async () => {
+      const client = this.getConnection(accountId);
+      if (!client.capabilities.has('QUOTA')) return null;
+      const quota = await client.getQuota(path);
+      return quota && typeof quota === 'object' ? (quota as any) : null;
+    }, `getQuota(${path})`);
+  }
+
+  /**
    * Query IMAP server capabilities (Issue #55)
    * Implements capability detection as required by RFC 9051
    * Includes caching to avoid repeated queries

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -66,6 +66,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_get_email':                    READ_REMOTE,
   'imap_get_latest_emails':            READ_REMOTE,
   'imap_get_email_sizes':              READ_REMOTE,
+  'imap_get_quota':                    READ_REMOTE,
   'imap_export_email':                 READ_REMOTE,
   'imap_export_folder':                READ_REMOTE,
   'imap_export_account':               READ_REMOTE,

--- a/src/tools/folder-tools.test.ts
+++ b/src/tools/folder-tools.test.ts
@@ -60,6 +60,7 @@ function makeImapMock(overrides: Record<string, any> = {}) {
     getMultipleMailboxStatus: async () => [
       { mailbox: 'INBOX', messages: 10, unseen: 3, uidNext: 11, uidValidity: 5n, deleted: 0, size: 2 * 1024 * 1024 },
     ],
+    getQuota: async () => ({ path: 'INBOX', storage: { used: 512 * 1024 * 1024, limit: 1024 * 1024 * 1024 } }),
     ...overrides,
   };
 }
@@ -73,6 +74,7 @@ describe('folderTools registration', () => {
       'imap_delete_folder',
       'imap_folder_status',
       'imap_get_mailbox_status',
+      'imap_get_quota',
       'imap_get_unread_count',
       'imap_list_folders',
       'imap_list_subscribed_mailboxes',
@@ -157,5 +159,24 @@ describe('folderTools route outputs', () => {
     const single = await invoke(tools, 'imap_get_mailbox_status', { accountId: 'a', mailboxName: 'INBOX' });
     const array = await invoke(tools, 'imap_get_mailbox_status', { accountId: 'a', mailboxName: ['INBOX'] });
     expect(single).toEqual(array);
+  });
+
+  it('imap_get_quota reports human-readable storage usage + percent', async () => {
+    const out = await invoke(tools, 'imap_get_quota', { accountId: 'a', mailbox: 'INBOX' });
+    expect(out.supported).toBe(true);
+    expect(out.storage).toEqual({
+      used: 512 * 1024 * 1024,
+      limit: 1024 * 1024 * 1024,
+      usedHuman: '512.00 MB',
+      limitHuman: '1.00 GB',
+      percentUsed: 50,
+    });
+  });
+
+  it('imap_get_quota returns supported:false when the server lacks QUOTA', async () => {
+    const made = makeServer();
+    folderTools(made.server as any, makeImapMock({ getQuota: async () => null }) as any, {} as any);
+    const out = await invoke(made.tools, 'imap_get_quota', { accountId: 'a' });
+    expect(out).toMatchObject({ supported: false });
   });
 });

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -171,6 +171,39 @@ export function folderTools(
     });
   }));
 
+  // IMAP QUOTA — account storage used/limit (RFC 9208) (#192)
+  server.registerTool('imap_get_quota', {
+    description:
+      'Report account storage quota — used / limit / percent — via the IMAP QUOTA extension (RFC 9208). ' +
+      'Returns supported:false when the server does not advertise QUOTA. (For a single mailbox size, ' +
+      'use imap_get_mailbox_status, which reports SIZE via STATUS=SIZE.)',
+    inputSchema: {
+      accountId,
+      mailbox: z.string().optional().default('INBOX').describe('Mailbox whose quota root to query (default: INBOX)'),
+    },
+  }, withErrorHandling(async ({ accountId, mailbox }) => {
+    const quota = await imapService.getQuota(accountId, mailbox);
+    if (!quota) {
+      return jsonResult({ supported: false, mailbox, message: 'Server does not advertise the QUOTA extension.' });
+    }
+
+    const pct = (used: number, limit: number) => (limit > 0 ? Math.round((used / limit) * 1000) / 10 : null);
+    const storage = quota.storage && quota.storage.limit
+      ? {
+          used: quota.storage.used,
+          limit: quota.storage.limit,
+          usedHuman: humanBytes(quota.storage.used),
+          limitHuman: humanBytes(quota.storage.limit),
+          percentUsed: pct(quota.storage.used, quota.storage.limit),
+        }
+      : undefined;
+    const messages = quota.messages && quota.messages.limit
+      ? { used: quota.messages.used, limit: quota.messages.limit, percentUsed: pct(quota.messages.used, quota.messages.limit) }
+      : undefined;
+
+    return jsonResult({ supported: true, path: quota.path ?? mailbox, storage, messages });
+  }));
+
   // RFC 9051: Get mailbox status (Issue #56)
   server.registerTool('imap_get_mailbox_status', {
     description: 'Get mailbox statistics without selecting it (RFC 9051 STATUS command) - more efficient than SELECT',


### PR DESCRIPTION
## Summary
Closes #192 — IMAP capability-aware mailbox size & quota.

- **`imap_get_quota`** — account storage **used / limit / percent** (human-readable) via the IMAP `QUOTA` extension (RFC 9208), plus message-count quota when present. Returns `supported:false` when the server doesn't advertise QUOTA.
- `ImapService.getQuota()` guards on the `QUOTA` capability and handles the `false` response.

**On the "mailbox size" half of #192:** already covered — `imap_get_mailbox_status` reports per-mailbox `SIZE` via `STATUS=SIZE` (and now renders it human-readable). So the genuinely-missing piece was account QUOTA, added here.

## Test Plan
- [x] `folder-tools.test.ts` +2: storage percent + human formatting; `supported:false` when QUOTA absent.
- [x] Build + lint green; tools 105 → 106; full suite **163**.

Closes #192
