### PR TITLE
feat: IMAP message priority management (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An enterprise-grade Model Context Protocol (MCP) server that provides production
 
 ## Features
 
-**107 MCP tools** across email/folder/account/category/scoring/subscription/dns-firewall/usercheck/staging/cache/diagnostics — every IMAP4rev2 (RFC 9051) operation we use is exposed. See the full categorized list in [docs/TOOL_CATALOG.md](docs/TOOL_CATALOG.md) (generated from the manifest on every build), or run `imap_list_tools` for the live catalog at runtime.
+**100+ MCP tools** across email/folder/account/category/scoring/subscription/dns-firewall/usercheck/staging/cache/diagnostics — every IMAP4rev2 (RFC 9051) operation we use is exposed. See the full categorized list with exact count in [docs/TOOL_CATALOG.md](docs/TOOL_CATALOG.md) (generated from the manifest on every build), or run `imap_list_tools` for the live catalog at runtime.
 
 ### Core Features
 - 🔐 **Secure Account Management**: Encrypted credential storage with AES-256 encryption

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ src/
 │   ├── results-service.ts        # Tool-result cache (handle/file modes), LRU eviction
 │   ├── file-export-service.ts    # Encrypted JSON/JSONL writer for file-mode results
 │   └── message-export-service.ts # Local .eml/attachment export, path-traversal-guarded (#170)
-├── tools/                        # 107 MCP tools across 12 files (run imap_list_tools for the live catalog)
+├── tools/                        # 100+ MCP tools across 12 files (see docs/TOOL_CATALOG.md for the exact list)
 │   ├── account-tools.ts          # 8  add/remove/list/share accounts
 │   ├── email-tools.ts            # 32 search/get/mark/delete/move/copy/send/bulk + WP1/2/3/4
 │   ├── folder-tools.ts           # 6  list/status/create/delete/rename

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -34,7 +34,7 @@
 IMAP MCP Pro is a Model Context Protocol (MCP) server that provides comprehensive IMAP email integration for Claude AI, enabling intelligent email management, automation, and analysis.
 
 ### Key Features
-- ✅ **107 MCP Tools** for complete email management (run `imap_list_tools` for the authoritative live catalog)
+- ✅ **100+ MCP Tools** for complete email management (see [TOOL_CATALOG.md](./TOOL_CATALOG.md) for the exact list, or run `imap_list_tools` at runtime)
 - ✅ **15 Email Provider Presets** (Gmail, Outlook, Yahoo, etc.)
 - ✅ **Auto-Chunking** for operations >50 UIDs
 - ✅ **Circuit Breaker Pattern** with automatic recovery
@@ -156,7 +156,7 @@ imap-mcp-pro/
 
 ## MCP Tools
 
-> **Authoritative catalog:** the complete categorized tool list is generated from the manifest on every build at **[TOOL_CATALOG.md](./TOOL_CATALOG.md)** (currently **107 tools**), and is also available at runtime via `imap_list_tools`. The detailed catalog below documents the core set with full input/output notes; the "Recent additions" section tracks the newest tools.
+> **Authoritative catalog:** the complete categorized tool list (with the exact current count) is generated from the manifest on every build at **[TOOL_CATALOG.md](./TOOL_CATALOG.md)**, and is also available at runtime via `imap_list_tools`. The detailed catalog below documents the core set with full input/output notes; the "Recent additions" section tracks the newest tools.
 
 ### Recent additions (v2.17–v2.19)
 
@@ -175,6 +175,9 @@ imap-mcp-pro/
 
 **SMTP**
 - Capability-aware **SIZE** send limits (#191) — `imap_test_smtp` reports the server's EHLO `SIZE`; oversized sends fail fast with a clear message instead of a 552 round-trip.
+
+**Message priority (#48)**
+- **imap_set_email_priority** / **imap_get_email_priority** — set/read high/normal/low priority. Because IMAP messages are immutable, priority is *set* via a custom keyword (`$Priority-High` / `$Priority-Low`) and *read* by preferring that keyword, then the compose-time `X-Priority` / `Importance` / `X-MSMail-Priority` header, then normal.
 
 All byte sizes in tool output are human-readable (B/KB/MB/GB). Credential storage is file-based AES-256-GCM (`node:sqlite`; no native `keytar`/SQLCipher dependency).
 
@@ -910,7 +913,7 @@ POST /api/usercheck         - UserCheck email validation
 
 **Expected Output**:
 ```
-✅ 107 tools registered
+✅ all tools registered
 ✅ All tools categorized correctly
 ✅ No missing or extra tools
 ✅ PASS

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,7 +4,7 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**107 MCP tools** total.
+**109 MCP tools** total.
 
 ## Categories
 
@@ -22,6 +22,7 @@
 - [Local cache](#local-cache) — 2
 - [Capabilities, diagnostics & metrics](#capabilities-diagnostics-metrics) — 11
 - [Meta & discovery](#meta-discovery) — 5
+- [Other](#other) — 2
 
 ## Users (MSP multi-tenant)
 
@@ -199,4 +200,11 @@
 | `imap_list_tools` | List all available MCP tools with descriptions and parameters |
 | `imap_results` | Manage cached MCP tool results (resource-handle pattern). |
 | `imap_update_skills` | Apply skill updates from public GitHub for explicitly named skills. |
+
+## Other
+
+| Tool | Description |
+| --- | --- |
+| `imap_get_email_priority` | Get the resolved priority of a message: our $Priority-* keyword if set (the explicit user setting), otherwise the compose-time X-Priority / Importance / X-MSMail-Priority header, otherwise normal. |
+| `imap_set_email_priority` | Set the priority (high / normal / low) of one or more messages. |
 

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -51,6 +51,33 @@ export interface EmailSizeInfo {
   hasAttachments: boolean;
 }
 
+/** Message priority level (Issue #48). */
+export type EmailPriority = 'high' | 'normal' | 'low';
+
+/** Custom IMAP keywords used to persist a settable priority (headers are immutable). */
+const PRIORITY_KEYWORDS = { high: '$Priority-High', low: '$Priority-Low' } as const;
+
+/**
+ * Resolve a priority from raw message headers (compose-time): X-Priority
+ * (1-2 high, 3 normal, 4-5 low), then Importance, then X-MSMail-Priority.
+ * Returns null when no recognized priority header is present.
+ */
+function parsePriorityHeaders(raw: string): EmailPriority | null {
+  if (!raw) return null;
+  const xp = raw.match(/^x-priority:\s*(\d)/im);
+  if (xp) {
+    const n = Number(xp[1]);
+    if (n <= 2) return 'high';
+    if (n >= 4) return 'low';
+    return 'normal';
+  }
+  const imp = raw.match(/^importance:\s*(high|normal|low)/im);
+  if (imp) return imp[1].toLowerCase() as EmailPriority;
+  const ms = raw.match(/^x-msmail-priority:\s*(high|normal|low)/im);
+  if (ms) return ms[1].toLowerCase() as EmailPriority;
+  return null;
+}
+
 /** Best-effort: does a fetched bodyStructure contain an attachment disposition? */
 function bodyStructureHasAttachment(node: any): boolean {
   if (!node) return false;
@@ -1373,6 +1400,70 @@ export class ImapService {
       await client.mailboxOpen(folderName);
       await client.messageFlagsRemove(uids.join(','), [keyword], { uid: true });
     }, `bulkRemoveKeyword(${folderName}, ${keyword}, ${uids.length} messages)`);
+  }
+
+  // RFC 9051: message priority (Issue #48).
+  //
+  // IMAP messages are immutable, so compose-time priority headers
+  // (X-Priority/Importance) can't be changed after delivery. We therefore SET
+  // priority with custom IMAP keywords ($Priority-High / $Priority-Low; "normal"
+  // clears both) via STORE, and RESOLVE priority on read by preferring our
+  // keyword (the user's explicit setting) and otherwise parsing the headers.
+
+  async setEmailPriority(
+    accountId: string,
+    folderName: string,
+    uids: number[],
+    priority: EmailPriority
+  ): Promise<{ priority: EmailPriority; keyword: string | null; accepted: boolean; uids: number[] }> {
+    return this.withRetry(accountId, async () => {
+      const client = this.getConnection(accountId);
+      await client.mailboxOpen(folderName);
+      const range = uids.join(',');
+
+      // Clear any prior priority keyword first so levels never stack.
+      await client.messageFlagsRemove(range, [PRIORITY_KEYWORDS.high, PRIORITY_KEYWORDS.low], { uid: true });
+
+      let keyword: string | null = null;
+      let accepted = true;
+      if (priority === 'high') keyword = PRIORITY_KEYWORDS.high;
+      else if (priority === 'low') keyword = PRIORITY_KEYWORDS.low;
+
+      if (keyword) {
+        // messageFlagsAdd returns false when the server rejects the keyword
+        // (e.g. a mailbox that doesn't allow custom keywords).
+        accepted = await client.messageFlagsAdd(range, [keyword], { uid: true });
+      }
+
+      return { priority, keyword, accepted, uids };
+    }, `setEmailPriority(${folderName}, ${priority}, ${uids.length} messages)`);
+  }
+
+  async getEmailPriority(
+    accountId: string,
+    folderName: string,
+    uid: number
+  ): Promise<{ uid: number; priority: EmailPriority; source: 'keyword' | 'header' | 'default'; flags: string[] }> {
+    return this.withRetry(accountId, async () => {
+      const client = this.getConnection(accountId);
+      await client.mailboxOpen(folderName);
+
+      const msg = await client.fetchOne(uid.toString(), {
+        uid: true,
+        flags: true,
+        headers: ['x-priority', 'importance', 'x-msmail-priority'],
+      }, { uid: true });
+
+      if (!msg) throw new Error(`Email with UID ${uid} not found`);
+      const flags = msg.flags ? Array.from(msg.flags) : [];
+
+      if (flags.includes(PRIORITY_KEYWORDS.high)) return { uid, priority: 'high', source: 'keyword', flags };
+      if (flags.includes(PRIORITY_KEYWORDS.low)) return { uid, priority: 'low', source: 'keyword', flags };
+
+      const headerPriority = parsePriorityHeaders(msg.headers ? msg.headers.toString() : '');
+      if (headerPriority) return { uid, priority: headerPriority, source: 'header', flags };
+      return { uid, priority: 'normal', source: 'default', flags };
+    }, `getEmailPriority(${folderName}, ${uid})`);
   }
 
   // ============================================================================

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -67,6 +67,8 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_get_latest_emails':            READ_REMOTE,
   'imap_get_email_sizes':              READ_REMOTE,
   'imap_get_largest_emails':           READ_REMOTE,
+  'imap_get_email_priority':           READ_REMOTE,
+  'imap_set_email_priority':           WRITE_REMOTE,
   'imap_get_quota':                    READ_REMOTE,
   'imap_export_email':                 READ_REMOTE,
   'imap_export_folder':                READ_REMOTE,

--- a/src/tools/email-tools.test.ts
+++ b/src/tools/email-tools.test.ts
@@ -48,6 +48,15 @@ function makeImap(overrides: Record<string, any> = {}) {
       { uid: 2, size: 15 * 1024 * 1024, subject: 'big', from: 'b@x.com', date: new Date('2026-01-02'), hasAttachments: true },
       { uid: 3, size: 5 * 1024 * 1024, subject: 'medium', from: 'c@x.com', date: new Date('2026-01-03'), hasAttachments: true },
     ],
+    lastPriorityArgs: undefined as any,
+    setEmailPriority: async function (this: any, _a: string, _f: string, uids: number[], priority: string) {
+      this.lastPriorityArgs = { uids, priority };
+      const keyword = priority === 'high' ? '$Priority-High' : priority === 'low' ? '$Priority-Low' : null;
+      return { priority, keyword, accepted: true, uids };
+    },
+    getEmailPriority: async (_a: string, _f: string, uid: number) => ({
+      uid, priority: 'high', source: 'header', flags: ['\\Seen'],
+    }),
     ...overrides,
   };
 }
@@ -151,6 +160,35 @@ describe('emailTools core routes', () => {
     const asc = await invoke(tools, 'imap_get_email_sizes', { accountId: 'a', folder: 'INBOX', order: 'asc', limit: 2 });
     expect(asc.returned).toBe(2);
     expect(asc.messages.map((m: any) => m.uid)).toEqual([1, 3]); // smallest first, capped
+  });
+});
+
+describe('imap_set/get_email_priority (#48)', () => {
+  let imap: any, tools: Map<string, Registered>;
+  beforeEach(() => { imap = makeImap(); tools = register(imap); });
+
+  it('sets high priority via the $Priority-High keyword', async () => {
+    const out = await invoke(tools, 'imap_set_email_priority', { accountId: 'a', folder: 'INBOX', uids: [1, 2], priority: 'high' });
+    expect(imap.lastPriorityArgs).toEqual({ uids: [1, 2], priority: 'high' });
+    expect(out).toMatchObject({ priority: 'high', keyword: '$Priority-High', accepted: true, updated: 2, uids: [1, 2] });
+    expect(out.note).toBeUndefined();
+  });
+
+  it('clears the keyword for normal priority', async () => {
+    const out = await invoke(tools, 'imap_set_email_priority', { accountId: 'a', folder: 'INBOX', uids: [5], priority: 'normal' });
+    expect(out.keyword).toBeNull();
+  });
+
+  it('surfaces a note when the server rejects the keyword', async () => {
+    const rejecting = makeImap({ setEmailPriority: async (_a: string, _f: string, uids: number[], priority: string) => ({ priority, keyword: '$Priority-High', accepted: false, uids }) });
+    const out = await invoke(register(rejecting), 'imap_set_email_priority', { accountId: 'a', folder: 'INBOX', uids: [1], priority: 'high' });
+    expect(out.accepted).toBe(false);
+    expect(out.note).toMatch(/did not accept/);
+  });
+
+  it('reads the resolved priority with its source', async () => {
+    const out = await invoke(tools, 'imap_get_email_priority', { accountId: 'a', folder: 'INBOX', uid: 7 });
+    expect(out).toMatchObject({ uid: 7, priority: 'high', source: 'header' });
   });
 });
 

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -495,6 +495,51 @@ export function emailTools(
     });
   }));
 
+  // Set message priority (#48). IMAP messages are immutable, so this stores a
+  // custom keyword ($Priority-High / $Priority-Low) rather than rewriting the
+  // X-Priority header. "normal" clears the keyword.
+  server.registerTool('imap_set_email_priority', {
+    description:
+      'Set the priority (high / normal / low) of one or more messages. Because IMAP messages are immutable, ' +
+      'this is stored as a custom IMAP keyword ($Priority-High / $Priority-Low) via STORE, not by rewriting the ' +
+      'X-Priority header; "normal" clears the keyword. Some servers may not allow custom keywords — the result ' +
+      'reports whether the server accepted it. To set real priority headers on outgoing mail, use imap_send_email.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder containing the messages (default: INBOX)'),
+      uids: z.array(z.number()).min(1).describe('UIDs to update'),
+      priority: z.enum(['high', 'normal', 'low']).describe("Priority level: 'high', 'normal' (clears the keyword), or 'low'"),
+    }
+  }, withErrorHandling(async ({ accountId, folder, uids, priority }) => {
+    const result = await imapService.setEmailPriority(accountId, folder, uids, priority);
+    return jsonResult({
+      folder,
+      priority: result.priority,
+      keyword: result.keyword,
+      accepted: result.accepted,
+      updated: result.uids.length,
+      uids: result.uids,
+      ...(result.accepted ? {} : { note: 'The server did not accept the priority keyword; this mailbox may not support custom keywords.' }),
+    });
+  }));
+
+  // Read the resolved priority of a message (#48): our keyword wins, else the
+  // compose-time X-Priority / Importance / X-MSMail-Priority header, else normal.
+  server.registerTool('imap_get_email_priority', {
+    description:
+      'Get the resolved priority of a message: our $Priority-* keyword if set (the explicit user setting), ' +
+      'otherwise the compose-time X-Priority / Importance / X-MSMail-Priority header, otherwise normal. ' +
+      'The `source` field says which of keyword / header / default the answer came from.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder containing the message (default: INBOX)'),
+      uid: z.number().describe('UID of the message'),
+    }
+  }, withErrorHandling(async ({ accountId, folder, uid }) => {
+    const result = await imapService.getEmailPriority(accountId, folder, uid);
+    return jsonResult({ folder, uid: result.uid, priority: result.priority, source: result.source, flags: result.flags });
+  }));
+
   // Export messages to standard .eml files on disk — download & save (#170)
   server.registerTool('imap_export_email', {
     description:


### PR DESCRIPTION
## #48 — IMAP message priority management

Adds `imap_set_email_priority` / `imap_get_email_priority` (high / normal / low).

### Design — why keywords, not header rewriting
IMAP messages are **immutable**: the compose-time `X-Priority` / `Importance` headers can't be changed after delivery. So priority is:
- **Set** via a custom IMAP keyword (`$Priority-High` / `$Priority-Low`; `normal` clears them) using STORE. The result reports whether the server **accepted** the custom keyword (some mailboxes don't allow them) and surfaces a note if not.
- **Read** by preferring our keyword (the explicit user setting), then parsing the compose-time `X-Priority` (1-2 high / 3 normal / 4-5 low) / `Importance` / `X-MSMail-Priority` header, then defaulting to `normal`. The response's `source` field says which path answered.

Real priority on **outgoing** mail belongs at compose time via `imap_send_email`; this feature covers existing messages.

### Service
`ImapService.setEmailPriority` (bulk) + `getEmailPriority`, an `EmailPriority` type, and a header parser. Tools annotated WRITE_REMOTE / READ_REMOTE.

### Tests (4 new, 181 total)
set high (keyword + args), normal clears keyword, server-rejection note, read with source.

### Docs
`\Answered` was already supported (`imap_bulk_mark_emails` answered/unanswered), so this completes #48's remaining scope. Tools 107 → **109**. Also switched the prose tool counts to "100+" — the exact count now lives only in the generated `docs/TOOL_CATALOG.md` + `imap_list_tools`, so it stops drifting on every new tool.
