### PR TITLE
feat: imap_get_attachment — preview/download a single attachment (#89)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,14 +4,14 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**112 MCP tools** total.
+**113 MCP tools** total.
 
 ## Categories
 
 - [Users (MSP multi-tenant)](#users-msp-multitenant) — 3
 - [Account management](#account-management) — 15
 - [Bulk operations](#bulk-operations) — 11
-- [Size, export & quota](#size-export-quota) — 7
+- [Size, export & quota](#size-export-quota) — 8
 - [Attachment staging](#attachment-staging) — 6
 - [Email operations](#email-operations) — 13
 - [Folder & mailbox operations](#folder-mailbox-operations) — 11
@@ -76,6 +76,7 @@
 | `imap_export_email` | Export one or more messages to standard .eml files on the server host (download & save). |
 | `imap_export_folder` | Export all messages in a folder to standard .eml files on the server host, mirroring the folder hierarchy under the per-user outbox (exports/[subfolder]/{folder path}/). |
 | `imap_extract_attachments` | Extract file attachments from a block of messages and save them to disk under the per-user outbox (exports/attachments/[subfolder]/). |
+| `imap_get_attachment` | Fetch a single attachment from a message for preview or download. |
 | `imap_get_email_sizes` | List messages by size to find large emails — uses RFC822.SIZE (no body download, cheap even on big folders). |
 | `imap_get_largest_emails` | Find the largest emails across several folders at once (default: just INBOX) and return the global top-N. |
 | `imap_get_quota` | Report account storage quota — used / limit / percent — via the IMAP QUOTA extension (RFC 9208). |

--- a/scripts/gen-tool-catalog.mjs
+++ b/scripts/gen-tool-catalog.mjs
@@ -34,7 +34,7 @@ const CATEGORIES = [
   ['Users (MSP multi-tenant)', /^imap_(create_user|get_user|list_users)$/],
   ['Account management', /^imap_(add_account|add_account_auto|add_account_with_provider|remove_account|list_accounts|connect|disconnect|test_account|share_account|unshare_account|list_providers|db_add_account|db_get_account|db_list_accounts|db_remove_account)$/],
   ['Bulk operations', /^imap_bulk_/],
-  ['Size, export & quota', /^imap_(get_email_sizes|get_largest_emails|export_email|export_folder|export_account|extract_attachments|get_quota)$/],
+  ['Size, export & quota', /^imap_(get_email_sizes|get_largest_emails|export_email|export_folder|export_account|extract_attachments|get_attachment|get_quota)$/],
   ['Attachment staging', /^imap_(attachment_stage_|list_staged_attachments|get_outbox_dir)/],
   ['Email operations', /^imap_(search_emails|get_email|get_latest_emails|mark_as_read|mark_as_unread|delete_email|copy_email|move_email|send_email|reply_to_email|forward_email|get_email_priority|set_email_priority)$/],
   ['Folder & mailbox operations', /^imap_(list_folders|folder_status|get_unread_count|create_folder|delete_folder|rename_folder|get_mailbox_status|subscribe_mailbox|unsubscribe_mailbox|list_subscribed_mailboxes|append_message)$/],

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -74,6 +74,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_export_folder':                READ_REMOTE,
   'imap_export_account':               READ_REMOTE,
   'imap_extract_attachments':          READ_REMOTE,
+  'imap_get_attachment':               READ_REMOTE,
   'imap_get_unsubscribe_links_for':    READ_REMOTE,
   'imap_get_unread_count':             READ_REMOTE,
   'imap_bulk_get_emails':              READ_REMOTE,

--- a/src/tools/email-tools.test.ts
+++ b/src/tools/email-tools.test.ts
@@ -57,6 +57,10 @@ function makeImap(overrides: Record<string, any> = {}) {
     getEmailPriority: async (_a: string, _f: string, uid: number) => ({
       uid, priority: 'high', source: 'header', flags: ['\\Seen'],
     }),
+    getAttachments: async (_a: string, _f: string, uids: number[]) => [
+      { uid: uids[0], filename: 'notes.txt', content: Buffer.from('X'.repeat(50)), contentType: 'text/plain', size: 50, inline: false },
+      { uid: uids[0], filename: 'logo.png', content: Buffer.from([0x89, 0x50, 0x4e, 0x47]), contentType: 'image/png', size: 4, inline: true, cid: 'logo@x' },
+    ],
     ...overrides,
   };
 }
@@ -160,6 +164,44 @@ describe('emailTools core routes', () => {
     const asc = await invoke(tools, 'imap_get_email_sizes', { accountId: 'a', folder: 'INBOX', order: 'asc', limit: 2 });
     expect(asc.returned).toBe(2);
     expect(asc.messages.map((m: any) => m.uid)).toEqual([1, 3]); // smallest first, capped
+  });
+});
+
+describe('imap_get_attachment (#89)', () => {
+  it('returns text attachments inline, selected by filename', async () => {
+    const tools = register(makeImap());
+    const out = await invoke(tools, 'imap_get_attachment', { accountId: 'a', folder: 'INBOX', uid: 1, filename: 'notes.txt' });
+    expect(out).toMatchObject({ success: true, kind: 'text', filename: 'notes.txt', truncated: false });
+    expect(out.text).toBe('X'.repeat(50));
+  });
+
+  it('truncates text at maxTextChars', async () => {
+    const tools = register(makeImap());
+    const out = await invoke(tools, 'imap_get_attachment', { accountId: 'a', folder: 'INBOX', uid: 1, filename: 'notes.txt', maxTextChars: 10 });
+    expect(out.truncated).toBe(true);
+    expect(out.text).toHaveLength(10);
+  });
+
+  it('returns small images inline as base64, selected by cid', async () => {
+    const tools = register(makeImap());
+    const res = await tools.get('imap_get_attachment')!.handler({ accountId: 'a', folder: 'INBOX', uid: 1, cid: 'logo@x' });
+    const summary = JSON.parse(res.content[0].text);
+    expect(summary).toMatchObject({ success: true, kind: 'image', inlined: true, filename: 'logo.png' });
+    expect(res.content[1]).toMatchObject({ type: 'image', mimeType: 'image/png' });
+    expect(res.content[1].data).toBe(Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'));
+  });
+
+  it('lists available attachments when the selector is ambiguous', async () => {
+    const tools = register(makeImap());
+    const out = await invoke(tools, 'imap_get_attachment', { accountId: 'a', folder: 'INBOX', uid: 1 });
+    expect(out.success).toBe(false);
+    expect(out.available.map((x: any) => x.filename)).toEqual(['notes.txt', 'logo.png']);
+  });
+
+  it('reports when the message has no attachments', async () => {
+    const tools = register(makeImap({ getAttachments: async () => [] }));
+    const out = await invoke(tools, 'imap_get_attachment', { accountId: 'a', folder: 'INBOX', uid: 1 });
+    expect(out).toMatchObject({ success: false, message: expect.stringMatching(/No attachments/) });
   });
 });
 

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -687,6 +687,93 @@ export function emailTools(
     });
   }));
 
+  // Fetch a single attachment for preview/download (#89): text-like attachments
+  // are returned inline as text, images inline as base64 (so Claude can view
+  // them), and other binaries are saved to the per-user outbox. Large images are
+  // saved rather than inlined to protect the token budget.
+  const ATT_TEXT_TYPES = /^(text\/|application\/(json|xml|csv|x-ndjson|javascript|x-yaml))/i;
+  const ATT_TEXT_EXTS = new Set(['txt', 'md', 'markdown', 'csv', 'tsv', 'json', 'log', 'xml', 'yml', 'yaml', 'ini', 'conf', 'env']);
+  const ATT_INLINE_IMAGE_MAX = 5 * 1024 * 1024; // 5 MiB — above this, save instead of inlining base64.
+
+  server.registerTool('imap_get_attachment', {
+    description:
+      'Fetch a single attachment from a message for preview or download. Text-like attachments ' +
+      '(txt/md/csv/json/log/...) are returned inline as text (truncated at maxTextChars); images are returned ' +
+      'inline as base64 so they can be viewed (large images are saved to disk instead); other binaries (incl. ' +
+      'PDFs) are saved under the per-user outbox and the path is returned. Identify the attachment by filename ' +
+      'or cid; if the message has exactly one attachment, neither is required.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder containing the message (default: INBOX)'),
+      uid: z.number().describe('UID of the message'),
+      filename: z.string().optional().describe('Select the attachment by filename (case-insensitive)'),
+      cid: z.string().optional().describe('Select the attachment by Content-ID (for inline images)'),
+      maxTextChars: z.number().optional().default(100000).describe('Max characters to return for text attachments (default 100000)'),
+      save: z.boolean().optional().default(false).describe('Also save the attachment to the per-user outbox (always done for non-text binaries)'),
+    }
+  }, withErrorHandling(async ({ accountId, folder, uid, filename, cid, maxTextChars, save }) => {
+    const all = await imapService.getAttachments(accountId, folder, [uid]);
+    if (all.length === 0) {
+      return jsonResult({ success: false, message: 'No attachments found on this message', folder, uid });
+    }
+
+    const norm = (c?: string) => (c ?? '').replace(/^<|>$/g, '');
+    let att = cid
+      ? all.find((a) => norm(a.cid) === norm(cid))
+      : filename
+        ? all.find((a) => a.filename.toLowerCase() === filename.toLowerCase())
+        : all.length === 1 ? all[0] : undefined;
+
+    if (!att) {
+      return jsonResult({
+        success: false,
+        message: (filename || cid) ? 'No attachment matched filename/cid' : 'Message has multiple attachments — specify filename or cid',
+        available: all.map((a) => ({ filename: a.filename, contentType: a.contentType, size: humanBytes(a.size), inline: a.inline, cid: a.cid })),
+      });
+    }
+
+    const userId = resolveUserId(db) ?? 'default';
+    const ext = path.extname(att.filename).slice(1).toLowerCase();
+    const saveToDisk = async () => {
+      const dir = path.join(getOutboxDir(userId), 'attachments');
+      const r = await new MessageExportService().writeAttachments(dir, [att!]);
+      return r.files[0]?.path;
+    };
+
+    // Image → inline base64 (unless too large), optionally saved too.
+    if (/^image\//i.test(att.contentType)) {
+      if (att.size > ATT_INLINE_IMAGE_MAX) {
+        const savedAs = await saveToDisk();
+        return jsonResult({ success: true, uid, filename: att.filename, contentType: att.contentType, size: humanBytes(att.size), kind: 'image', inlined: false, savedAs, note: `Image exceeds ${humanBytes(ATT_INLINE_IMAGE_MAX)}; saved to disk instead of inlining.` });
+      }
+      const savedAs = save ? await saveToDisk() : undefined;
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ success: true, uid, filename: att.filename, contentType: att.contentType, size: humanBytes(att.size), kind: 'image', inlined: true, ...(savedAs ? { savedAs } : {}) }, null, 2) },
+          { type: 'image', data: att.content.toString('base64'), mimeType: att.contentType },
+        ],
+      };
+    }
+
+    // Text-like → inline text (truncated).
+    if (ATT_TEXT_TYPES.test(att.contentType) || ATT_TEXT_EXTS.has(ext)) {
+      const full = att.content.toString('utf8');
+      const limit = maxTextChars ?? 100000;
+      const truncated = full.length > limit;
+      const savedAs = save ? await saveToDisk() : undefined;
+      return jsonResult({ success: true, uid, filename: att.filename, contentType: att.contentType, size: humanBytes(att.size), kind: 'text', truncated, ...(savedAs ? { savedAs } : {}), text: truncated ? full.slice(0, limit) : full });
+    }
+
+    // Other binary (incl. PDF) → save to disk.
+    const savedAs = await saveToDisk();
+    return jsonResult({
+      success: true, uid, filename: att.filename, contentType: att.contentType, size: humanBytes(att.size), kind: 'binary', savedAs,
+      note: ext === 'pdf'
+        ? 'PDF saved to disk. Inline text extraction is not enabled yet (requires the pdf-parse dependency).'
+        : 'Binary attachment saved to disk.',
+    });
+  }));
+
   // Bulk delete emails tool
   // AUTO-CHUNKING: Automatically uses chunked processing for >50 UIDs
   server.registerTool('imap_bulk_delete_emails', {


### PR DESCRIPTION
Adds the **dependency-free core** of #89: `imap_get_attachment` fetches one attachment (by filename/cid, or the sole one) and returns it by type — **text inline** (truncated), **images inline as base64** (large ones saved to disk instead), **other binaries/PDF saved** to the per-user outbox. Ambiguous/missing selectors return the available list. 5 new tests; tools 112→113.\n\n**Deferred (needs dependency sign-off):** PDF text extraction (`pdf-parse`) and inline attachment text inside `imap_get_email`. Refs #89 (kept open for those).