### PR TITLE
fix(security): upgrade js-yaml 4 -> 5.0.0 (DoS advisory) (#205)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "express-rate-limit": "^8.2.1",
         "express-slow-down": "^3.0.1",
         "imapflow": "^1.1.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^5.0.0",
         "mailparser": "^3.7.4",
         "mime-types": "^3.0.2",
         "nodemailer": "^9.0.1",
@@ -3006,15 +3006,25 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.0.0.tgz",
+      "integrity": "sha512-GSvaPUbk1U+FMZ7rJzF+F8e5YVtu7KnD40et/5rBXXRBv2jCO9L3qCewvIDDdudC0QycTFlf6EAA+h3kxBsuUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "express-rate-limit": "^8.2.1",
     "express-slow-down": "^3.0.1",
     "imapflow": "^1.1.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^5.0.0",
     "mailparser": "^3.7.4",
     "mime-types": "^3.0.2",
     "nodemailer": "^9.0.1",


### PR DESCRIPTION
js-yaml <=4.1.1 quadratic DoS via merge-key aliases (GHSA-h67p-54hq-rp68). Bump to ^5.0.0 — only used at `loader.ts yaml.load()` (unchanged in v5). Verified: build clean, 164 tests, `yaml.load` parses correctly, **advisory cleared**.

Refs #205