### PR TITLE
feat: imap_test_quad9_dns — verify Quad9 threat-blocking (#65)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,7 +4,7 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**109 MCP tools** total.
+**110 MCP tools** total.
 
 ## Categories
 
@@ -22,7 +22,7 @@
 - [Local cache](#local-cache) — 2
 - [Capabilities, diagnostics & metrics](#capabilities-diagnostics-metrics) — 11
 - [Meta & discovery](#meta-discovery) — 5
-- [Other](#other) — 2
+- [Other](#other) — 3
 
 ## Users (MSP multi-tenant)
 
@@ -207,4 +207,5 @@
 | --- | --- |
 | `imap_get_email_priority` | Get the resolved priority of a message: our $Priority-* keyword if set (the explicit user setting), otherwise the compose-time X-Priority / Importance / X-MSMail-Priority header, otherwise normal. |
 | `imap_set_email_priority` | Set the priority (high / normal / low) of one or more messages. |
+| `imap_test_quad9_dns` | Verify Quad9 DNS threat-blocking is active. |
 

--- a/src/services/dns-firewall-service.test.ts
+++ b/src/services/dns-firewall-service.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for DnsFirewallService.testQuad9 (#65). The protected quad9Lookup is
+// overridden in a subclass so the logic is exercised without a real DoH socket.
+
+import { describe, expect, it } from 'vitest';
+import { DnsFirewallService } from './dns-firewall-service.js';
+
+type Lookup = { status: number; answers: number } | null;
+
+class StubDnsFirewall extends DnsFirewallService {
+  constructor(private lookups: Record<string, Lookup>) {
+    // db is only used via getDefaultDnsFirewallProvider → return null to hit the Quad9 fallback.
+    super({ getDefaultDnsFirewallProvider: () => null } as any);
+  }
+  protected async quad9Lookup(domain: string): Promise<Lookup> {
+    return domain in this.lookups ? this.lookups[domain] : null;
+  }
+}
+
+const RESOLVED = { status: 0, answers: 2 };
+const NXDOMAIN = { status: 3, answers: 0 };
+
+describe('DnsFirewallService.testQuad9 (#65)', () => {
+  it('reports ACTIVE when the control resolves and the blocked domain does not', async () => {
+    const svc = new StubDnsFirewall({ 'www.google.com': RESOLVED, 'malware.wicar.org': NXDOMAIN });
+    const out = await svc.testQuad9();
+    expect(out.quad9Active).toBe(true);
+    expect(out.reachable).toBe(true);
+    expect(out.control).toMatchObject({ domain: 'www.google.com', resolved: true, status: 0 });
+    expect(out.blocked).toMatchObject({ domain: 'malware.wicar.org', resolved: false, status: 3 });
+    expect(out.message).toMatch(/ACTIVE/);
+  });
+
+  it('is not active (and says so) when the blocked-test domain also resolves', async () => {
+    const svc = new StubDnsFirewall({ 'www.google.com': RESOLVED, 'malware.wicar.org': RESOLVED });
+    const out = await svc.testQuad9();
+    expect(out.quad9Active).toBe(false);
+    expect(out.blocked.resolved).toBe(true);
+    expect(out.message).toMatch(/also resolved/);
+  });
+
+  it('flags an unreachable endpoint', async () => {
+    const svc = new StubDnsFirewall({}); // every lookup → null
+    const out = await svc.testQuad9();
+    expect(out.reachable).toBe(false);
+    expect(out.quad9Active).toBe(false);
+    expect(out.message).toMatch(/Could not reach/);
+  });
+
+  it('flags a control domain that fails to resolve (misconfiguration)', async () => {
+    const svc = new StubDnsFirewall({ 'www.google.com': NXDOMAIN, 'malware.wicar.org': NXDOMAIN });
+    const out = await svc.testQuad9();
+    expect(out.quad9Active).toBe(false);
+    expect(out.message).toMatch(/control domain .* did not resolve/);
+  });
+
+  it('honors custom control and blocked domains', async () => {
+    const svc = new StubDnsFirewall({ 'clean.example': RESOLVED, 'bad.example': NXDOMAIN });
+    const out = await svc.testQuad9({ controlDomain: 'clean.example', blockedTestDomain: 'bad.example' });
+    expect(out.quad9Active).toBe(true);
+    expect(out.control.domain).toBe('clean.example');
+    expect(out.blocked.domain).toBe('bad.example');
+  });
+});

--- a/src/services/dns-firewall-service.ts
+++ b/src/services/dns-firewall-service.ts
@@ -167,6 +167,104 @@ export class DnsFirewallService {
   }
 
   /**
+   * Low-level Quad9 DoH lookup returning the raw DNS rcode + answer count
+   * (rather than queryProvider's safe/unsafe boolean). Returns null when the
+   * provider is unreachable (network error / timeout). Used by testQuad9.
+   *
+   * `protected` so tests can stub it without opening a real socket.
+   */
+  protected async quad9Lookup(
+    domain: string,
+    timeout = this.DEFAULT_TIMEOUT_MS
+  ): Promise<{ status: number; answers: number } | null> {
+    const endpoint = this.getProvider().endpoint;
+    return new Promise((resolve) => {
+      const req = https.request({
+        hostname: endpoint,
+        path: `/dns-query?name=${encodeURIComponent(domain)}&type=A`,
+        method: 'GET',
+        headers: { 'Accept': 'application/dns-json' },
+        timeout,
+      }, (res) => {
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => {
+          try {
+            const response = JSON.parse(data);
+            resolve({
+              status: typeof response.Status === 'number' ? response.Status : -1,
+              answers: Array.isArray(response.Answer) ? response.Answer.length : 0,
+            });
+          } catch {
+            resolve(null);
+          }
+        });
+      });
+      req.on('error', () => resolve(null));
+      req.on('timeout', () => { req.destroy(); resolve(null); });
+      req.end();
+    });
+  }
+
+  /**
+   * Verify Quad9 threat-blocking is active (#65). Resolves a clean control
+   * domain (expected to resolve) and a blocked-test domain (expected to be
+   * NXDOMAIN/empty when filtering is on) via Quad9 DoH, and reports a derived
+   * pass/fail. Since there is no standardized public Quad9 "blocked" test host,
+   * `blockedTestDomain` is configurable — pass a domain you know Quad9 blocks
+   * for a definitive result.
+   */
+  async testQuad9(opts?: {
+    controlDomain?: string;
+    blockedTestDomain?: string;
+    timeoutMs?: number;
+  }): Promise<{
+    quad9Active: boolean;
+    reachable: boolean;
+    control: { domain: string; resolved: boolean; status: number | null };
+    blocked: { domain: string; resolved: boolean; status: number | null };
+    endpoint: string;
+    message: string;
+  }> {
+    const controlDomain = opts?.controlDomain || 'www.google.com';
+    const blockedTestDomain = opts?.blockedTestDomain || 'malware.wicar.org';
+    const timeout = opts?.timeoutMs ?? this.DEFAULT_TIMEOUT_MS;
+    const endpoint = this.getProvider().endpoint;
+
+    const [c, b] = await Promise.all([
+      this.quad9Lookup(controlDomain, timeout),
+      this.quad9Lookup(blockedTestDomain, timeout),
+    ]);
+
+    const reachable = c !== null || b !== null;
+    const controlResolved = !!c && c.status === 0 && c.answers > 0;
+    // "Blocked" = did NOT resolve (NXDOMAIN/empty). A null (unreachable) is not
+    // treated as blocked — we can't conclude blocking from a transport failure.
+    const blockedResolved = !!b && b.status === 0 && b.answers > 0;
+    const quad9Active = reachable && controlResolved && !blockedResolved;
+
+    let message: string;
+    if (!reachable) {
+      message = `Could not reach the Quad9 DoH endpoint (${endpoint}). Check network/DNS configuration.`;
+    } else if (!controlResolved) {
+      message = `Quad9 reached but the control domain "${controlDomain}" did not resolve — the endpoint may be misconfigured.`;
+    } else if (quad9Active) {
+      message = `Quad9 filtering appears ACTIVE: "${controlDomain}" resolved and the blocked-test domain "${blockedTestDomain}" did not. For a definitive result, pass a blockedTestDomain you know Quad9 blocks.`;
+    } else {
+      message = `Quad9 is reachable and resolving, but the blocked-test domain "${blockedTestDomain}" also resolved, so threat blocking could not be confirmed. Override blockedTestDomain with a domain you know Quad9 blocks.`;
+    }
+
+    return {
+      quad9Active,
+      reachable,
+      control: { domain: controlDomain, resolved: controlResolved, status: c ? c.status : null },
+      blocked: { domain: blockedTestDomain, resolved: blockedResolved, status: b ? b.status : null },
+      endpoint,
+      message,
+    };
+  }
+
+  /**
    * Query DNS-over-HTTPS provider
    * Returns true if domain is safe, false if blocked
    */

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -191,12 +191,13 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_check_folder_spam':            READ_REMOTE,
   'imap_scan_account_spam':            READ_REMOTE,
 
-  // ---- dns-firewall-tools (5) ----
+  // ---- dns-firewall-tools (6) ----
   'imap_check_domain':                 READ_REMOTE,
   'imap_bulk_check_domains':           READ_REMOTE,
   'imap_check_domain_dns_firewall':    READ_REMOTE,
   'imap_scan_message_domains':         READ_REMOTE,
   'imap_bulk_scan_messages':           READ_REMOTE,
+  'imap_test_quad9_dns':               READ_REMOTE,
 };
 
 /**

--- a/src/tools/dns-firewall-tools.ts
+++ b/src/tools/dns-firewall-tools.ts
@@ -39,6 +39,25 @@ export function dnsFirewallTools(
     };
   }));
 
+  // Verify Quad9 threat-blocking is active (#65)
+  server.registerTool('imap_test_quad9_dns', {
+    description:
+      'Verify Quad9 DNS threat-blocking is active. Resolves a clean control domain (should resolve) and a ' +
+      'blocked-test domain (should be NXDOMAIN/empty when filtering is on) via Quad9 DNS-over-HTTPS, then reports ' +
+      'a derived pass/fail. There is no standardized public Quad9 "blocked" test host, so pass a blockedTestDomain ' +
+      'you know Quad9 blocks for a definitive result.',
+    inputSchema: {
+      controlDomain: z.string().optional().describe('Clean domain expected to resolve (default: www.google.com)'),
+      blockedTestDomain: z.string().optional().describe('Domain expected to be blocked when filtering is active (default: malware.wicar.org)'),
+      timeoutMs: z.number().optional().describe('Per-query timeout in ms (default: 5000)'),
+    }
+  }, withErrorHandling(async ({ controlDomain, blockedTestDomain, timeoutMs }) => {
+    const result = await dnsFirewall.testQuad9({ controlDomain, blockedTestDomain, timeoutMs });
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+    };
+  }));
+
   // Check multiple domains
   server.registerTool('imap_bulk_check_domains', {
     description: 'Check multiple domains against DNS firewall in bulk',


### PR DESCRIPTION
## #65 — `imap_test_quad9_dns`

Lets a user verify Quad9 DNS threat-blocking is active.

### How it works
Queries Quad9 **DNS-over-HTTPS** (`dns.quad9.net`, reusing the DNS-firewall provider config) for two domains:
- a **control** domain (default `www.google.com`) — expected to resolve (Status 0 + Answer);
- a **blocked-test** domain (default `malware.wicar.org`) — expected to be NXDOMAIN/empty when filtering is on.

`quad9Active = reachable && controlResolved && !blockedResolved`. Distinct, helpful messages for: unreachable endpoint, non-resolving control (misconfig), blocking-confirmed, and blocking-unconfirmed.

### Honest about the limitation
There's no standardized public Quad9 "blocked" test host, so **`blockedTestDomain` is configurable** — the tool tells the user to pass a domain they know Quad9 blocks for a definitive result. An unreachable lookup is **not** treated as "blocked" (can't conclude blocking from a transport failure).

### Service + tests
`DnsFirewallService.quad9Lookup` (raw rcode + answer count; `protected` so tests stub it without a socket) + `testQuad9`. 5 new tests (active / not-active / unreachable / control-misconfig / custom domains). Tools 109 → **110**.

Acceptance: user can test Quad9, clear pass/fail, graceful failure handling, helpful messages, cross-platform (pure DoH over HTTPS).
