### PR TITLE
fix(security): path-traversal containment guard on export writes (#203)

### DIFF
--- a/src/services/message-export-service.test.ts
+++ b/src/services/message-export-service.test.ts
@@ -128,4 +128,16 @@ describe('MessageExportService.writeAttachments', () => {
     expect(res.files[0].savedAs).not.toMatch(/[\\/]/);
     expect(res.files[0].savedAs.startsWith('uid1_')).toBe(true);
   });
+
+  it('keeps every written file inside the output dir for adversarial names (path-traversal guard, #203)', async () => {
+    const out = path.join(dir, 'att4');
+    const res = await svc.writeAttachments(out, [
+      { uid: 1, filename: '../../../../etc/passwd', content: Buffer.from('a'), contentType: 'text/plain' },
+      { uid: 2, filename: '..\\..\\windows\\system32\\evil', content: Buffer.from('b'), contentType: 'text/plain' },
+    ]);
+    const base = path.resolve(out);
+    for (const f of res.files) {
+      expect(path.resolve(f.path).startsWith(base + path.sep)).toBe(true); // never escapes
+    }
+  });
 });

--- a/src/services/message-export-service.ts
+++ b/src/services/message-export-service.ts
@@ -14,6 +14,20 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { sanitizeFilename } from './attachment-validator.js';
 
+/**
+ * Defense-in-depth: refuse to write outside `baseDir`. Callers already sanitize
+ * filenames (basename-stripping) and confine `baseDir` to the per-user outbox,
+ * but this guard makes path traversal impossible at the write site regardless
+ * of caller behavior (closes the Aikido AIK_ts_generic_path_traversal finding).
+ */
+function assertInside(baseDir: string, targetPath: string): void {
+  const base = path.resolve(baseDir);
+  const resolved = path.resolve(targetPath);
+  if (resolved !== base && !resolved.startsWith(base + path.sep)) {
+    throw new Error(`Refusing to write outside the export directory: ${targetPath}`);
+  }
+}
+
 /** One message to write: raw RFC822 source + envelope bits for the filename. */
 export interface ExportItem {
   uid: number;
@@ -104,6 +118,7 @@ export class MessageExportService {
     for (const item of items) {
       const filename = this.buildFilename(item);
       const fullPath = path.join(outputDir, filename);
+      assertInside(outputDir, fullPath);
       await fs.writeFile(fullPath, item.source);
       files.push({ uid: item.uid, filename, path: fullPath, bytes: item.source.length });
       totalBytes += item.source.length;
@@ -133,6 +148,7 @@ export class MessageExportService {
       used.add(savedAs);
 
       const fullPath = path.join(outputDir, savedAs);
+      assertInside(outputDir, fullPath);
       await fs.writeFile(fullPath, a.content);
       files.push({ uid: a.uid, filename: a.filename, savedAs, path: fullPath, contentType: a.contentType, bytes: a.content.length });
       totalBytes += a.content.length;


### PR DESCRIPTION
## Summary
Hardens the `.eml`/attachment write paths against traversal (Aikido SAST, High, #203).

- **`assertInside(baseDir, targetPath)`** in `MessageExportService`: resolves the final path and throws if it escapes `outputDir`. Applied in both `exportEml` and `writeAttachments` before every `fs.writeFile`.
- Defense-in-depth atop existing controls: callers confine `outputDir` to the per-user outbox (`getOutboxDir` + sanitized segments), and filenames pass `sanitizeFilename` (basename-stripping) + slash-strip + UID prefix.

## Triage of the Aikido finding
`AIK_ts_generic_path_traversal` is a **generic taint rule** on `path.join`/`path.resolve` with non-literal args — it cannot recognize the runtime `assertInside` guard as a sanitizer (post-fix it even flags the guard's own `path.resolve`). So the residual report is a **verified false positive**; the new guard + test prove writes can never escape `outputDir`.

## Test Plan
- [x] New test: `writeAttachments` with `../../../../etc/passwd` and `..\..\windows\...` names — asserts every written path resolves inside the output dir.
- [x] Build + lint green; full suite **164**.

Closes #203
