### PR TITLE
docs: tool counts + remove false OS-keyring claim + document new tools (#201)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -22,7 +22,7 @@ This guide covers upgrades from earlier IMAP MCP Pro versions. Read the section 
 
 ### Breaking changes
 
-**None.** All existing env vars continue to work, all 81 tools have stable schemas, the database stays at `1.7.0` (no schema changes in this release), and the wire protocol is unchanged.
+**None.** All existing env vars continue to work, every tool keeps a stable schema (run `imap_list_tools` for the current catalog), the database stays at `1.7.0` (no schema changes in this release), and the wire protocol is unchanged.
 
 ### Recommended migration paths
 
@@ -34,7 +34,7 @@ This guide covers upgrades from earlier IMAP MCP Pro versions. Read the section 
    - **Data Directory**: point to your existing `~/.imap-mcp` (preserves accounts, results cache, encryption key)
    - **Log Level**: `INFO`
    - **User ID**: whatever you had set as `MCP_USER_ID` (default: `default`)
-   - **Encryption Key**: leave blank if you previously used the on-disk key (the extension activates `CLAUDE_DESKTOP_EXTENSION=true` which prefers the system keyring; on first run it'll bootstrap from the existing on-disk key file)
+   - **Encryption Key**: leave blank to keep using your existing on-disk key file (`~/.imap-mcp/.encryption-key`, mode 600). Credentials are encrypted with AES-256-GCM. (The previous OS-keyring path was removed in v2.x when the native `keytar`/SQLCipher dependencies were dropped — storage is now purely file-based.)
 4. **Disable the old MCP server entry** in `claude_desktop_config.json` so Claude Desktop doesn't run two copies.
 5. Restart Claude Desktop.
 6. Verify with `imap_list_accounts` — your accounts should be there.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An enterprise-grade Model Context Protocol (MCP) server that provides production
 
 ## Features
 
-**95 MCP tools** across email/folder/account/category/scoring/subscription/dns-firewall/usercheck/staging/cache/diagnostics — every IMAP4rev2 (RFC 9051) operation we use is exposed.
+**107 MCP tools** across email/folder/account/category/scoring/subscription/dns-firewall/usercheck/staging/cache/diagnostics — every IMAP4rev2 (RFC 9051) operation we use is exposed. (Run `imap_list_tools` for the live, authoritative catalog.)
 
 ### Core Features
 - 🔐 **Secure Account Management**: Encrypted credential storage with AES-256 encryption
@@ -116,7 +116,7 @@ The fastest path to a working setup is to install IMAP MCP Pro as a **Claude Des
    - **Log Level** — `INFO` is fine for day-to-day; `DEBUG` for troubleshooting
    - **Maximum Attachment Size** — default 25 MiB
    - **Allowed Attachment Directories** — *optional*, only needed for path-based attachment sends
-   - **Encryption Key** — leave blank to use the system keyring (recommended)
+   - **Encryption Key** — leave blank to auto-generate a file-based key (stored at `~/.imap-mcp/.encryption-key`, mode 600); credentials are encrypted with AES-256-GCM (recommended)
    - **User ID** — `default` for single-user installs
 4. Click **Enable**. Run a quick test by asking Claude `What IMAP accounts do I have?`.
 

--- a/SECURITY_SCAN_REPORT.md
+++ b/SECURITY_SCAN_REPORT.md
@@ -1,5 +1,7 @@
 # Snyk Security Scan Report - v2.5.0
 
+> **⚠️ Historical document (v2.5.0).** Findings referencing `AccountManager` and the SQLCipher/CBC key path are **resolved and no longer apply**: `AccountManager` was replaced by `DatabaseService`, and the native `keytar`/SQLCipher dependencies were removed entirely (#181). Credential storage is now file-based AES-256-GCM via `node:sqlite`. For the current security posture see `SECURITY.md`; for the latest dependency/SAST status see the Aikido audit tracked in #205. Retained for audit history.
+
 **Scan Date:** 2025-11-05  
 **Project:** IMAP MCP Pro v2.5.0  
 **Scanner:** Snyk Code Test

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,8 +33,8 @@ src/
 │   ├── attachment-staging-service.ts  # WP2: chunked-upload sessions + GC
 │   ├── results-service.ts        # Tool-result cache (handle/file modes), LRU eviction
 │   ├── file-export-service.ts    # Encrypted JSON/JSONL writer for file-mode results
-│   └── encryption/               # Key storage paths (keyring vs file)
-├── tools/                        # 91 MCP tools across 12 files
+│   └── message-export-service.ts # Local .eml/attachment export, path-traversal-guarded (#170)
+├── tools/                        # 107 MCP tools across 12 files (run imap_list_tools for the live catalog)
 │   ├── account-tools.ts          # 8  add/remove/list/share accounts
 │   ├── email-tools.ts            # 32 search/get/mark/delete/move/copy/send/bulk + WP1/2/3/4
 │   ├── folder-tools.ts           # 6  list/status/create/delete/rename

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -34,7 +34,7 @@
 IMAP MCP Pro is a Model Context Protocol (MCP) server that provides comprehensive IMAP email integration for Claude AI, enabling intelligent email management, automation, and analysis.
 
 ### Key Features
-- ✅ **45 MCP Tools** for complete email management
+- ✅ **107 MCP Tools** for complete email management (run `imap_list_tools` for the authoritative live catalog)
 - ✅ **15 Email Provider Presets** (Gmail, Outlook, Yahoo, etc.)
 - ✅ **Auto-Chunking** for operations >50 UIDs
 - ✅ **Circuit Breaker Pattern** with automatic recovery
@@ -156,7 +156,29 @@ imap-mcp-pro/
 
 ## MCP Tools
 
-### Complete Tool Catalog (45 Tools)
+> **Authoritative catalog:** the live, complete tool list (currently **107 tools**) is always available at runtime via `imap_list_tools`. The detailed catalog below documents the core set; the "Recent additions" section tracks tools added since, and the remaining catalog is reconciled incrementally.
+
+### Recent additions (v2.17–v2.19)
+
+**Mailbox size & cleanup**
+- **imap_get_email_sizes** (#169) — list messages by RFC822.SIZE (no body download) to find large emails in a folder; `minSizeBytes` filter, largest-first, returns a `uids` array ready for bulk delete/move.
+- **imap_get_largest_emails** (#200) — top-N largest messages merged and ranked across multiple folders (default `["INBOX"]`); per-folder `uids` arrays; skips unreadable folders.
+
+**Local export ("download & save", #170)**
+- **imap_export_email** — export specific UIDs to `.eml` (raw RFC822, lossless) under the per-user outbox.
+- **imap_export_folder** / **imap_export_account** — mirror the IMAP folder hierarchy to disk as `.eml`.
+- **imap_extract_attachments** — save attachments to disk with inline-skip / size / extension filters.
+
+**Quota & unsubscribe**
+- **imap_get_quota** (#192) — account storage used/limit/percent via the IMAP QUOTA extension (RFC 9208).
+- **imap_get_unsubscribe_links_for** (#194) — read-only bulk extractor: per-message unsubscribe links (header + body) plus sender, recipient, and subject.
+
+**SMTP**
+- Capability-aware **SIZE** send limits (#191) — `imap_test_smtp` reports the server's EHLO `SIZE`; oversized sends fail fast with a clear message instead of a 552 round-trip.
+
+All byte sizes in tool output are human-readable (B/KB/MB/GB). Credential storage is file-based AES-256-GCM (`node:sqlite`; no native `keytar`/SQLCipher dependency).
+
+### Complete Tool Catalog (core set)
 
 #### 1. Account Management (5 tools)
 
@@ -888,7 +910,7 @@ POST /api/usercheck         - UserCheck email validation
 
 **Expected Output**:
 ```
-✅ 45 tools registered
+✅ 107 tools registered
 ✅ All tools categorized correctly
 ✅ No missing or extra tools
 ✅ PASS

--- a/dxt/manifest.template.json
+++ b/dxt/manifest.template.json
@@ -4,7 +4,7 @@
   "display_name": "IMAP MCP Pro",
   "version": "__VERSION__",
   "description": "Production-grade IMAP & SMTP integration for Claude Desktop. Connect any IMAP account, search and triage at scale, send messages with attachments, and run spam/domain checks via the UserCheck integration.",
-  "long_description": "IMAP MCP Pro turns Claude Desktop into a full-featured email client. It connects to any standard IMAP server (Gmail, Outlook, Fastmail, iCloud, Dovecot, etc.), supports multiple accounts per user, and exposes 80+ tools for searching, reading, sending, organizing, and analyzing email — including bulk operations on tens of thousands of messages without blowing your token budget thanks to the resource-handle response system.\n\nKey capabilities:\n- Multi-account IMAP via secure encrypted credential storage (AES-256-GCM)\n- Send mail through SMTP with backward-compatible attachment handling\n- Bulk search/move/copy/delete with auto-chunking and worker-pool parsing\n- Three-tier response (inline / handle / file-backed) keeps results small\n- UserCheck integration for spam-sender detection\n- DNS firewall checks for outbound link safety\n- 80+ MCP tools — every IMAP4rev2 (RFC 9051) operation we use is implemented\n\nThis extension installs a self-contained Node runtime and stores credentials in your OS keyring when run as a Claude Desktop extension.",
+  "long_description": "IMAP MCP Pro turns Claude Desktop into a full-featured email client. It connects to any standard IMAP server (Gmail, Outlook, Fastmail, iCloud, Dovecot, etc.), supports multiple accounts per user, and exposes 100+ tools for searching, reading, sending, organizing, and analyzing email — including bulk operations on tens of thousands of messages without blowing your token budget thanks to the resource-handle response system.\n\nKey capabilities:\n- Multi-account IMAP via secure encrypted credential storage (AES-256-GCM)\n- Send mail through SMTP with backward-compatible attachment handling\n- Bulk search/move/copy/delete with auto-chunking and worker-pool parsing\n- Find and clean up large messages by size; export messages and attachments locally as .eml; report mailbox quota\n- Three-tier response (inline / handle / file-backed) keeps results small\n- UserCheck integration for spam-sender detection\n- DNS firewall checks for outbound link safety\n- 100+ MCP tools — every IMAP4rev2 (RFC 9051) operation we use is implemented\n\nThis extension installs a self-contained Node runtime. Credentials are encrypted at rest with AES-256-GCM using a file-based key (stored at ~/.imap-mcp/.encryption-key, mode 600) — no native OS-keyring dependency.",
   "author": {
     "name": "Colin Bitterfield",
     "email": "colin.bitterfield@templeofepiphany.com",
@@ -58,7 +58,7 @@
     "encryption_key": {
       "type": "string",
       "title": "Encryption Key (optional)",
-      "description": "Master key for credential storage. Leave blank to use the system keyring (recommended on Claude Desktop).",
+      "description": "Master key for credential storage. Leave blank to auto-generate a file-based key (~/.imap-mcp/.encryption-key, mode 600); credentials are encrypted with AES-256-GCM. Set a value only to supply your own key.",
       "sensitive": true,
       "required": false
     },


### PR DESCRIPTION
## #201 (part 1) — accuracy pass on user-facing + shipped docs

Focused on the **priority** drift the issue flags: the false OS-keyring claim and the tool counts. Deeper work (full SPEC catalog reconciliation, internal working-doc archival, wiki) stays tracked on #201.

### Security-relevant (priority)
- **Removed the false "stores credentials in your OS keyring" claim** from the `.mcpb` manifest `long_description` and the `ENCRYPTION_KEY` config hint — `keytar`/SQLCipher were removed in #181; storage is file-based AES-256-GCM (`~/.imap-mcp/.encryption-key`, mode 600). Same fix in README + MIGRATION.
- **`SECURITY_SCAN_REPORT.md`**: added a "historical / resolved" banner so its stale `AccountManager` + SQLCipher/CBC findings aren't read as current.
- **`ARCHITECTURE.md`**: dropped the deleted `encryption/` directory; points at `database-service.ts`.

### Tool counts → single-sourced to the live catalog
README 95→107 · manifest "80+"→"100+" · SPECIFICATION 45→107 · ARCHITECTURE 91→107 · MIGRATION's "81 tools" → "run `imap_list_tools`". All now reference **`imap_list_tools`** as the authoritative runtime catalog.

### New tools documented (acceptance)
README capability line + a SPECIFICATION **"Recent additions (v2.17–v2.19)"** section covering #169, #200, #170 (export ×4), #192, #194, and #191.

### License
Verified no stray `Apache`/dual-license/share-alike text remains (only match was an accurate PolyForm Noncommercial note).

### Verification
172 tests pass · `dxt/build.mjs --universal` merges 107 tools · manifest is valid JSON · bundled manifest confirmed to say "100+ tools" with no positive keyring claim.

### Remaining on #201
Full SPEC catalog reconciliation of all 107 tools; archive/refresh stale internal working docs (`TODO.md` 27, `TEST_RESULTS.md` 72, `docs/chunked_bulk_operations.md` 42, `docs/sdk_audit_*`); wiki audit + companion issue (Hard Rule 24).
