### PR TITLE
ci: dormant Claude PR review + assistant workflows (#93)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,40 @@
+name: Claude Code Review
+
+# Automated PR code review by Claude (#93).
+#
+# DORMANT BY DEFAULT. This job only runs when BOTH are configured:
+#   - repository variable  ENABLE_CLAUDE_REVIEW = true   (opt-in switch)
+#   - repository secret    ANTHROPIC_API_KEY            (Claude API key)
+# Until then the job is skipped (not failed), so PR checks stay green.
+# Gating on a variable (not the secret) avoids referencing secrets in `if`,
+# which GitHub does not support.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  claude-review:
+    name: Claude review
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          fetch-depth: 1
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb  # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request for the imap-mcp-pro TypeScript MCP server.
+            Focus on: correctness, security (credential handling, path traversal,
+            injection), IMAP/SMTP edge cases, error handling, and test coverage.
+            Be concise; flag real issues with file/line references and skip nits.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,45 @@
+name: Claude PR Assistant
+
+# Responds to `@claude` mentions in issues / PR comments (#93).
+#
+# DORMANT BY DEFAULT. Only runs when BOTH are configured:
+#   - repository variable  ENABLE_CLAUDE_REVIEW = true
+#   - repository secret    ANTHROPIC_API_KEY
+# Otherwise the job is skipped (not failed). The comment-body check keeps the
+# action from running on every comment.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude:
+    name: Claude assistant
+    if: >-
+      ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' &&
+          (
+            (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+            (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+            (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+          ) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          fetch-depth: 1
+
+      - name: Claude assistant
+        uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb  # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
CI build/test (ci.yml) already satisfies #93's CI criterion. This adds the two remaining workflows — `claude-code-review.yml` (automated PR review) and `claude.yml` (@claude assistant) — SHA-pinned and **dormant by default** (gated on `vars.ENABLE_CLAUDE_REVIEW == 'true'`, so they skip rather than fail until enabled). **To activate:** add secret `ANTHROPIC_API_KEY` and set variable `ENABLE_CLAUDE_REVIEW=true`. Refs #93.