### PR TITLE
fix: bound imap_extract_unsubscribe_links — header-first + time budget (#131)

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -1148,6 +1148,44 @@ export class ImapService {
     }, `getEmailContent(${folderName}, ${uid})`);
   }
 
+  /**
+   * Cheaply fetch only the List-Unsubscribe header lines (envelope + the two
+   * unsubscribe headers, NO message body) for a set of UIDs in a single
+   * streaming FETCH. Used by imap_extract_unsubscribe_links to avoid a
+   * full-body download per message — the common case (promotional mail almost
+   * always carries List-Unsubscribe) resolves from headers alone (#131).
+   *
+   * `headerBytes` is the raw header block ImapFlow returns for the requested
+   * fields; pass it (with a trailing blank line) to the unsubscribe parser.
+   */
+  async getUnsubscribeHeaders(
+    accountId: string,
+    folderName: string,
+    uids: number[]
+  ): Promise<Array<{ uid: number; from: string; subject: string; date: Date; headerBytes: Buffer | null }>> {
+    if (!uids || uids.length === 0) return [];
+    return this.withRetry(accountId, async () => {
+      const client = this.getConnection(accountId);
+      await client.mailboxOpen(folderName);
+
+      const out: Array<{ uid: number; from: string; subject: string; date: Date; headerBytes: Buffer | null }> = [];
+      for await (const msg of client.fetch(uids.join(','), {
+        uid: true,
+        envelope: true,
+        headers: ['list-unsubscribe', 'list-unsubscribe-post'],
+      }, { uid: true })) {
+        out.push({
+          uid: msg.uid,
+          from: msg.envelope?.from?.[0]?.address || '',
+          subject: msg.envelope?.subject || '',
+          date: msg.envelope?.date || new Date(),
+          headerBytes: (msg.headers as Buffer) ?? null,
+        });
+      }
+      return out;
+    }, `getUnsubscribeHeaders(${folderName})`);
+  }
+
   // ==================
   // Bulk Operations
   // ==================

--- a/src/tools/subscription-tools.test.ts
+++ b/src/tools/subscription-tools.test.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for imap_extract_unsubscribe_links — header-first extraction, body
+// fallback, time budget, and afterUid resume (#131).
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { registerSubscriptionTools } from './subscription-tools.js';
+
+type Registered = { spec: any; handler: any };
+
+function makeServer() {
+  const tools = new Map<string, Registered>();
+  const server = { registerTool: (name: string, spec: any, handler: any) => tools.set(name, { spec, handler }) };
+  return { server, tools };
+}
+
+async function invoke(tools: Map<string, Registered>, name: string, args: any) {
+  const entry = tools.get(name);
+  if (!entry) throw new Error(`tool not registered: ${name}`);
+  return JSON.parse((await entry.handler(args)).content[0].text);
+}
+
+function headerBuf(value: string | null): Buffer | null {
+  return value == null ? null : Buffer.from(`List-Unsubscribe: ${value}\r\n`);
+}
+
+// Three messages: uid 1 has a header, uid 2 has no header (body link), uid 3 has nothing.
+function makeImap(overrides: Record<string, any> = {}) {
+  const calls = { getEmailContent: [] as number[], getUnsubscribeHeaders: [] as number[][] };
+  const imap = {
+    calls,
+    searchEmails: async () => [
+      { uid: 3, from: 'c@x.com', subject: 'three', date: new Date('2026-01-03') },
+      { uid: 1, from: 'a@x.com', subject: 'one', date: new Date('2026-01-01') },
+      { uid: 2, from: 'b@x.com', subject: 'two', date: new Date('2026-01-02') },
+    ],
+    getUnsubscribeHeaders: async (_a: string, _f: string, uids: number[]) => {
+      calls.getUnsubscribeHeaders.push(uids);
+      const headers: Record<number, string | null> = {
+        1: '<https://unsub.example/one>',
+        2: null,
+        3: null,
+      };
+      return uids.map((uid) => ({
+        uid,
+        from: `uid${uid}@x.com`,
+        subject: `subject-${uid}`,
+        date: new Date('2026-01-0' + uid),
+        headerBytes: headerBuf(headers[uid] ?? null),
+      }));
+    },
+    getEmailContent: async (_a: string, _f: string, uid: number) => {
+      calls.getEmailContent.push(uid);
+      // Only uid 2 has an in-body unsubscribe link.
+      const html = uid === 2 ? '<a href="https://body.example/unsubscribe">unsubscribe</a>' : '<p>nothing</p>';
+      return { uid, textContent: '', htmlContent: html, from: `uid${uid}@x.com`, subject: `subject-${uid}` };
+    },
+    ...overrides,
+  };
+  return imap;
+}
+
+function makeDb() {
+  const stored: any[] = [];
+  return {
+    stored,
+    resolveUserId: () => 'user-1',
+    insertUnsubscribeLink: (row: any) => stored.push(row),
+    upsertSubscriptionSummary: () => {},
+  };
+}
+
+function register(imap: any, db: any) {
+  const { server, tools } = makeServer();
+  registerSubscriptionTools(server as any, imap as any, db as any, {} as any);
+  return tools;
+}
+
+describe('imap_extract_unsubscribe_links (#131)', () => {
+  let imap: any, db: any, tools: Map<string, Registered>;
+  beforeEach(() => { imap = makeImap(); db = makeDb(); tools = register(imap, db); });
+
+  it('resolves header-first without a body fetch when List-Unsubscribe is present', async () => {
+    const out = await invoke(tools, 'imap_extract_unsubscribe_links', {
+      userId: 'user-1', accountId: 'a', folder: 'INBOX', scanBodies: false,
+    });
+    // uid 1 found via header; uids 2 & 3 have no header and bodies are skipped.
+    expect(out.summary.processed).toBe(3);
+    expect(out.summary.linksFound).toBe(1);
+    expect(out.summary.bodyScans).toBe(0);
+    expect(imap.calls.getEmailContent).toHaveLength(0);
+    const found = out.emails.find((e: any) => e.uid === 1);
+    expect(found.unsubscribe_link).toBe('https://unsub.example/one');
+    expect(found.has_list_unsubscribe_header).toBe(true);
+  });
+
+  it('falls back to a body fetch only on header-miss when scanBodies is on', async () => {
+    const out = await invoke(tools, 'imap_extract_unsubscribe_links', {
+      userId: 'user-1', accountId: 'a', folder: 'INBOX', scanBodies: true,
+    });
+    // uid 1 from header (no body), uids 2 & 3 trigger a body fetch; only uid 2 yields a link.
+    expect(imap.calls.getEmailContent.sort()).toEqual([2, 3]);
+    expect(out.summary.bodyScans).toBe(2);
+    expect(out.summary.linksFound).toBe(2);
+    expect(out.emails.find((e: any) => e.uid === 2).unsubscribe_link).toContain('https://body.example/unsubscribe');
+  });
+
+  it('processes in ascending UID order and honors afterUid for resume', async () => {
+    const out = await invoke(tools, 'imap_extract_unsubscribe_links', {
+      userId: 'user-1', accountId: 'a', folder: 'INBOX', afterUid: 1, scanBodies: false,
+    });
+    // uid 1 skipped by the cursor; only 2 and 3 considered.
+    expect(out.summary.processed).toBe(2);
+    expect(imap.calls.getUnsubscribeHeaders[0]).toEqual([2, 3]);
+  });
+
+  it('returns a partial result with truncated + nextUid when the time budget is exceeded', async () => {
+    const out = await invoke(tools, 'imap_extract_unsubscribe_links', {
+      userId: 'user-1', accountId: 'a', folder: 'INBOX', maxDurationMs: -1,
+    });
+    expect(out.summary.truncated).toBe(true);
+    expect(out.summary.processed).toBe(0);
+    expect(out.summary.nextUid).toBe(0); // first uid (1) minus 1 → resume includes uid 1
+    expect(out.summary.hint).toMatch(/afterUid: 0/);
+  });
+
+  it('stores found links to the database', async () => {
+    await invoke(tools, 'imap_extract_unsubscribe_links', {
+      userId: 'user-1', accountId: 'a', folder: 'INBOX', scanBodies: false,
+    });
+    expect(db.stored).toHaveLength(1);
+    expect(db.stored[0]).toMatchObject({ user_id: 'user-1', account_id: 'a', uid: 1 });
+  });
+});

--- a/src/tools/subscription-tools.ts
+++ b/src/tools/subscription-tools.ts
@@ -90,19 +90,30 @@ export function registerSubscriptionTools(
    * Extract unsubscribe links from emails in a folder
    */
   server.registerTool('imap_extract_unsubscribe_links', {
-    description: 'Scan folder for unsubscribe links in emails. Extracts List-Unsubscribe headers and body links. Stores to database for subscription management. Processes 100+ emails efficiently.',
+    description:
+      'Scan a folder for unsubscribe links and store them for subscription management. ' +
+      'Header-first: reads each message\'s List-Unsubscribe header cheaply (no body download) and only ' +
+      'falls back to a full-body fetch when a message has no header and scanBodies is on. Bounded by an ' +
+      'internal time budget (maxDurationMs) so it always returns — on timeout it returns a partial result ' +
+      'with truncated:true and nextUid for resuming via afterUid. For large folders, paginate with afterUid.',
     inputSchema: {
       userId: z.string().describe('User ID (either canonical user_id UUID or username from the users table). Call imap_list_users for valid values.'),
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name'),
       limit: z.number().optional().default(100).describe('Max emails to process (default: 100)'),
-      olderThan: z.number().optional().describe('Optional: Only process emails older than N days')
+      olderThan: z.number().optional().describe('Optional: Only process emails older than N days'),
+      afterUid: z.number().optional().describe('Resume: only process messages with UID greater than this (pass the previous run\'s nextUid).'),
+      scanBodies: z.boolean().optional().default(true).describe('On a header miss, fetch the full body to find in-body unsubscribe links (slower). Default true.'),
+      maxDurationMs: z.number().optional().default(50000).describe('Internal time budget in ms; on exceed, return a partial result with truncated:true (default 50000).'),
     }
-  }, withErrorHandling(async ({ userId: userIdRaw, accountId, folder, limit, olderThan }: {
-    userId: string; accountId: string; folder: string; limit?: number; olderThan?: number
+  }, withErrorHandling(async ({ userId: userIdRaw, accountId, folder, limit, olderThan, afterUid, scanBodies, maxDurationMs }: {
+    userId: string; accountId: string; folder: string; limit?: number; olderThan?: number;
+    afterUid?: number; scanBodies?: boolean; maxDurationMs?: number;
   }) => {
     const userId = resolveUserOrThrow(db, userIdRaw);
     const startTime = Date.now();
+    const budgetMs = maxDurationMs ?? 50000;
+    const wantBodyScan = scanBodies !== false;
 
     // Build search criteria
     const searchCriteria: any = {};
@@ -112,16 +123,25 @@ export function registerSubscriptionTools(
       searchCriteria.before = date;
     }
 
-    // Search for emails
-    const emails = await imapService.searchEmails(accountId, folder, searchCriteria);
-
-    // Limit results if specified
+    // Search for emails, apply resume cursor + limit. Process in ascending UID
+    // order so nextUid/afterUid paging is monotonic.
+    const emails = (await imapService.searchEmails(accountId, folder, searchCriteria))
+      .filter((e) => afterUid == null || e.uid > afterUid)
+      .sort((a, b) => a.uid - b.uid);
     const limitedEmails = limit ? emails.slice(0, limit) : emails;
+
+    // One cheap streaming fetch of just the List-Unsubscribe header lines for
+    // the whole set — avoids a full-body download per message (#131).
+    const headerRows = await imapService.getUnsubscribeHeaders(
+      accountId, folder, limitedEmails.map((e) => e.uid)
+    );
+    const headerByUid = new Map(headerRows.map((r) => [r.uid, r]));
 
     const results = {
       processed: 0,
       linksFound: 0,
       linksStored: 0,
+      bodyScans: 0,
       errors: 0,
       emails: [] as any[],
       // Per-message error reasons so the tool surface is debuggable on its
@@ -129,44 +149,57 @@ export function registerSubscriptionTools(
       failedLinks: [] as Array<{ uid: number; from: string; reason: string }>
     };
 
-    // Process each email
+    let truncated = false;
+    let nextUid: number | null = null;
+
     for (const email of limitedEmails) {
+      // Time budget (#131): stop before starting more work and hand back a
+      // partial result the caller can resume from.
+      if (Date.now() - startTime > budgetMs) {
+        truncated = true;
+        nextUid = email.uid - 1; // resume with afterUid = nextUid → reprocesses from here
+        break;
+      }
+
       try {
         results.processed++;
+        const row = headerByUid.get(email.uid);
+        const from = row?.from || email.from;
+        const subject = row?.subject || email.subject;
+        const date = row?.date ?? (email.date ? new Date(email.date) : undefined);
 
-        // Get full email content (includes body for parsing)
-        const emailContent = await imapService.getEmailContent(accountId, folder, email.uid, false);
+        // Header-first: parse the cheap header block (trailing blank line makes
+        // it a valid header-only RFC822 fragment for the parser).
+        let unsubscribeInfo = row?.headerBytes
+          ? await unsubscribeService.extractFromEmail(Buffer.concat([row.headerBytes, Buffer.from('\r\n')]))
+          : {};
 
-        // Build email source from parts for parsing
-        const emailSource = [
-          emailContent.textContent || '',
-          emailContent.htmlContent || ''
-        ].join('\n\n');
-
-        // Extract unsubscribe info from the email body/headers
-        const unsubscribeInfo = await unsubscribeService.extractFromEmail(emailSource);
+        // Fallback: only when the header yielded nothing and body scan is on.
+        if (!unsubscribeInfo.unsubscribe_link && !unsubscribeInfo.list_unsubscribe_header && wantBodyScan) {
+          results.bodyScans++;
+          const emailContent = await imapService.getEmailContent(accountId, folder, email.uid, false);
+          const emailSource = [emailContent.textContent || '', emailContent.htmlContent || ''].join('\n\n');
+          unsubscribeInfo = await unsubscribeService.extractFromEmail(emailSource);
+        }
 
         // v2.17.6 (#143): sanitize before storing so future-stored URLs
-        // are free of parsing residue (`>™`, `]`, control chars). Existing
-        // stored data is sanitized on the read path; new writes get the
-        // benefit at the source.
+        // are free of parsing residue (`>™`, `]`, control chars).
         const cleanLink = sanitizeUrl(unsubscribeInfo.unsubscribe_link);
         const cleanHeader = sanitizeText(unsubscribeInfo.list_unsubscribe_header, 500);
-        const cleanSubject = sanitizeText(email.subject, 200);
+        const cleanSubject = sanitizeText(subject, 200);
 
         if (cleanLink || cleanHeader) {
           results.linksFound++;
 
-          // Store to database with sanitized fields.
           unsubscribeService.storeUnsubscribeLink({
             user_id: userId,
             account_id: accountId,
             folder,
             uid: email.uid,
-            sender_email: email.from,
-            sender_name: email.from.split('<')[0].trim(),
+            sender_email: from,
+            sender_name: from.split('<')[0].trim(),
             subject: cleanSubject ?? undefined,
-            message_date: email.date ? new Date(email.date) : undefined,
+            message_date: date,
             unsubscribe_info: {
               ...unsubscribeInfo,
               unsubscribe_link: cleanLink ?? undefined,
@@ -178,9 +211,9 @@ export function registerSubscriptionTools(
 
           results.emails.push({
             uid: email.uid,
-            from: email.from,
+            from,
             subject: cleanSubject,
-            date: email.date,
+            date,
             unsubscribe_link: cleanLink,
             unsubscribe_method: unsubscribeInfo.unsubscribe_method,
             has_list_unsubscribe_header: !!cleanHeader,
@@ -206,10 +239,14 @@ export function registerSubscriptionTools(
         text: JSON.stringify({
           summary: {
             processed: results.processed,
+            candidates: limitedEmails.length,
             linksFound: results.linksFound,
             linksStored: results.linksStored,
+            bodyScans: results.bodyScans,
             errors: results.errors,
-            elapsed_ms: elapsed
+            elapsed_ms: elapsed,
+            truncated,
+            ...(truncated ? { nextUid, hint: `Re-run with afterUid: ${nextUid} to continue.` } : {}),
           },
           emails: results.emails,
           // Only include when non-empty to avoid noise on healthy runs.


### PR DESCRIPTION
## #131 — `imap_extract_unsubscribe_links` timeout on large folders

On a large folder the tool fetched the **full body of every message** and could exceed the MCP transport timeout (~4 min) returning nothing. Fixed two ways:

### Header-first (cheap) extraction
New `ImapService.getUnsubscribeHeaders()` does **one streaming FETCH of just the `List-Unsubscribe`(/`-Post`) header lines** (envelope + headers, no body) for the whole UID set. The common case — promotional mail, which almost always carries `List-Unsubscribe` — resolves from headers alone with **zero body downloads**.

This also fixes a **latent correctness bug**: the old code built the parse source from body text only (`textContent` + `htmlContent`) and never passed the actual header, so the header-based extractor branch never fired — it silently under-found header links and only caught in-body HTML links.

A full-body fetch is now a **fallback**, used only on a header miss and only when `scanBodies` (new input, default `true`) is on.

### Time budget + resume
- `maxDurationMs` (new, default 50000): when exceeded, the tool stops and returns a **partial result** with `truncated: true` and `nextUid`.
- `afterUid` (new): resume from the previous run's `nextUid`. Processing is now in **ascending UID order** so paging is monotonic.

Summary gains `candidates` / `bodyScans` / `truncated` / `nextUid`.

### Tests (5 new, 177 total)
header-first with no body fetch · body fallback only on header miss · `afterUid` resume · budget-exceeded partial result · DB store.

### Notes
Related longer-term paths remain open: #119 (local cache obsolesces body-fetching for sender enumeration). The HTML in-body link extractor has a minor trailing-markup quirk (pre-existing, out of scope here).
