### PR TITLE
feat(web): show Account ID with copy button (#64)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -673,6 +673,6 @@
         </main>
     </div>
 
-    <script src="js/app.js?v=2.13.0"></script>
+    <script src="js/app.js?v=2.23.0"></script>
 </body>
 </html>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -235,6 +235,21 @@ function copyConfig(elementId) {
   });
 }
 
+// Copy `text` and briefly flip the clicked button's label to confirm (#64).
+function copyWithFeedback(btn, text) {
+  navigator.clipboard.writeText(text).then(() => {
+    const orig = btn.textContent;
+    btn.textContent = 'Copied!';
+    btn.classList.add('text-green-600');
+    setTimeout(() => {
+      btn.textContent = orig;
+      btn.classList.remove('text-green-600');
+    }, 1500);
+  }).catch(() => {
+    alert('Copy failed. Please select and copy the ID manually.');
+  });
+}
+
 function copyText(text) {
   navigator.clipboard.writeText(text).then(() => {
     // Visual feedback is minimal for inline copy buttons
@@ -1060,6 +1075,12 @@ async function loadAccountsList() {
               <h5 class="font-semibold">${acc.user}</h5>
               <p class="text-sm text-gray-500">Name: ${acc.name}</p>
               <p class="text-sm text-gray-500">Host: ${acc.host}:${acc.port}</p>
+              <p class="text-sm text-gray-500 flex items-center gap-2">
+                <span>Account ID:</span>
+                <code class="text-xs bg-gray-100 px-1.5 py-0.5 rounded select-all">${acc.id}</code>
+                <button type="button" onclick="copyWithFeedback(this, '${acc.id}')" title="Copy account ID"
+                        class="text-xs text-blue-600 hover:text-blue-800">Copy</button>
+              </p>
               <span class="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">Configured</span>
             </div>
             <div class="flex gap-2">


### PR DESCRIPTION
Each account card in the Web UI now shows its full **Account ID** (monospace, select-all) with a **Copy** button that confirms with a transient "Copied!". Makes the ID easy to grab for CLI/MCP calls, multi-account reference, and support. Adds a `copyWithFeedback` helper and bumps the app.js cache-bust version. Closes #64.