### PR TITLE
fix: js-yaml named import — unblock v2.19.0 .mcpb build (#211)

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -12,7 +12,8 @@
 
 import fs from 'fs';
 import path from 'path';
-import yaml from 'js-yaml';
+// js-yaml 5.x is ESM with named exports only — no default export (#209).
+import { load as yamlLoad } from 'js-yaml';
 import toml from '@iarna/toml';
 import { z } from 'zod';
 import {
@@ -126,7 +127,7 @@ function readConfigFile(filePath: string): Record<string, any> {
   const ext = path.extname(filePath).toLowerCase();
   const text = fs.readFileSync(filePath, 'utf8');
   if (ext === '.yaml' || ext === '.yml') {
-    const parsed = yaml.load(text);
+    const parsed = yamlLoad(text);
     if (parsed && typeof parsed === 'object') return parsed as Record<string, any>;
     throw new ConfigError(`Config file at ${filePath} did not parse to an object`, []);
   }


### PR DESCRIPTION
## Summary

`v2.19.0`'s js-yaml bump to `^5.0.0` (#209) is a release-blocker regression: js-yaml 5.x is ESM with **named exports only** and no longer ships a `default` export, but `src/config/loader.ts` imports it as `import yaml from 'js-yaml'`.

## Impact

- `tsc` passes — `@types/js-yaml@4` still declares a default export and `skipLibCheck` is on.
- `vitest` passes — esbuild's CJS/ESM interop tolerates the default import.
- **Native Node ESM fails at runtime**: `SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'`.

This breaks `node dist/index.js --print-tools-manifest`, which the `.mcpb` build (`dxt/build.mjs`) runs to generate the tools manifest — so the **v2.19.0 release build failed** (run 27918448881; release + registry-publish jobs skipped). It would also break server/CLI startup wherever the YAML config path is loaded.

## Fix

Use a named import:

```ts
import { load as yamlLoad } from 'js-yaml';
...
const parsed = yamlLoad(text);
```

## Verification

- `node dxt/build.mjs --universal` now succeeds (33 MB bundle, manifest = 106 tools).
- 164/164 tests pass.

No GitHub release or registry publish occurred for v2.19.0, so the fix lands on `main` and the `v2.19.0` tag is re-pointed (nothing external consumed it).
