### PR TITLE
fix(security): prototype-pollution guard + pin/verify mcp-publisher (#205)

### DIFF
--- a/.github/workflows/build-dxt.yml
+++ b/.github/workflows/build-dxt.yml
@@ -131,9 +131,18 @@ jobs:
           ' server.json > server.tmp && mv server.tmp server.json
           cat server.json
 
-      - name: Install mcp-publisher
+      - name: Install mcp-publisher (pinned + checksum-verified)
+        # Pinned to a specific release and SHA-256-verified before extraction —
+        # no `latest`, no pipe-to-tar (closes the Aikido "remote pull without
+        # integrity verification" finding). Job runs on ubuntu-latest → linux_amd64.
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          set -euo pipefail
+          VERSION=v1.7.9
+          ASSET=mcp-publisher_linux_amd64.tar.gz
+          SHA256=ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
+          curl -fsSL -o "$ASSET" "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ASSET}"
+          echo "${SHA256}  ${ASSET}" | sha256sum -c -
+          tar xzf "$ASSET" mcp-publisher
 
       - name: Authenticate (GitHub OIDC)
         run: ./mcp-publisher login github-oidc

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -59,12 +59,21 @@ const CLI_FLAG_MAP: Record<string, string> = {
   '--mcp-user-id': 'user.mcpUserId',
 };
 
+/** Path segments that could pollute Object.prototype if used as keys. */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * Set a value at a dotted path in a nested object, creating intermediate
  * objects as needed.
+ *
+ * Prototype-pollution guard: refuse any segment named `__proto__`,
+ * `constructor`, or `prototype`. Dotted paths today come from a fixed internal
+ * ENV_VAR_MAPPING (not user input), so this is defense-in-depth — it keeps the
+ * setter safe if it's ever driven by external data.
  */
 function setPath(obj: any, dotted: string, value: unknown): void {
   const parts = dotted.split('.');
+  if (parts.some((k) => UNSAFE_KEYS.has(k))) return;
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const k = parts[i];


### PR DESCRIPTION
## Summary
First remediation batch from the Aikido audit (#205) — two in-our-control fixes.

- **Prototype pollution (High) — `src/config/loader.ts`**: `setPath()` now rejects `__proto__`/`constructor`/`prototype` segments. Defense-in-depth — the dotted paths come from a fixed internal `ENV_VAR_MAPPING` (not user input), so real risk was low, but the setter is now safe regardless of input source.
- **Remote pull without integrity verification (Medium) — `.github/workflows/build-dxt.yml`**: the `mcp-publisher` install used `latest | tar` with no checksum. Now **pinned to v1.7.9**, downloaded to a file, and **SHA-256-verified** (`ab128162…81ac`, from the release's `checksums.txt`) before extraction.

## Test Plan
- [x] Build + 164 tests green; `build-dxt.yml` YAML valid.

## Remaining in #205 (separate PRs)
Dependency upgrades (nodemailer/fast-uri/js-yaml/zod/MCP-SDK — highest real risk), `document.write` XSS in `version-check.html`/`test-api.html`, optional notarize CLI-arg hardening, and triaging the two false-positive secret findings in Aikido.

Refs #205
