### PR TITLE
feat: imap_get_largest_emails — top-N largest across folders (#200)

### DIFF
--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -66,6 +66,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_get_email':                    READ_REMOTE,
   'imap_get_latest_emails':            READ_REMOTE,
   'imap_get_email_sizes':              READ_REMOTE,
+  'imap_get_largest_emails':           READ_REMOTE,
   'imap_get_quota':                    READ_REMOTE,
   'imap_export_email':                 READ_REMOTE,
   'imap_export_folder':                READ_REMOTE,

--- a/src/tools/email-tools.test.ts
+++ b/src/tools/email-tools.test.ts
@@ -154,6 +154,58 @@ describe('emailTools core routes', () => {
   });
 });
 
+describe('imap_get_largest_emails (multi-folder, #200)', () => {
+  // Folder-aware mock: INBOX and Sent return distinct sizes; "Junk" throws (e.g. \Noselect).
+  function multiFolderImap() {
+    return makeImap({
+      getEmailSizes: async (_a: string, folder: string) => {
+        if (folder === 'INBOX') return [
+          { uid: 10, size: 3 * 1024 * 1024, subject: 'inbox-mid', from: 'a@x.com', date: new Date('2026-01-01'), hasAttachments: false },
+          { uid: 11, size: 1 * 1024 * 1024, subject: 'inbox-small', from: 'b@x.com', date: new Date('2026-01-02'), hasAttachments: false },
+        ];
+        if (folder === 'Sent') return [
+          { uid: 20, size: 9 * 1024 * 1024, subject: 'sent-big', from: 'me@x.com', date: new Date('2026-02-01'), hasAttachments: true },
+          { uid: 21, size: 2 * 1024 * 1024, subject: 'sent-small', from: 'me@x.com', date: new Date('2026-02-02'), hasAttachments: false },
+        ];
+        throw new Error(`Mailbox does not exist: ${folder}`);
+      },
+    });
+  }
+
+  it('defaults to INBOX only and ranks largest-first', async () => {
+    const tools = register(multiFolderImap());
+    const out = await invoke(tools, 'imap_get_largest_emails', { accountId: 'a' });
+    expect(out.foldersScanned).toEqual(['INBOX']);
+    expect(out.messages.map((m: any) => m.uid)).toEqual([10, 11]);
+    expect(out.messages[0].folder).toBe('INBOX');
+  });
+
+  it('merges and ranks across folders with per-folder uid arrays', async () => {
+    const tools = register(multiFolderImap());
+    const out = await invoke(tools, 'imap_get_largest_emails', { accountId: 'a', folders: ['INBOX', 'Sent'], topN: 3 });
+    expect(out.returned).toBe(3);
+    // global size-desc: Sent#20 (9M), INBOX#10 (3M), Sent#21 (2M) — INBOX#11 (1M) drops off at topN=3
+    expect(out.messages.map((m: any) => `${m.folder}:${m.uid}`)).toEqual(['Sent:20', 'INBOX:10', 'Sent:21']);
+    expect(out.uidsByFolder).toEqual({ Sent: [20, 21], INBOX: [10] });
+    expect(out.totalHuman).toBe('14.00 MB');
+  });
+
+  it('skips unreadable folders and reports them', async () => {
+    const tools = register(multiFolderImap());
+    const out = await invoke(tools, 'imap_get_largest_emails', { accountId: 'a', folders: ['INBOX', 'Junk'] });
+    expect(out.foldersScanned).toEqual(['INBOX']);
+    expect(out.skippedFolders).toHaveLength(1);
+    expect(out.skippedFolders[0].folder).toBe('Junk');
+    expect(out.skippedFolders[0].reason).toMatch(/does not exist/);
+  });
+
+  it('applies minSizeBytes across all folders', async () => {
+    const tools = register(multiFolderImap());
+    const out = await invoke(tools, 'imap_get_largest_emails', { accountId: 'a', folders: ['INBOX', 'Sent'], minSizeBytes: 3 * 1024 * 1024 });
+    expect(out.messages.map((m: any) => `${m.folder}:${m.uid}`)).toEqual(['Sent:20', 'INBOX:10']);
+  });
+});
+
 describe('emailTools send/reply/forward', () => {
   it('imap_reply_to_email builds Re: subject, threads, and reply-all recipients', async () => {
     let sent: any;

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -429,6 +429,72 @@ export function emailTools(
     });
   }));
 
+  // Top-N largest emails across multiple folders (#200) — multi-folder extension
+  // of imap_get_email_sizes. Scans each folder cheaply (RFC822.SIZE, no body),
+  // merges, ranks globally, and returns per-folder UID arrays for bulk cleanup.
+  server.registerTool('imap_get_largest_emails', {
+    description:
+      'Find the largest emails across several folders at once (default: just INBOX) and return the global top-N. ' +
+      'Uses RFC822.SIZE — no body download — so it stays cheap even across big folders. Each row is tagged with the ' +
+      'folder it came from; results are merged and ranked by size across all folders. Unreadable/\\Noselect folders are ' +
+      'skipped and reported. Returns per-folder `uids` arrays (UIDs are only unique within a folder) ready to pass to ' +
+      'imap_bulk_delete_emails / imap_bulk_move_emails to reclaim space.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folders: z.array(z.string()).optional().default(['INBOX']).describe('Folders to scan (default: ["INBOX"])'),
+      topN: z.number().optional().default(20).describe('How many of the largest messages to return overall (default 20)'),
+      minSizeBytes: z.number().optional().describe('Only consider messages at least this many bytes (e.g. 10485760 = 10 MiB)'),
+    }
+  }, withErrorHandling(async ({ accountId, folders, topN, minSizeBytes }) => {
+    const folderList = (folders && folders.length > 0) ? folders : ['INBOX'];
+    const cap = topN ?? 20;
+
+    type Row = { folder: string; uid: number; size: number; subject: string; from: string; date: Date; hasAttachments: boolean };
+    const merged: Row[] = [];
+    const skippedFolders: Array<{ folder: string; reason: string }> = [];
+
+    for (const folder of folderList) {
+      try {
+        const sizes = await imapService.getEmailSizes(accountId, folder);
+        for (const m of sizes) {
+          if (minSizeBytes != null && m.size < minSizeBytes) continue;
+          merged.push({ folder, ...m });
+        }
+      } catch (err) {
+        skippedFolders.push({ folder, reason: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    merged.sort((a, b) => b.size - a.size);
+    const top = merged.slice(0, cap);
+    const totalBytes = top.reduce((sum, m) => sum + m.size, 0);
+
+    // Per-folder UID arrays — UIDs are only unique within a folder, and bulk
+    // delete/move operate on (accountId, folder, uids).
+    const uidsByFolder: Record<string, number[]> = {};
+    for (const m of top) (uidsByFolder[m.folder] ??= []).push(m.uid);
+
+    return jsonResult({
+      foldersScanned: folderList.filter(f => !skippedFolders.some(s => s.folder === f)),
+      skippedFolders,
+      matched: merged.length,
+      returned: top.length,
+      totalBytes,
+      totalHuman: humanBytes(totalBytes),
+      messages: top.map(m => ({
+        folder: m.folder,
+        uid: m.uid,
+        size: m.size,
+        sizeHuman: humanBytes(m.size),
+        subject: m.subject,
+        from: m.from,
+        date: toIsoDate(m.date),
+        hasAttachments: m.hasAttachments,
+      })),
+      uidsByFolder,
+    });
+  }));
+
   // Export messages to standard .eml files on disk — download & save (#170)
   server.registerTool('imap_export_email', {
     description:


### PR DESCRIPTION
## #200 — Top-N largest emails across multiple folders

Adds `imap_get_largest_emails`, the multi-folder extension of `imap_get_email_sizes` (#169).

### Behavior
- Inputs: `accountId`, `folders?` (default `["INBOX"]`), `topN?` (default 20), optional `minSizeBytes`.
- Reuses `ImapService.getEmailSizes()` per folder (RFC822.SIZE, no body download), merges, sorts size-desc, takes top-N.
- Each row: `folder`, `uid`, `size` + `sizeHuman`, `subject`, `from`, `date`, `hasAttachments`.
- Aggregate `totalBytes`/`totalHuman`; **per-folder** `uidsByFolder` (UIDs are only unique within a folder) ready for `imap_bulk_delete_emails` / `imap_bulk_move_emails`.
- Unreadable/`\Noselect` folders are skipped gracefully and reported in `skippedFolders`.

### Tests (4 new, 168 total)
default-INBOX ranking · cross-folder merge + per-folder uid arrays + topN cap · skipped-folder handling · `minSizeBytes` across folders.

Tools 106 → 107. Build green, full suite passes.
