### PR TITLE
fix(security): upgrade nodemailer 7 -> 9.0.1 (SMTP send-path advisories) (#205)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.17.16",
+  "version": "2.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.17.16",
+      "version": "2.18.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -24,7 +24,7 @@
         "js-yaml": "^4.1.1",
         "mailparser": "^3.7.4",
         "mime-types": "^3.0.2",
-        "nodemailer": "^7.0.5",
+        "nodemailer": "^9.0.1",
         "open": "^10.2.0",
         "ora": "^8.2.0",
         "zod": "^3.25.76",
@@ -3657,9 +3657,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "js-yaml": "^4.1.1",
     "mailparser": "^3.7.4",
     "mime-types": "^3.0.2",
-    "nodemailer": "^7.0.5",
+    "nodemailer": "^9.0.1",
     "open": "^10.2.0",
     "ora": "^8.2.0",
     "zod": "^3.25.76",


### PR DESCRIPTION
## Summary
Upgrades the **direct** `nodemailer` dependency 7.0.5 → **9.0.1**, patching the High advisories (SMTP command injection / CRLF / OAuth2 TLS / raw-send SSRF). We actively send mail, so this is the highest-real-risk item in #205.

## Verification
- `tsc` build clean; full suite **164** green (incl. real-`mailparser` unsubscribe tests).
- **Runtime smoke** of the exact v9 internal APIs we use: `createTransport`, `MailComposer.compile().build()` (**Bcc preserved** for the Sent-folder copy), `SMTPConnection` (`connect`/`login` for `imap_test_smtp`). All OK.

## Scope decision
- Patches our **send path** (the exploitable surface).
- `imapflow`/`mailparser` keep a transitive nodemailer 8.x; those advisories are **all send-side** and those libs only use nodemailer's MIME encode/parse (libmime), never its transport — **not applicable** in our usage. I deliberately did **not** force an `overrides` (it deduped cleanly + tests passed, but forcing the core IMAP client onto a major-bumped transitive without a live-IMAP test is the wrong risk/reward for a non-applicable advisory).
- `@types/nodemailer` left at 6.x — build is green.

## Note (separate, in #205)
The MCP SDK ReDoS fix (≥1.26) currently **crashes `tsc` (`Abort trap`)** even with `skipLibCheck` on — a hard blocker needing a TS-version bump or `--stack-size` workaround; tracked in #205. js-yaml 4→5 not yet done.

Refs #205
