### PR TITLE
feat: imap_server_reload — reset runtime state without restart (#84)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,7 +4,7 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**110 MCP tools** total.
+**111 MCP tools** total.
 
 ## Categories
 
@@ -13,16 +13,16 @@
 - [Bulk operations](#bulk-operations) — 11
 - [Size, export & quota](#size-export-quota) — 7
 - [Attachment staging](#attachment-staging) — 6
-- [Email operations](#email-operations) — 11
+- [Email operations](#email-operations) — 13
 - [Folder & mailbox operations](#folder-mailbox-operations) — 11
 - [Subscriptions & unsubscribe](#subscriptions-unsubscribe) — 9
 - [Categorization & scoring](#categorization-scoring) — 6
 - [Spam & UserCheck](#spam-usercheck) — 7
-- [DNS firewall & domain checks](#dns-firewall-domain-checks) — 3
+- [DNS firewall & domain checks](#dns-firewall-domain-checks) — 4
 - [Local cache](#local-cache) — 2
 - [Capabilities, diagnostics & metrics](#capabilities-diagnostics-metrics) — 11
 - [Meta & discovery](#meta-discovery) — 5
-- [Other](#other) — 3
+- [Admin & lifecycle](#admin-lifecycle) — 1
 
 ## Users (MSP multi-tenant)
 
@@ -99,6 +99,7 @@
 | `imap_delete_email` | Delete an email (moves to trash or expunges) |
 | `imap_forward_email` | Forward an existing email |
 | `imap_get_email` | Get the full content of an email or just headers |
+| `imap_get_email_priority` | Get the resolved priority of a message: our $Priority-* keyword if set (the explicit user setting), otherwise the compose-time X-Priority / Importance / X-MSMail-Priority header, otherwise normal. |
 | `imap_get_latest_emails` | Get the latest emails from a folder. |
 | `imap_mark_as_read` | Mark an email as read |
 | `imap_mark_as_unread` | Mark an email as unread |
@@ -106,6 +107,7 @@
 | `imap_reply_to_email` | Reply to an existing email |
 | `imap_search_emails` | Search for emails in a folder. |
 | `imap_send_email` | Send an email via SMTP and (by default) append the message to the IMAP Sent folder. |
+| `imap_set_email_priority` | Set the priority (high / normal / low) of one or more messages. |
 
 ## Folder & mailbox operations
 
@@ -167,6 +169,7 @@
 | `imap_check_domain` | Check a domain against UserCheck for spam/validity |
 | `imap_check_domain_dns_firewall` | Check if a domain is blocked by DNS firewall (Quad9 threat intelligence) |
 | `imap_scan_message_domains` | Extract and validate all domains from an email message against DNS firewall |
+| `imap_test_quad9_dns` | Verify Quad9 DNS threat-blocking is active. |
 
 ## Local cache
 
@@ -201,11 +204,9 @@
 | `imap_results` | Manage cached MCP tool results (resource-handle pattern). |
 | `imap_update_skills` | Apply skill updates from public GitHub for explicitly named skills. |
 
-## Other
+## Admin & lifecycle
 
 | Tool | Description |
 | --- | --- |
-| `imap_get_email_priority` | Get the resolved priority of a message: our $Priority-* keyword if set (the explicit user setting), otherwise the compose-time X-Priority / Importance / X-MSMail-Priority header, otherwise normal. |
-| `imap_set_email_priority` | Set the priority (high / normal / low) of one or more messages. |
-| `imap_test_quad9_dns` | Verify Quad9 DNS threat-blocking is active. |
+| `imap_server_reload` | Reset the server's runtime state without restarting Claude Desktop: close pooled IMAP and SMTP connections and clear the in-memory IMAP capabilities cache. |
 

--- a/scripts/gen-tool-catalog.mjs
+++ b/scripts/gen-tool-catalog.mjs
@@ -36,15 +36,16 @@ const CATEGORIES = [
   ['Bulk operations', /^imap_bulk_/],
   ['Size, export & quota', /^imap_(get_email_sizes|get_largest_emails|export_email|export_folder|export_account|extract_attachments|get_quota)$/],
   ['Attachment staging', /^imap_(attachment_stage_|list_staged_attachments|get_outbox_dir)/],
-  ['Email operations', /^imap_(search_emails|get_email|get_latest_emails|mark_as_read|mark_as_unread|delete_email|copy_email|move_email|send_email|reply_to_email|forward_email)$/],
+  ['Email operations', /^imap_(search_emails|get_email|get_latest_emails|mark_as_read|mark_as_unread|delete_email|copy_email|move_email|send_email|reply_to_email|forward_email|get_email_priority|set_email_priority)$/],
   ['Folder & mailbox operations', /^imap_(list_folders|folder_status|get_unread_count|create_folder|delete_folder|rename_folder|get_mailbox_status|subscribe_mailbox|unsubscribe_mailbox|list_subscribed_mailboxes|append_message)$/],
   ['Subscriptions & unsubscribe', /^imap_(extract_unsubscribe_links|get_unsubscribe_links|get_unsubscribe_links_for|execute_unsubscribe|get_subscription_summary|list_unsubscribe_candidates|mark_subscription_unsubscribed|update_subscription_category|update_subscription_notes)$/],
   ['Categorization & scoring', /^imap_(add_keyword|remove_keyword|list_categories|apply_categories|analyze_folder_confidence|score_email_confidence)$/],
   ['Spam & UserCheck', /^imap_(check_email_spam|check_emails_spam_bulk|check_folder_spam|scan_account_spam|add_usercheck_key|get_usercheck_key|delete_usercheck_key)$/],
-  ['DNS firewall & domain checks', /^imap_(check_domain|check_domain_dns_firewall|scan_message_domains)$/],
+  ['DNS firewall & domain checks', /^imap_(check_domain|check_domain_dns_firewall|scan_message_domains|test_quad9_dns)$/],
   ['Local cache', /^imap_(search_cache|sync_folder_cache)$/],
   ['Capabilities, diagnostics & metrics', /^imap_(get_capabilities|test_smtp|test_sent_folder|list_unarchived_sends|get_metrics|get_operation_metrics|reset_metrics|get_smtp_metrics|reset_smtp_metrics|get_circuit_breaker|reset_circuit_breaker)$/],
   ['Meta & discovery', /^imap_(about|list_tools|check_skill_updates|update_skills|results)$/],
+  ['Admin & lifecycle', /^imap_(server_reload|open_web_ui)$/],
 ];
 
 function categoryFor(name) {

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -594,6 +594,28 @@ export class ImapService {
   }
 
   /**
+   * Disconnect every pooled IMAP connection (server reload, #84). Returns the
+   * number of connections that were closed. Next operation reconnects lazily.
+   */
+  async disconnectAll(): Promise<number> {
+    const accountIds = Array.from(this.activeConnections.keys());
+    for (const accountId of accountIds) {
+      await this.disconnect(accountId);
+    }
+    return accountIds.length;
+  }
+
+  /**
+   * Clear the in-memory server-capabilities cache (server reload, #84). Returns
+   * the number of cached entries dropped; they re-populate on next query.
+   */
+  clearCapabilitiesCache(): number {
+    const n = this.capabilitiesCache.size;
+    this.capabilitiesCache.clear();
+    return n;
+  }
+
+  /**
    * One-shot connectivity probe (#90). Spawns a fresh ImapFlow client so the
    * test does not interact with the connection pool, retry queue, or circuit
    * breaker — the probe is for diagnostics, not for warming up state. Returns

--- a/src/tools/admin-tools.test.ts
+++ b/src/tools/admin-tools.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for imap_server_reload (#84).
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { adminTools } from './admin-tools.js';
+
+type Registered = { spec: any; handler: any };
+
+function makeServer() {
+  const tools = new Map<string, Registered>();
+  const server = { registerTool: (name: string, spec: any, handler: any) => tools.set(name, { spec, handler }) };
+  return { server, tools };
+}
+
+async function invoke(tools: Map<string, Registered>, name: string, args: any) {
+  return JSON.parse((await tools.get(name)!.handler(args)).content[0].text);
+}
+
+function makeImap() {
+  const calls = { disconnectAll: 0, clearCaps: 0 };
+  return {
+    calls,
+    disconnectAll: async () => { calls.disconnectAll++; return 3; },
+    clearCapabilitiesCache: () => { calls.clearCaps++; return 2; },
+  };
+}
+
+function makeSmtp() {
+  const calls = { disconnectAll: 0 };
+  return {
+    calls,
+    getPoolStats: () => ({ configured: 4 }),
+    disconnectAll: () => { calls.disconnectAll++; },
+  };
+}
+
+function register(imap: any, smtp: any) {
+  const { server, tools } = makeServer();
+  adminTools(server as any, imap as any, smtp as any);
+  return tools;
+}
+
+describe('imap_server_reload (#84)', () => {
+  let imap: any, smtp: any, tools: Map<string, Registered>;
+  beforeEach(() => { imap = makeImap(); smtp = makeSmtp(); tools = register(imap, smtp); });
+
+  it('registers the tool', () => {
+    expect(tools.has('imap_server_reload')).toBe(true);
+  });
+
+  it('resets everything by default and reports counts', async () => {
+    const out = await invoke(tools, 'imap_server_reload', {});
+    expect(out.success).toBe(true);
+    expect(out.reset).toEqual({ imapConnectionsClosed: 3, smtpConnectionsClosed: 4, capabilitiesCacheCleared: 2 });
+    expect(out.actions).toEqual(['imap-pool', 'smtp-pool', 'capabilities-cache']);
+    expect(imap.calls).toEqual({ disconnectAll: 1, clearCaps: 1 });
+    expect(smtp.calls.disconnectAll).toBe(1);
+    expect(out.note).toMatch(/restart/i);
+  });
+
+  it('skips the IMAP pool when disconnectImap is false', async () => {
+    const out = await invoke(tools, 'imap_server_reload', { disconnectImap: false });
+    expect(imap.calls.disconnectAll).toBe(0);
+    expect(out.reset.imapConnectionsClosed).toBe(0);
+    expect(out.actions).not.toContain('imap-pool');
+    // others still run
+    expect(smtp.calls.disconnectAll).toBe(1);
+    expect(out.reset.capabilitiesCacheCleared).toBe(2);
+  });
+
+  it('can clear only the capabilities cache', async () => {
+    const out = await invoke(tools, 'imap_server_reload', { disconnectImap: false, disconnectSmtp: false });
+    expect(out.actions).toEqual(['capabilities-cache']);
+    expect(out.reset).toEqual({ imapConnectionsClosed: 0, smtpConnectionsClosed: 0, capabilitiesCacheCleared: 2 });
+  });
+});

--- a/src/tools/admin-tools.ts
+++ b/src/tools/admin-tools.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Admin / lifecycle tools — runtime state reset without a full restart (#84).
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+// Part of: IMAP MCP Pro (Temple of Epiphany)
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { ImapService } from '../services/imap-service.js';
+import { SmtpService } from '../services/smtp-service.js';
+import { withErrorHandling } from '../utils/error-handler.js';
+
+export function adminTools(
+  server: McpServer,
+  imapService: ImapService,
+  smtpService: SmtpService
+): void {
+  // Reset runtime state without restarting Claude Desktop (#84).
+  //
+  // Scope is deliberately limited to what is SAFE to reset on a live stdio
+  // session: pooled connections and the in-memory capabilities cache.
+  // Configuration, environment variables, and the tool registry are fixed for
+  // the process lifetime — reloading them is not safely possible mid-session,
+  // so those still require a full restart. The database and stored data are
+  // never touched.
+  server.registerTool('imap_server_reload', {
+    description:
+      'Reset the server\'s runtime state without restarting Claude Desktop: close pooled IMAP and SMTP ' +
+      'connections and clear the in-memory IMAP capabilities cache. Connections reconnect lazily on the next ' +
+      'operation — useful after changing account settings on the server, or when connections have gone stale. ' +
+      'NOTE: this does NOT reload configuration, environment variables, or the tool list, and never touches the ' +
+      'database or stored data; picking up config/env changes or a server upgrade still requires a full restart.',
+    inputSchema: {
+      disconnectImap: z.boolean().optional().default(true).describe('Close all pooled IMAP connections (default true)'),
+      disconnectSmtp: z.boolean().optional().default(true).describe('Close all pooled SMTP connections (default true)'),
+      clearCapabilitiesCache: z.boolean().optional().default(true).describe('Clear the cached IMAP server capabilities (default true)'),
+    }
+  }, withErrorHandling(async ({ disconnectImap, disconnectSmtp, clearCapabilitiesCache }) => {
+    const reset = { imapConnectionsClosed: 0, smtpConnectionsClosed: 0, capabilitiesCacheCleared: 0 };
+    const actions: string[] = [];
+
+    if (disconnectImap !== false) {
+      reset.imapConnectionsClosed = await imapService.disconnectAll();
+      actions.push('imap-pool');
+    }
+    if (disconnectSmtp !== false) {
+      reset.smtpConnectionsClosed = smtpService.getPoolStats().configured;
+      smtpService.disconnectAll();
+      actions.push('smtp-pool');
+    }
+    if (clearCapabilitiesCache !== false) {
+      reset.capabilitiesCacheCleared = imapService.clearCapabilitiesCache();
+      actions.push('capabilities-cache');
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          reset,
+          actions,
+          note: 'Configuration, environment variables, and tools are NOT reloaded; a full restart is still required to pick those up. Stored data and the database are untouched.',
+        }, null, 2)
+      }]
+    };
+  }));
+}

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -133,6 +133,9 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_delete_folder':                WRITE_REMOTE,
   'imap_rename_folder':                WRITE_REMOTE,
 
+  // ---- admin-tools (1) ----
+  'imap_server_reload':                NEUTRAL_IDEMPOTENT,
+
   // ---- meta-tools (8) ----
   'imap_about':                        READ_ONLY,
   'imap_list_tools':                   READ_ONLY,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -14,6 +14,7 @@ import { accountTools } from './account-tools.js';
 import { emailTools } from './email-tools.js';
 import { folderTools } from './folder-tools.js';
 import { metaTools } from './meta-tools.js';
+import { adminTools } from './admin-tools.js';
 import { userTools } from './user-tools.js';
 import { userCheckTools } from './usercheck-tools.js';
 import { registerScoringTools } from './scoring-tools.js';
@@ -112,6 +113,9 @@ export function registerTools(
   if (skillsInstaller) {
     skillsTools(server, skillsInstaller);
   }
+
+  // Register admin/lifecycle tools (Issue #84 - runtime reset without restart)
+  adminTools(server, imapService, smtpService);
 
   // Register meta/discovery tools (passes webUIManager so meta-tools can expose
   // the imap_open_web_ui MCP tool when the embedded Web UI is available).


### PR DESCRIPTION
## #84 — `imap_server_reload`

Reset the server's runtime state without restarting Claude Desktop.

### Scope — only what's safe on a live stdio session
- Close all pooled **IMAP** connections (`ImapService.disconnectAll`)
- Close all pooled **SMTP** connections (`SmtpService.disconnectAll`)
- Clear the in-memory **IMAP capabilities cache** (`clearCapabilitiesCache`)

Connections reconnect lazily on the next operation — handy after changing account settings server-side or when connections go stale. Each part is independently toggleable (`disconnectImap` / `disconnectSmtp` / `clearCapabilitiesCache`, all default true); the result reports per-part counts + an `actions` list.

### Deliberately NOT done (and the tool says so)
Configuration, environment variables, and the tool registry are fixed for the process lifetime — reloading them mid-session isn't safely possible (tools register once; env is per-process), so those still require a full restart. The **database and stored data are never touched**. This keeps the tool honest rather than implementing the issue's riskier "close/reopen DB + re-register tools" verbatim.

### Also
The tool-catalog generator gained an **Admin & lifecycle** category and now correctly buckets the priority (#48) and Quad9 (#65) tools that had been landing in "Other" — the catalog is fully categorized again.

### Tests (4 new, 190 total)
registration, full reset with counts, selective skip, capabilities-only. Tools 110 → **111**.
