### PR TITLE
feat: PDF attachment text + inline attachment text in imap_get_email (#89)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.18.1",
+  "version": "2.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.18.1",
+      "version": "2.23.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -27,6 +27,7 @@
         "nodemailer": "^9.0.1",
         "open": "^10.2.0",
         "ora": "^8.2.0",
+        "pdf-parse": "^1.1.1",
         "zod": "^3.25.76",
         "zod-to-json-schema": "^3.25.2"
       },
@@ -3666,6 +3667,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/nodemailer": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
@@ -3963,6 +3970,28 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/peberminta": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "nodemailer": "^9.0.1",
     "open": "^10.2.0",
     "ora": "^8.2.0",
+    "pdf-parse": "^1.1.1",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.25.2"
   }

--- a/src/tools/email-tools.test.ts
+++ b/src/tools/email-tools.test.ts
@@ -39,6 +39,7 @@ function makeImap(overrides: Record<string, any> = {}) {
     getEmailContent: async () => ({
       uid: 1, subject: 'Hello', from: 'a@x.com',
       textContent: 'T'.repeat(20000), htmlContent: 'H'.repeat(20000),
+      attachments: [],
     }),
     markAsRead: async () => {},
     markAsUnread: async () => {},
@@ -164,6 +165,54 @@ describe('emailTools core routes', () => {
     const asc = await invoke(tools, 'imap_get_email_sizes', { accountId: 'a', folder: 'INBOX', order: 'asc', limit: 2 });
     expect(asc.returned).toBe(2);
     expect(asc.messages.map((m: any) => m.uid)).toEqual([1, 3]); // smallest first, capped
+  });
+});
+
+describe('imap_get_email includeAttachmentText (#89)', () => {
+  function imapWithAttachmentText() {
+    return makeImap({
+      getEmailContent: async () => ({
+        uid: 1, subject: 'Hi', from: 'a@x.com', textContent: 'body', htmlContent: '',
+        attachments: [
+          { filename: 'notes.txt', contentType: 'text/plain', size: 11 },
+          { filename: 'doc.pdf', contentType: 'application/pdf', size: 999 },
+          { filename: 'logo.png', contentType: 'image/png', size: 4 },
+        ],
+      }),
+      getAttachments: async () => [
+        { uid: 1, filename: 'notes.txt', content: Buffer.from('hello there'), contentType: 'text/plain', size: 11, inline: false },
+        { uid: 1, filename: 'doc.pdf', content: Buffer.from('not a real pdf'), contentType: 'application/pdf', size: 999, inline: false },
+        { uid: 1, filename: 'logo.png', content: Buffer.from([0x89]), contentType: 'image/png', size: 4, inline: true },
+      ],
+    });
+  }
+
+  it('does not fetch attachment text by default', async () => {
+    const out = await invoke(register(makeImap()), 'imap_get_email', { accountId: 'a', folder: 'INBOX', uid: 1 });
+    expect(out.email.attachments).toEqual([]);
+  });
+
+  it('inlines text for text attachments and attempts PDF extraction when requested', async () => {
+    const out = await invoke(register(imapWithAttachmentText()), 'imap_get_email', {
+      accountId: 'a', folder: 'INBOX', uid: 1, includeAttachmentText: true,
+    });
+    const byName = Object.fromEntries(out.email.attachments.map((a: any) => [a.filename, a]));
+    expect(byName['notes.txt'].textContent).toBe('hello there');
+    expect(byName['notes.txt'].textContentTruncated).toBe(false);
+    // PDF: extraction runs and degrades gracefully on a non-PDF buffer (no throw).
+    expect(byName['doc.pdf']).toHaveProperty('textContent');
+    expect(byName['doc.pdf'].textContent).toBe('');
+    // Images are left as metadata only.
+    expect(byName['logo.png'].textContent).toBeUndefined();
+  });
+
+  it('truncates attachment text at maxAttachmentTextChars', async () => {
+    const out = await invoke(register(imapWithAttachmentText()), 'imap_get_email', {
+      accountId: 'a', folder: 'INBOX', uid: 1, includeAttachmentText: true, maxAttachmentTextChars: 4,
+    });
+    const notes = out.email.attachments.find((a: any) => a.filename === 'notes.txt');
+    expect(notes.textContent).toBe('hell');
+    expect(notes.textContentTruncated).toBe(true);
   });
 });
 

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { withErrorHandling, AccountNotFoundError } from '../utils/error-handler.js';
 import { ImapAccount } from '../types/index.js';
 import { humanBytes } from '../utils/human-bytes.js';
+import { extractPdfText } from '../utils/pdf-text.js';
 import {
   maybeStoreAsHandle,
   ResponseModeSchema,
@@ -28,6 +29,22 @@ function resolveUserId(db: DatabaseService): string | null {
   } catch {
     return null;
   }
+}
+
+// Attachment text-preview classification, shared by imap_get_attachment and
+// imap_get_email (#89).
+const ATT_TEXT_TYPES = /^(text\/|application\/(json|xml|csv|x-ndjson|javascript|x-yaml))/i;
+const ATT_TEXT_EXTS = new Set(['txt', 'md', 'markdown', 'csv', 'tsv', 'json', 'log', 'xml', 'yml', 'yaml', 'ini', 'conf', 'env']);
+const ATT_INLINE_IMAGE_MAX = 5 * 1024 * 1024; // 5 MiB — above this, save instead of inlining base64.
+
+function attExt(filename: string): string {
+  return path.extname(filename || '').slice(1).toLowerCase();
+}
+function isTextLikeAttachment(filename: string, contentType: string): boolean {
+  return ATT_TEXT_TYPES.test(contentType || '') || ATT_TEXT_EXTS.has(attExt(filename));
+}
+function isPdfAttachment(filename: string, contentType: string): boolean {
+  return attExt(filename) === 'pdf' || /\/pdf$/i.test(contentType || '');
 }
 
 function shouldUseHandle(mode: ResponseModeOpt, n: number): boolean {
@@ -329,21 +346,50 @@ export function emailTools(
 
   // Get email content tool
   server.registerTool('imap_get_email', {
-    description: 'Get the full content of an email or just headers',
+    description:
+      'Get the full content of an email (or just headers). Optionally inline the text of text-like and PDF ' +
+      'attachments with includeAttachmentText (truncated at maxAttachmentTextChars).',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name'),
       uid: z.number().describe('Email UID'),
-      headersOnly: z.boolean().optional().default(false).describe('Fetch only headers without body content (saves bandwidth and context space)')
+      headersOnly: z.boolean().optional().default(false).describe('Fetch only headers without body content (saves bandwidth and context space)'),
+      includeAttachmentText: z.boolean().optional().default(false).describe('Inline extracted text for text-like (txt/md/csv/json/...) and PDF attachments'),
+      maxAttachmentTextChars: z.number().optional().default(20000).describe('Max characters of extracted text per attachment (default 20000)'),
     }
-  }, withErrorHandling(async ({ accountId, folder, uid, headersOnly }) => {
+  }, withErrorHandling(async ({ accountId, folder, uid, headersOnly, includeAttachmentText, maxAttachmentTextChars }) => {
     const email = await imapService.getEmailContent(accountId, folder, uid, headersOnly);
+
+    let attachments = email.attachments;
+    // Enrich attachment metadata with extracted text on request. Done here (not
+    // in getEmailContent) so the cheap default path stays body-only; this fetches
+    // attachment content via a separate parse only when asked.
+    if (includeAttachmentText && !headersOnly && attachments.length > 0) {
+      const limit = maxAttachmentTextChars ?? 20000;
+      const fetched = await imapService.getAttachments(accountId, folder, [uid]);
+      attachments = await Promise.all(attachments.map(async (meta) => {
+        const match = fetched.find((f) => f.filename === meta.filename && f.contentType === meta.contentType)
+          ?? fetched.find((f) => f.filename === meta.filename);
+        if (!match) return meta;
+        if (isTextLikeAttachment(match.filename, match.contentType)) {
+          const full = match.content.toString('utf8');
+          const truncated = full.length > limit;
+          return { ...meta, textContent: truncated ? full.slice(0, limit) : full, textContentTruncated: truncated };
+        }
+        if (isPdfAttachment(match.filename, match.contentType)) {
+          const pdf = await extractPdfText(match.content, limit);
+          return { ...meta, textContent: pdf.text, textContentTruncated: pdf.truncated };
+        }
+        return meta;
+      }));
+    }
 
     return jsonResult({
       email: {
         ...email,
         textContent: clip(email.textContent),
         htmlContent: clip(email.htmlContent),
+        attachments,
       },
     });
   }));
@@ -689,12 +735,8 @@ export function emailTools(
 
   // Fetch a single attachment for preview/download (#89): text-like attachments
   // are returned inline as text, images inline as base64 (so Claude can view
-  // them), and other binaries are saved to the per-user outbox. Large images are
-  // saved rather than inlined to protect the token budget.
-  const ATT_TEXT_TYPES = /^(text\/|application\/(json|xml|csv|x-ndjson|javascript|x-yaml))/i;
-  const ATT_TEXT_EXTS = new Set(['txt', 'md', 'markdown', 'csv', 'tsv', 'json', 'log', 'xml', 'yml', 'yaml', 'ini', 'conf', 'env']);
-  const ATT_INLINE_IMAGE_MAX = 5 * 1024 * 1024; // 5 MiB — above this, save instead of inlining base64.
-
+  // them), PDFs as extracted text, and other binaries are saved to the per-user
+  // outbox. Large images are saved rather than inlined to protect the token budget.
   server.registerTool('imap_get_attachment', {
     description:
       'Fetch a single attachment from a message for preview or download. Text-like attachments ' +
@@ -733,7 +775,6 @@ export function emailTools(
     }
 
     const userId = resolveUserId(db) ?? 'default';
-    const ext = path.extname(att.filename).slice(1).toLowerCase();
     const saveToDisk = async () => {
       const dir = path.join(getOutboxDir(userId), 'attachments');
       const r = await new MessageExportService().writeAttachments(dir, [att!]);
@@ -755,22 +796,33 @@ export function emailTools(
       };
     }
 
+    const limit = maxTextChars ?? 100000;
+
     // Text-like → inline text (truncated).
-    if (ATT_TEXT_TYPES.test(att.contentType) || ATT_TEXT_EXTS.has(ext)) {
+    if (isTextLikeAttachment(att.filename, att.contentType)) {
       const full = att.content.toString('utf8');
-      const limit = maxTextChars ?? 100000;
       const truncated = full.length > limit;
       const savedAs = save ? await saveToDisk() : undefined;
       return jsonResult({ success: true, uid, filename: att.filename, contentType: att.contentType, size: humanBytes(att.size), kind: 'text', truncated, ...(savedAs ? { savedAs } : {}), text: truncated ? full.slice(0, limit) : full });
     }
 
-    // Other binary (incl. PDF) → save to disk.
+    // PDF → extract text inline (and save the file too).
+    if (isPdfAttachment(att.filename, att.contentType)) {
+      const savedAs = await saveToDisk();
+      const pdf = await extractPdfText(att.content, limit);
+      return jsonResult({
+        success: true, uid, filename: att.filename, contentType: att.contentType, size: humanBytes(att.size),
+        kind: 'pdf', pages: pdf.pages, truncated: pdf.truncated, savedAs,
+        ...(pdf.error ? { note: `Saved to disk; PDF text extraction failed: ${pdf.error}` } : {}),
+        text: pdf.text,
+      });
+    }
+
+    // Other binary → save to disk.
     const savedAs = await saveToDisk();
     return jsonResult({
       success: true, uid, filename: att.filename, contentType: att.contentType, size: humanBytes(att.size), kind: 'binary', savedAs,
-      note: ext === 'pdf'
-        ? 'PDF saved to disk. Inline text extraction is not enabled yet (requires the pdf-parse dependency).'
-        : 'Binary attachment saved to disk.',
+      note: 'Binary attachment saved to disk.',
     });
   }));
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -118,6 +118,10 @@ export interface Attachment {
   contentType: string;
   size: number;
   contentId?: string;
+  /** Extracted text preview (text-like or PDF attachments), when requested (#89). */
+  textContent?: string;
+  /** True when textContent was truncated to the requested character limit. */
+  textContentTruncated?: boolean;
 }
 
 /** A mailbox/folder node, optionally with nested children. */

--- a/src/types/pdf-parse.d.ts
+++ b/src/types/pdf-parse.d.ts
@@ -1,0 +1,13 @@
+// Minimal ambient declaration for pdf-parse's lib entry (no @types published).
+declare module 'pdf-parse/lib/pdf-parse.js' {
+  interface PdfParseResult {
+    text: string;
+    numpages: number;
+    numrender?: number;
+    info?: unknown;
+    metadata?: unknown;
+    version?: string;
+  }
+  function pdf(data: Buffer, options?: Record<string, unknown>): Promise<PdfParseResult>;
+  export default pdf;
+}

--- a/src/utils/pdf-text.test.ts
+++ b/src/utils/pdf-text.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for extractPdfText (#89).
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { extractPdfText } from './pdf-text.js';
+
+describe('extractPdfText (#89)', () => {
+  it('degrades gracefully on a non-PDF buffer (returns error, never throws)', async () => {
+    const r = await extractPdfText(Buffer.from('this is not a pdf'));
+    expect(r.text).toBe('');
+    expect(r.pages).toBe(0);
+    expect(r.truncated).toBe(false);
+    expect(typeof r.error).toBe('string');
+  });
+
+  it('extracts text from a real PDF', async () => {
+    // Use a sample PDF shipped with the pdf-parse dependency.
+    const require = createRequire(import.meta.url);
+    const pkgDir = path.dirname(require.resolve('pdf-parse/package.json'));
+    const sample = path.join(pkgDir, 'test', 'data', '01-valid.pdf');
+    if (!existsSync(sample)) return; // dependency layout changed — skip rather than fail
+    const r = await extractPdfText(readFileSync(sample));
+    expect(r.error).toBeUndefined();
+    expect(r.pages).toBeGreaterThan(0);
+    expect(r.text.length).toBeGreaterThan(0);
+  });
+
+  it('truncates at maxChars', async () => {
+    const require = createRequire(import.meta.url);
+    const pkgDir = path.dirname(require.resolve('pdf-parse/package.json'));
+    const sample = path.join(pkgDir, 'test', 'data', '01-valid.pdf');
+    if (!existsSync(sample)) return;
+    const r = await extractPdfText(readFileSync(sample), 5);
+    expect(r.text.length).toBeLessThanOrEqual(5);
+    expect(r.truncated).toBe(true);
+  });
+});

--- a/src/utils/pdf-text.ts
+++ b/src/utils/pdf-text.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// pdf-text — extract plain text from a PDF buffer (#89).
+//
+// Uses pdf-parse, imported lazily from its lib entry so (a) the parser is only
+// loaded when a PDF is actually encountered, and (b) we avoid pdf-parse's
+// index.js debug block (which reads a bundled sample file at import time under
+// some loaders). Extraction failures are returned, never thrown, so a malformed
+// PDF degrades to "couldn't extract" rather than failing the whole tool call.
+
+export interface PdfTextResult {
+  text: string;
+  pages: number;
+  truncated: boolean;
+  error?: string;
+}
+
+export async function extractPdfText(buffer: Buffer, maxChars = 100000): Promise<PdfTextResult> {
+  try {
+    const mod: any = await import('pdf-parse/lib/pdf-parse.js');
+    const pdf = (mod.default ?? mod) as (data: Buffer, opts?: any) => Promise<{ text?: string; numpages?: number }>;
+    const data = await pdf(buffer);
+    const full = (data.text || '').trim();
+    const truncated = full.length > maxChars;
+    return { text: truncated ? full.slice(0, maxChars) : full, pages: data.numpages ?? 0, truncated };
+  } catch (e) {
+    return { text: '', pages: 0, truncated: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}


### PR DESCRIPTION
## #89 — completes attachment preview (PDF + inline-in-get_email)

Finishes the parts deferred from PR #229 (now that `pdf-parse` is approved).

### PDF text extraction
- New `src/utils/pdf-text.ts` wraps `pdf-parse`, imported **lazily** from its lib entry (loaded only when a PDF is encountered; avoids the index.js debug block). Failures are **returned, not thrown**, so a malformed PDF degrades to "couldn't extract".
- `imap_get_attachment` PDF branch now returns extracted text inline (`kind: 'pdf'`, `pages`, `truncated`) and still saves the file.

### Inline attachment text in `imap_get_email`
- New `includeAttachmentText` + `maxAttachmentTextChars` options inline the text of text-like and PDF attachments. Fetched on demand via a separate parse, so the **default path stays body-only** (cheap). Added `textContent` / `textContentTruncated` to the `Attachment` type.

### Dependency safety
`pdf-parse` adds **zero new audited vulnerabilities** (its only deps are `debug`/`node-ensure`). The 8 existing prod advisories are the pre-existing deferred set (#205 SDK + fast-uri, transitive nodemailer/mailparser/ip-address). Bundle grew ~8 MB (vendored pdf.js).

### Tests (6 new, 235 total)
`extractPdfText` happy/error/truncate (uses pdf-parse's bundled sample, skips if absent); `imap_get_email` enrichment for text/PDF/truncation.

Closes #89.
