### PR TITLE
docs: generate tool catalog from manifest + archive stale docs (#201)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An enterprise-grade Model Context Protocol (MCP) server that provides production
 
 ## Features
 
-**107 MCP tools** across email/folder/account/category/scoring/subscription/dns-firewall/usercheck/staging/cache/diagnostics — every IMAP4rev2 (RFC 9051) operation we use is exposed. (Run `imap_list_tools` for the live, authoritative catalog.)
+**107 MCP tools** across email/folder/account/category/scoring/subscription/dns-firewall/usercheck/staging/cache/diagnostics — every IMAP4rev2 (RFC 9051) operation we use is exposed. See the full categorized list in [docs/TOOL_CATALOG.md](docs/TOOL_CATALOG.md) (generated from the manifest on every build), or run `imap_list_tools` for the live catalog at runtime.
 
 ### Core Features
 - 🔐 **Secure Account Management**: Encrypted credential storage with AES-256 encryption

--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -1,5 +1,7 @@
 # IMAP MCP Pro - Test Results
 
+> **⚠️ Historical snapshot (v2.12.0).** The tool counts and tool lists below reflect that release and are out of date. For the current tool catalog see [docs/TOOL_CATALOG.md](docs/TOOL_CATALOG.md) (or `imap_list_tools`); current automated-test status is the `vitest` suite (`npm test`). Retained for history.
+
 **Date:** 2025-11-17
 **Version:** 2.12.0
 **Node.js:** v24.11.0

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,7 @@
 # IMAP MCP Pro - Development TODO
 
+> **⚠️ Historical document.** Active work is tracked in **GitHub Issues / Projects**, not here. Any tool counts or task lists below are a point-in-time snapshot and are out of date — the authoritative tool list is [docs/TOOL_CATALOG.md](docs/TOOL_CATALOG.md) (or `imap_list_tools`). Retained for history.
+
 **Project**: IMAP MCP Pro (Enterprise Edition)
 **Organization**: Temple of Epiphany
 **Repository**: https://github.com/Temple-of-Epiphany/imap-mcp-pro

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -156,7 +156,7 @@ imap-mcp-pro/
 
 ## MCP Tools
 
-> **Authoritative catalog:** the live, complete tool list (currently **107 tools**) is always available at runtime via `imap_list_tools`. The detailed catalog below documents the core set; the "Recent additions" section tracks tools added since, and the remaining catalog is reconciled incrementally.
+> **Authoritative catalog:** the complete categorized tool list is generated from the manifest on every build at **[TOOL_CATALOG.md](./TOOL_CATALOG.md)** (currently **107 tools**), and is also available at runtime via `imap_list_tools`. The detailed catalog below documents the core set with full input/output notes; the "Recent additions" section tracks the newest tools.
 
 ### Recent additions (v2.17–v2.19)
 

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -1,0 +1,202 @@
+# Tool Catalog
+
+> **Generated file — do not edit by hand.** Produced from the live tool
+> manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
+> The authoritative runtime list is always available via the `imap_list_tools` tool.
+
+**107 MCP tools** total.
+
+## Categories
+
+- [Users (MSP multi-tenant)](#users-msp-multitenant) — 3
+- [Account management](#account-management) — 15
+- [Bulk operations](#bulk-operations) — 11
+- [Size, export & quota](#size-export-quota) — 7
+- [Attachment staging](#attachment-staging) — 6
+- [Email operations](#email-operations) — 11
+- [Folder & mailbox operations](#folder-mailbox-operations) — 11
+- [Subscriptions & unsubscribe](#subscriptions-unsubscribe) — 9
+- [Categorization & scoring](#categorization-scoring) — 6
+- [Spam & UserCheck](#spam-usercheck) — 7
+- [DNS firewall & domain checks](#dns-firewall-domain-checks) — 3
+- [Local cache](#local-cache) — 2
+- [Capabilities, diagnostics & metrics](#capabilities-diagnostics-metrics) — 11
+- [Meta & discovery](#meta-discovery) — 5
+
+## Users (MSP multi-tenant)
+
+| Tool | Description |
+| --- | --- |
+| `imap_create_user` | Create a new user (MSP multi-tenant support) |
+| `imap_get_user` | Get user details by username |
+| `imap_list_users` | List all active users |
+
+## Account management
+
+| Tool | Description |
+| --- | --- |
+| `imap_add_account` | Add a new IMAP account with optional SMTP configuration for current user (from MCP_USER_ID environment variable) |
+| `imap_add_account_auto` | Add a new IMAP account by auto-detecting provider from email address (e.g., @gmail.com → Gmail preset) |
+| `imap_add_account_with_provider` | Add a new IMAP account using a provider preset (auto-fills IMAP/SMTP settings). |
+| `imap_connect` | Connect to an IMAP account |
+| `imap_db_add_account` | Add IMAP account to database (with encryption at rest) |
+| `imap_db_get_account` | Get decrypted account details |
+| `imap_db_list_accounts` | List all IMAP accounts for a user |
+| `imap_db_remove_account` | Remove IMAP account from database |
+| `imap_disconnect` | Disconnect from an IMAP account |
+| `imap_list_accounts` | List all IMAP accounts for current user (from MCP_USER_ID environment variable) |
+| `imap_list_providers` | List all available email provider presets (Gmail, Outlook, Yahoo, etc.) with pre-configured IMAP/SMTP settings |
+| `imap_remove_account` | Remove an IMAP account from database |
+| `imap_share_account` | Share an account with another user (MSP feature) |
+| `imap_test_account` | Test an existing account's IMAP connectivity using its stored credentials. |
+| `imap_unshare_account` | Revoke account access from a user |
+
+## Bulk operations
+
+| Tool | Description |
+| --- | --- |
+| `imap_bulk_check_domains` | Check multiple domains against DNS firewall in bulk |
+| `imap_bulk_copy_emails` | Bulk copy multiple emails to another folder |
+| `imap_bulk_delete_emails` | Bulk delete multiple emails by UIDs. |
+| `imap_bulk_delete_emails_chunked` | Bulk delete emails with chunking for large operations (1000+ messages). |
+| `imap_bulk_get_emails` | Bulk fetch multiple emails at once. |
+| `imap_bulk_get_emails_chunked` | Bulk fetch emails with chunking for large operations (1000+ messages). |
+| `imap_bulk_mark_emails` | Bulk mark multiple emails with standard IMAP flags. |
+| `imap_bulk_mark_emails_chunked` | Bulk mark emails with chunking for large operations (1000+ messages). |
+| `imap_bulk_move_emails` | Bulk move multiple emails to another folder (copy + delete) |
+| `imap_bulk_scan_messages` | Scan multiple messages for malicious domains and optionally auto-mark as spam |
+| `imap_bulk_score_emails` | Analyze multiple emails for spoofing detection. |
+
+## Size, export & quota
+
+| Tool | Description |
+| --- | --- |
+| `imap_export_account` | Export the entire account to .eml files, mirroring the full mailbox folder structure under exports/[subfolder]/. |
+| `imap_export_email` | Export one or more messages to standard .eml files on the server host (download & save). |
+| `imap_export_folder` | Export all messages in a folder to standard .eml files on the server host, mirroring the folder hierarchy under the per-user outbox (exports/[subfolder]/{folder path}/). |
+| `imap_extract_attachments` | Extract file attachments from a block of messages and save them to disk under the per-user outbox (exports/attachments/[subfolder]/). |
+| `imap_get_email_sizes` | List messages by size to find large emails — uses RFC822.SIZE (no body download, cheap even on big folders). |
+| `imap_get_largest_emails` | Find the largest emails across several folders at once (default: just INBOX) and return the global top-N. |
+| `imap_get_quota` | Report account storage quota — used / limit / percent — via the IMAP QUOTA extension (RFC 9208). |
+
+## Attachment staging
+
+| Tool | Description |
+| --- | --- |
+| `imap_attachment_stage_append` | Append one chunk to a staging session. |
+| `imap_attachment_stage_cancel` | Discard a staging session and reclaim its disk space. |
+| `imap_attachment_stage_finalize` | Concatenate the uploaded chunks in order, compute SHA-256, mark the session ready for use in imap_send_email via stagedAttachmentIds. |
+| `imap_attachment_stage_init` | Begin a chunked attachment upload. |
+| `imap_get_outbox_dir` | Return the per-user attachment outbox directory path. |
+| `imap_list_staged_attachments` | List staging sessions for the current user (or all users if no userId is provided and the caller is admin context). |
+
+## Email operations
+
+| Tool | Description |
+| --- | --- |
+| `imap_copy_email` | Copy an email to another folder |
+| `imap_delete_email` | Delete an email (moves to trash or expunges) |
+| `imap_forward_email` | Forward an existing email |
+| `imap_get_email` | Get the full content of an email or just headers |
+| `imap_get_latest_emails` | Get the latest emails from a folder. |
+| `imap_mark_as_read` | Mark an email as read |
+| `imap_mark_as_unread` | Mark an email as unread |
+| `imap_move_email` | Move an email to another folder (copy + delete) |
+| `imap_reply_to_email` | Reply to an existing email |
+| `imap_search_emails` | Search for emails in a folder. |
+| `imap_send_email` | Send an email via SMTP and (by default) append the message to the IMAP Sent folder. |
+
+## Folder & mailbox operations
+
+| Tool | Description |
+| --- | --- |
+| `imap_append_message` | Append a raw RFC822 message to a mailbox (useful for importing emails, saving drafts, or copying messages) |
+| `imap_create_folder` | Create a new folder/mailbox in an IMAP account |
+| `imap_delete_folder` | Delete a folder/mailbox from an IMAP account |
+| `imap_folder_status` | Get status information about a folder |
+| `imap_get_mailbox_status` | Get mailbox statistics without selecting it (RFC 9051 STATUS command) - more efficient than SELECT |
+| `imap_get_unread_count` | Get the count of unread emails in specified folders |
+| `imap_list_folders` | List all folders/mailboxes in an IMAP account |
+| `imap_list_subscribed_mailboxes` | List all subscribed mailboxes (RFC 9051 LSUB/LIST with SUBSCRIBED) |
+| `imap_rename_folder` | Rename a folder/mailbox in an IMAP account |
+| `imap_subscribe_mailbox` | Subscribe to a mailbox (RFC 9051 SUBSCRIBE command) |
+| `imap_unsubscribe_mailbox` | Unsubscribe from a mailbox (RFC 9051 UNSUBSCRIBE command) |
+
+## Subscriptions & unsubscribe
+
+| Tool | Description |
+| --- | --- |
+| `imap_execute_unsubscribe` | Execute unsubscribe request for one or more senders. |
+| `imap_extract_unsubscribe_links` | Scan a folder for unsubscribe links and store them for subscription management. |
+| `imap_get_subscription_summary` | Get aggregated subscription summary. |
+| `imap_get_unsubscribe_links` | Get all extracted unsubscribe links from emails. |
+| `imap_get_unsubscribe_links_for` | Read-only: for a block of messages (explicit UIDs, or a folder scan up to `limit`), return per message the unsubscribe links found in BOTH the List-Unsubscribe header and the body, along with sender, recipient, and subject. |
+| `imap_list_unsubscribe_candidates` | List all subscriptions with unsubscribe links. |
+| `imap_mark_subscription_unsubscribed` | Mark a sender as unsubscribed in the database. |
+| `imap_update_subscription_category` | Update the category of a subscription (marketing, newsletter, promotional, transactional, other). |
+| `imap_update_subscription_notes` | Add or update notes for a subscription. |
+
+## Categorization & scoring
+
+| Tool | Description |
+| --- | --- |
+| `imap_add_keyword` | Add a custom keyword to emails. |
+| `imap_analyze_folder_confidence` | Analyze all emails in a folder and provide confidence statistics. |
+| `imap_apply_categories` | Apply Quick Categories to emails in a folder. |
+| `imap_list_categories` | List all Quick Categories for a user, optionally filtered by account |
+| `imap_remove_keyword` | Remove a custom keyword from emails |
+| `imap_score_email_confidence` | Analyze email headers to detect spoofing and calculate confidence score (-100 to +100). |
+
+## Spam & UserCheck
+
+| Tool | Description |
+| --- | --- |
+| `imap_add_usercheck_key` | Add a UserCheck API key for a user (admin or own user only) |
+| `imap_check_email_spam` | Check a single email address against UserCheck for spam |
+| `imap_check_emails_spam_bulk` | Check multiple email addresses against UserCheck for spam (max 1000) |
+| `imap_check_folder_spam` | Check all emails in a folder against UserCheck and return spam messages |
+| `imap_delete_usercheck_key` | Delete a UserCheck API key |
+| `imap_get_usercheck_key` | Get UserCheck API key information for a user |
+| `imap_scan_account_spam` | Scan entire IMAP account for spam using UserCheck, checking all folders |
+
+## DNS firewall & domain checks
+
+| Tool | Description |
+| --- | --- |
+| `imap_check_domain` | Check a domain against UserCheck for spam/validity |
+| `imap_check_domain_dns_firewall` | Check if a domain is blocked by DNS firewall (Quad9 threat intelligence) |
+| `imap_scan_message_domains` | Extract and validate all domains from an email message against DNS firewall |
+
+## Local cache
+
+| Tool | Description |
+| --- | --- |
+| `imap_search_cache` | Fast SQL-backed search against the local header cache. |
+| `imap_sync_folder_cache` | Populate the local message header cache for one folder. |
+
+## Capabilities, diagnostics & metrics
+
+| Tool | Description |
+| --- | --- |
+| `imap_get_capabilities` | Query IMAP server capabilities and supported extensions (RFC 9051 CAPABILITY command) |
+| `imap_get_circuit_breaker` | Inspect the per-account circuit breaker state (CLOSED / OPEN / HALF_OPEN), failure count, last failure reason, and configured thresholds/timeout. |
+| `imap_get_metrics` | Get connection metrics and health information for an account |
+| `imap_get_operation_metrics` | Get detailed metrics for IMAP operations |
+| `imap_get_smtp_metrics` | Get per-account SMTP metrics: send total, success/failure counts, retry counts (split by error category), last-send duration and timestamp, last error info. |
+| `imap_list_unarchived_sends` | List queued Sent-folder APPEND operations that failed after a successful SMTP send. |
+| `imap_reset_circuit_breaker` | Manually reset the circuit breaker for an account back to CLOSED with zero failure count. |
+| `imap_reset_metrics` | Reset connection metrics for an account |
+| `imap_reset_smtp_metrics` | Reset SMTP metrics for an account (or all accounts if omitted). |
+| `imap_test_sent_folder` | Diagnose Sent folder resolution for an account. |
+| `imap_test_smtp` | Probe SMTP connectivity for an account without sending. |
+
+## Meta & discovery
+
+| Tool | Description |
+| --- | --- |
+| `imap_about` | Get comprehensive information about the IMAP MCP Pro service including version, features, and capabilities |
+| `imap_check_skill_updates` | Check public GitHub for newer skill versions without changing anything on disk. |
+| `imap_list_tools` | List all available MCP tools with descriptions and parameters |
+| `imap_results` | Manage cached MCP tool results (resource-handle pattern). |
+| `imap_update_skills` | Apply skill updates from public GitHub for explicitly named skills. |
+

--- a/docs/chunked_bulk_operations.md
+++ b/docs/chunked_bulk_operations.md
@@ -1,5 +1,7 @@
 # Chunked Bulk Operations - Solution for Large-Scale Email Processing
 
+> **Note:** Design/reference document. Any "N tools registered" figures in the example output are illustrative and dated — the authoritative tool list is [TOOL_CATALOG.md](./TOOL_CATALOG.md) (or `imap_list_tools`). The chunked-bulk design described here is current.
+
 **Author:** Colin Bitterfield
 **Email:** colin.bitterfield@templeofepiphany.com
 **Date Created:** 2025-01-24

--- a/docs/sdk_audit_2026-04-29.md
+++ b/docs/sdk_audit_2026-04-29.md
@@ -1,5 +1,7 @@
 # MCP SDK Alignment Audit — 2026-04-29
 
+> **⚠️ Historical audit (2026-04-29).** Tool counts (~80) and the OS-keyring/`CLAUDE_DESKTOP_EXTENSION` key-storage references reflect that date. Since then `keytar`/SQLCipher were removed (#181 — storage is now file-based AES-256-GCM) and the tool count has grown ([TOOL_CATALOG.md](./TOOL_CATALOG.md)). Current SDK status (ReDoS / cross-client-leak advisories, deferred upstream) is tracked in **#205**. Retained for history.
+
 **Author:** Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
 **Date Created:** 2026-04-29
 **Date Updated:** 2026-04-29

--- a/scripts/gen-tool-catalog.mjs
+++ b/scripts/gen-tool-catalog.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * gen-tool-catalog.mjs — generate docs/TOOL_CATALOG.md from the live tool manifest.
+ *
+ * Reads the authoritative tool list (name + description) straight from the
+ * built server (`node dist/index.js --print-tools-manifest`), buckets the tools
+ * into stable categories, and writes a Markdown catalog. Run from postbuild so
+ * the catalog can never drift from the registered tools again (#201).
+ *
+ * Author:        Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+ * Part of:       IMAP MCP Pro (Temple of Epiphany)
+ * Date Created:  2026-06-21
+ * Date Updated:  2026-06-21
+ * Version:       1.0.0
+ *
+ * Changelog:
+ *   1.0.0 (2026-06-21) — initial: manifest → categorized docs/TOOL_CATALOG.md.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const distEntry = path.join(repoRoot, 'dist', 'index.js');
+const outPath = path.join(repoRoot, 'docs', 'TOOL_CATALOG.md');
+
+// Ordered (regex → category) rules; first match wins. Keep specific patterns
+// (e.g. *_chunked, db_*) ahead of broader ones.
+const CATEGORIES = [
+  ['Users (MSP multi-tenant)', /^imap_(create_user|get_user|list_users)$/],
+  ['Account management', /^imap_(add_account|add_account_auto|add_account_with_provider|remove_account|list_accounts|connect|disconnect|test_account|share_account|unshare_account|list_providers|db_add_account|db_get_account|db_list_accounts|db_remove_account)$/],
+  ['Bulk operations', /^imap_bulk_/],
+  ['Size, export & quota', /^imap_(get_email_sizes|get_largest_emails|export_email|export_folder|export_account|extract_attachments|get_quota)$/],
+  ['Attachment staging', /^imap_(attachment_stage_|list_staged_attachments|get_outbox_dir)/],
+  ['Email operations', /^imap_(search_emails|get_email|get_latest_emails|mark_as_read|mark_as_unread|delete_email|copy_email|move_email|send_email|reply_to_email|forward_email)$/],
+  ['Folder & mailbox operations', /^imap_(list_folders|folder_status|get_unread_count|create_folder|delete_folder|rename_folder|get_mailbox_status|subscribe_mailbox|unsubscribe_mailbox|list_subscribed_mailboxes|append_message)$/],
+  ['Subscriptions & unsubscribe', /^imap_(extract_unsubscribe_links|get_unsubscribe_links|get_unsubscribe_links_for|execute_unsubscribe|get_subscription_summary|list_unsubscribe_candidates|mark_subscription_unsubscribed|update_subscription_category|update_subscription_notes)$/],
+  ['Categorization & scoring', /^imap_(add_keyword|remove_keyword|list_categories|apply_categories|analyze_folder_confidence|score_email_confidence)$/],
+  ['Spam & UserCheck', /^imap_(check_email_spam|check_emails_spam_bulk|check_folder_spam|scan_account_spam|add_usercheck_key|get_usercheck_key|delete_usercheck_key)$/],
+  ['DNS firewall & domain checks', /^imap_(check_domain|check_domain_dns_firewall|scan_message_domains)$/],
+  ['Local cache', /^imap_(search_cache|sync_folder_cache)$/],
+  ['Capabilities, diagnostics & metrics', /^imap_(get_capabilities|test_smtp|test_sent_folder|list_unarchived_sends|get_metrics|get_operation_metrics|reset_metrics|get_smtp_metrics|reset_smtp_metrics|get_circuit_breaker|reset_circuit_breaker)$/],
+  ['Meta & discovery', /^imap_(about|list_tools|check_skill_updates|update_skills|results)$/],
+];
+
+function categoryFor(name) {
+  for (const [label, rx] of CATEGORIES) if (rx.test(name)) return label;
+  return 'Other';
+}
+
+function loadManifest() {
+  if (!existsSync(distEntry)) {
+    throw new Error(`Built server not found at ${distEntry} — run "npm run build" first.`);
+  }
+  // Point the spawned server at a throwaway DB so generating docs during a
+  // build never touches the developer's real ~/.imap-mcp/data.db.
+  const throwawayDb = path.join(tmpdir(), `imap-mcp-catalog-${process.pid}.db`);
+  const raw = execFileSync('node', [distEntry, '--print-tools-manifest'], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, IMAP_MCP_DATABASE_PATH: throwawayDb },
+  });
+  return JSON.parse(raw);
+}
+
+function firstSentence(desc) {
+  const s = String(desc || '').replace(/\s+/g, ' ').trim();
+  const m = s.match(/^(.*?[.!?])(\s|$)/);
+  return (m ? m[1] : s).slice(0, 240);
+}
+
+function render(tools) {
+  const byCat = new Map(CATEGORIES.map(([label]) => [label, []]));
+  byCat.set('Other', []);
+  for (const t of tools) byCat.get(categoryFor(t.name)).push(t);
+
+  const lines = [];
+  lines.push('# Tool Catalog');
+  lines.push('');
+  lines.push('> **Generated file — do not edit by hand.** Produced from the live tool');
+  lines.push('> manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).');
+  lines.push('> The authoritative runtime list is always available via the `imap_list_tools` tool.');
+  lines.push('');
+  lines.push(`**${tools.length} MCP tools** total.`);
+  lines.push('');
+
+  // Table of contents with per-category counts.
+  lines.push('## Categories');
+  lines.push('');
+  for (const [label] of [...CATEGORIES, ['Other']]) {
+    const items = byCat.get(label);
+    if (!items || items.length === 0) continue;
+    const anchor = label.toLowerCase().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, '-');
+    lines.push(`- [${label}](#${anchor}) — ${items.length}`);
+  }
+  lines.push('');
+
+  for (const [label] of [...CATEGORIES, ['Other']]) {
+    const items = byCat.get(label);
+    if (!items || items.length === 0) continue;
+    items.sort((a, b) => a.name.localeCompare(b.name));
+    lines.push(`## ${label}`);
+    lines.push('');
+    lines.push('| Tool | Description |');
+    lines.push('| --- | --- |');
+    for (const t of items) {
+      lines.push(`| \`${t.name}\` | ${firstSentence(t.description).replace(/\|/g, '\\|')} |`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n') + '\n';
+}
+
+const manifest = loadManifest();
+const tools = (manifest.tools || []).slice().sort((a, b) => a.name.localeCompare(b.name));
+writeFileSync(outPath, render(tools));
+console.log(`[gen-tool-catalog] wrote ${path.relative(repoRoot, outPath)} (${tools.length} tools)`);

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -22,8 +22,12 @@
  * Author: Colin Bitterfield
  * Email: colin.bitterfield@templeofepiphany.com
  * Date Created: 2026-04-30
- * Date Updated: 2026-05-01
- * Version: 1.1.0
+ * Date Updated: 2026-06-21
+ * Version: 1.2.0
+ *
+ * Changelog:
+ *   1.2.0 (2026-06-21) — regenerate docs/TOOL_CATALOG.md from the built server (#201).
+ *   1.1.0 (2026-05-01) — bundle skills + web UI assets into dist/.
  */
 
 import { mkdir, copyFile, readdir, cp, stat } from 'node:fs/promises';
@@ -98,6 +102,23 @@ try {
 }
 
 // ---------------------------------------------------------------------------
+// Tool catalog: regenerate docs/TOOL_CATALOG.md from the just-built server (#201)
+// ---------------------------------------------------------------------------
+//
+// Keeps the documented tool catalog in lockstep with the registered tools.
+// gen-tool-catalog.mjs spawns the built server (pointed at a throwaway DB) to
+// read the live manifest. Non-fatal: a docs hiccup must never fail the build.
+
+let catalogGenerated = false;
+try {
+  const { execFileSync } = await import('node:child_process');
+  execFileSync('node', ['scripts/gen-tool-catalog.mjs'], { stdio: 'ignore' });
+  catalogGenerated = true;
+} catch (e) {
+  console.warn(`[postbuild] tool catalog generation skipped: ${e.message}`);
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 
@@ -107,5 +128,6 @@ const parts = [
 if (manifestCopied) parts.push('migrations-manifest.json');
 if (skillsCopied > 0) parts.push(`${skillsCopied} bundled skill${skillsCopied === 1 ? '' : 's'}`);
 if (publicAssetCount > 0) parts.push(`${publicAssetCount} web UI asset${publicAssetCount === 1 ? '' : 's'}`);
+if (catalogGenerated) parts.push('docs/TOOL_CATALOG.md');
 
 console.log(`[postbuild] copied ${parts.join(' + ')}`);


### PR DESCRIPTION
## #201 (part 2) — generated tool catalog + stale-doc archival

Completes the documentation cleanup remainder.

### Generated, drift-proof tool catalog
- New **`scripts/gen-tool-catalog.mjs`** reads the live tool manifest and writes **`docs/TOOL_CATALOG.md`** — 107 tools across 14 categories, no uncategorized "Other" bucket. Wired into **postbuild**, so the catalog is regenerated on every `npm run build` and can't drift from the registered tools.
- Side-effect-free: the script spawns the built server pointed at a **throwaway temp DB** (`IMAP_MCP_DATABASE_PATH`), so builds never touch the developer's `~/.imap-mcp/data.db`.
- **README** and **SPECIFICATION** now link the generated catalog as the single source of truth, alongside the runtime `imap_list_tools`.

### Stale working docs — historical banners
`TODO.md` (work is tracked in GitHub Issues), `TEST_RESULTS.md` (v2.12.0 snapshot), `docs/chunked_bulk_operations.md` (illustrative counts), `docs/sdk_audit_2026-04-29.md` (keyring/~80-tool references predate #181; current SDK status → #205). Each now points to `TOOL_CATALOG.md` / the authoritative source.

### Wiki
Opened **#218** (engineering-wiki companion, Hard Rule 24) to reconcile the wiki's tool list / keyring / license drift — preferring a link to the generated catalog over duplication.

### Verification
`npm run build` regenerates the 107-row catalog; 177 tests pass; working tree shows only docs + scripts (no real DB touched).

Refs #201. With this + #215, the repo-side #201 acceptance items are complete; #218 tracks the wiki.
