### PR TITLE
feat: FTS5 full-text search over the local message cache (#119)

### DIFF
--- a/src/database/migrations-manifest.json
+++ b/src/database/migrations-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.11.0",
+  "schemaVersion": "1.12.0",
   "description": "Release-indexed manifest of schema migrations. Each entry is applied in order via the `schema_version` ledger. A migration is complete when its `to` version is present in the ledger.",
   "migrations": [
     {
@@ -72,6 +72,13 @@
       "file": "schema_update_1.10.0_TO_1.11.0.sql",
       "rollbackFile": "schema_update_1.10.0_TO_1.11.0.down.sql",
       "description": "Add messages_cache table for v2.17.0 MVP local message header cache (Issue #124)"
+    },
+    {
+      "from": "1.11.0",
+      "to": "1.12.0",
+      "file": "schema_update_1.11.0_TO_1.12.0.sql",
+      "rollbackFile": "schema_update_1.11.0_TO_1.12.0.down.sql",
+      "description": "Add messages_cache_fts FTS5 full-text index over subject + sender (Track B, Issue #119)"
     }
   ]
 }

--- a/src/database/schema_update_1.11.0_TO_1.12.0.down.sql
+++ b/src/database/schema_update_1.11.0_TO_1.12.0.down.sql
@@ -1,0 +1,5 @@
+-- Rollback for schema 1.11.0 → 1.12.0 (#119: messages_cache FTS5 index)
+DROP TRIGGER IF EXISTS messages_cache_fts_au;
+DROP TRIGGER IF EXISTS messages_cache_fts_ad;
+DROP TRIGGER IF EXISTS messages_cache_fts_ai;
+DROP TABLE IF EXISTS messages_cache_fts;

--- a/src/database/schema_update_1.11.0_TO_1.12.0.sql
+++ b/src/database/schema_update_1.11.0_TO_1.12.0.sql
@@ -1,0 +1,51 @@
+-- Schema migration 1.11.0 → 1.12.0
+-- Track B (#119): FTS5 full-text search over the local message header cache.
+--
+-- Adds a full-text index over the fields already stored in messages_cache
+-- (subject + sender display name + sender address) so partial-recall queries
+-- ("something about a closing schedule from someone at a law firm") become a
+-- single ranked MATCH instead of fetching N bodies into the model's context.
+--
+-- PRIVACY NOTE: this indexes only data the header cache already holds — no
+-- message bodies are fetched or stored. Body-text FTS, the participants table,
+-- and threading columns remain deferred (the rest of #119).
+--
+-- Implementation: an external-content FTS5 table (content='messages_cache')
+-- kept in sync by AFTER INSERT/UPDATE/DELETE triggers, so no service code needs
+-- to write to it. INSERT OR REPLACE (used by syncFolder) fires DELETE+INSERT,
+-- which the triggers handle. Existing cached rows are backfilled below.
+--
+-- Author: Colin Bitterfield
+-- Email: colin.bitterfield@templeofepiphany.com
+-- Date: 2026-06-22
+
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_cache_fts USING fts5(
+  subject,
+  from_name,
+  from_address,
+  content='messages_cache',
+  content_rowid='rowid',
+  tokenize='unicode61'
+);
+
+-- Keep the FTS index in lockstep with messages_cache.
+CREATE TRIGGER IF NOT EXISTS messages_cache_fts_ai AFTER INSERT ON messages_cache BEGIN
+  INSERT INTO messages_cache_fts(rowid, subject, from_name, from_address)
+  VALUES (new.rowid, new.subject, new.from_name, new.from_address);
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_cache_fts_ad AFTER DELETE ON messages_cache BEGIN
+  INSERT INTO messages_cache_fts(messages_cache_fts, rowid, subject, from_name, from_address)
+  VALUES ('delete', old.rowid, old.subject, old.from_name, old.from_address);
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_cache_fts_au AFTER UPDATE ON messages_cache BEGIN
+  INSERT INTO messages_cache_fts(messages_cache_fts, rowid, subject, from_name, from_address)
+  VALUES ('delete', old.rowid, old.subject, old.from_name, old.from_address);
+  INSERT INTO messages_cache_fts(rowid, subject, from_name, from_address)
+  VALUES (new.rowid, new.subject, new.from_name, new.from_address);
+END;
+
+-- Backfill any rows cached before this migration.
+INSERT INTO messages_cache_fts(rowid, subject, from_name, from_address)
+  SELECT rowid, subject, from_name, from_address FROM messages_cache;

--- a/src/services/message-cache-fts.test.ts
+++ b/src/services/message-cache-fts.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// End-to-end tests for MessageCacheService.searchFullText (#119) against a real
+// node:sqlite DatabaseService in a temp dir — exercises the 1.12.0 migration
+// (FTS5 virtual table + sync triggers + backfill) and the ranked search path.
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseService } from './database-service.js';
+import { MessageCacheService, CacheMissError } from './message-cache-service.js';
+
+let tmpDir: string;
+let db: DatabaseService;
+let cache: MessageCacheService;
+
+const NOW = 1_750_000_000_000; // fixed unix-ms base (no Date.now() needed)
+
+function seed(row: {
+  uid: number; folder?: string; subject: string; fromAddress: string;
+  fromName?: string; date?: number;
+}) {
+  const fromDomain = row.fromAddress.split('@')[1]?.toLowerCase() ?? null;
+  db.getDb().prepare(
+    `INSERT OR REPLACE INTO messages_cache
+       (account_id, folder, uid, uid_validity, message_id, date_received,
+        subject, from_address, from_domain, from_name, list_unsubscribe, flags_json, cached_at)
+     VALUES ($a,$f,$u,1,$mid,$d,$s,$fa,$fd,$fn,NULL,'[]',$c)`
+  ).run({
+    $a: 'acc', $f: row.folder ?? 'INBOX', $u: row.uid, $mid: `<${row.uid}>`,
+    $d: row.date ?? NOW, $s: row.subject, $fa: row.fromAddress.toLowerCase(),
+    $fd: fromDomain, $fn: row.fromName ?? null, $c: NOW,
+  });
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imap-fts-'));
+  db = new DatabaseService({ dbPath: path.join(tmpDir, 'data.db') });
+  // Seed cache rows directly without a full accounts fixture — disable FK
+  // enforcement on this connection for the test (cache search is independent of
+  // the accounts FK). Production inserts go through real, existing accounts.
+  db.getDb().exec('PRAGMA foreign_keys = OFF');
+  cache = new MessageCacheService(db, {} as any); // searchFullText never touches imapService
+  seed({ uid: 1, subject: 'Closing schedule for the house', fromAddress: 'jane@lawfirm.com', fromName: 'Jane Counsel' });
+  seed({ uid: 2, subject: 'Lunch tomorrow?', fromAddress: 'bob@friends.com', fromName: 'Bob' });
+  seed({ uid: 3, subject: 'Re: closing documents', fromAddress: 'paralegal@lawfirm.com', fromName: 'Pat Legal', date: NOW - 400 * 86_400_000 });
+});
+
+afterEach(async () => {
+  try { db.close(); } catch { /* ignore */ }
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('MessageCacheService.searchFullText (#119)', () => {
+  it('matches a term in the subject', async () => {
+    const rows = await cache.searchFullText('acc', 'INBOX', 'schedule');
+    expect(rows.map((r) => r.uid)).toEqual([1]);
+  });
+
+  it('matches a term in the sender display name', async () => {
+    const rows = await cache.searchFullText('acc', 'INBOX', 'Counsel');
+    expect(rows.map((r) => r.uid)).toEqual([1]);
+  });
+
+  it('matches a token from the sender address/domain', async () => {
+    const rows = await cache.searchFullText('acc', 'INBOX', 'lawfirm');
+    expect(rows.map((r) => r.uid).sort()).toEqual([1, 3]);
+  });
+
+  it('applies implicit AND across terms', async () => {
+    const rows = await cache.searchFullText('acc', 'INBOX', 'closing schedule');
+    expect(rows.map((r) => r.uid)).toEqual([1]); // uid 3 has "closing" but not "schedule"
+  });
+
+  it('returns nothing for a non-matching query', async () => {
+    expect(await cache.searchFullText('acc', 'INBOX', 'zzzznomatch')).toEqual([]);
+  });
+
+  it('is injection-safe: FTS operators in input never throw', async () => {
+    for (const q of ['"); drop table messages_cache; --', 'a OR b NEAR(', '^*(', '""']) {
+      const rows = await cache.searchFullText('acc', 'INBOX', q);
+      expect(Array.isArray(rows)).toBe(true);
+    }
+    // table still intact
+    expect(await cache.searchFullText('acc', 'INBOX', 'schedule')).toHaveLength(1);
+  });
+
+  it('honors the since filter', async () => {
+    // uid 3 is ~400 days old; restrict to last 90 days → only uid 1 matches "closing"
+    const rows = await cache.searchFullText('acc', 'INBOX', 'closing', { since: NOW - 90 * 86_400_000 });
+    expect(rows.map((r) => r.uid)).toEqual([1]);
+  });
+
+  it('throws CacheMissError for an unsynced folder', async () => {
+    await expect(cache.searchFullText('acc', 'Sent', 'anything')).rejects.toBeInstanceOf(CacheMissError);
+  });
+
+  it('keeps the FTS index in sync when a row is deleted (trigger)', async () => {
+    db.getDb().prepare(`DELETE FROM messages_cache WHERE account_id='acc' AND folder='INBOX' AND uid=1`).run();
+    expect(await cache.searchFullText('acc', 'INBOX', 'schedule')).toEqual([]);
+  });
+});

--- a/src/services/message-cache-service.ts
+++ b/src/services/message-cache-service.ts
@@ -389,6 +389,54 @@ export class MessageCacheService {
     return rows.map(rowFromDb);
   }
 
+  /**
+   * Full-text search over the cached subject + sender display name + sender
+   * address via the messages_cache_fts FTS5 index (#119). Ranked by bm25, then
+   * recency. No message bodies are involved — this searches only the header
+   * fields already in the cache. Cache miss (folder not synced) throws.
+   *
+   * The query is tokenized and each term quoted, so FTS5 operators in user
+   * input can't change the query semantics or cause a syntax error.
+   */
+  async searchFullText(
+    accountId: string,
+    folder: string,
+    query: string,
+    options: SearchOptions = {},
+  ): Promise<CachedMessageRow[]> {
+    this.assertSynced(accountId, folder);
+
+    const ftsQuery = String(query ?? '')
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((t) => '"' + t.replace(/"/g, '""') + '"')
+      .join(' ');
+    if (!ftsQuery) return [];
+
+    const limit = Math.min(options.limit ?? 50, 1000);
+    const params: Record<string, unknown> = {
+      $a: accountId,
+      $f: folder,
+      $q: ftsQuery,
+      $limit: limit,
+    };
+    let extra = '';
+    if (options.since !== undefined) { extra += ` AND m.date_received >= $since`; params.$since = options.since; }
+    if (options.until !== undefined) { extra += ` AND m.date_received <= $until`; params.$until = options.until; }
+
+    const rows = this.db.getDb().prepare(
+      `SELECT m.* FROM messages_cache m
+       JOIN messages_cache_fts ON messages_cache_fts.rowid = m.rowid
+       WHERE messages_cache_fts MATCH $q
+         AND m.account_id = $a AND m.folder = $f${extra}
+       ORDER BY bm25(messages_cache_fts), m.date_received DESC
+       LIMIT $limit`
+    ).all(params as any) as any[];
+
+    return rows.map(rowFromDb);
+  }
+
   async groupBySender(
     accountId: string,
     folder: string,

--- a/src/tools/cache-tools.ts
+++ b/src/tools/cache-tools.ts
@@ -26,7 +26,7 @@ import {
   CacheMissError,
 } from '../services/message-cache-service.js';
 
-const SearchModeSchema = z.enum(['by_domain', 'by_address', 'group_by_sender']);
+const SearchModeSchema = z.enum(['by_domain', 'by_address', 'group_by_sender', 'fulltext']);
 
 /**
  * Convert a "since" string ("90d", "24h", ISO date) to a unix-ms lower bound.
@@ -82,7 +82,9 @@ export function cacheTools(
     description:
       'Fast SQL-backed search against the local header cache. ' +
       'Modes: by_domain (rows where from_domain matches), by_address (exact ' +
-      'from_address match), group_by_sender (top-N senders by message count). ' +
+      'from_address match), group_by_sender (top-N senders by message count), ' +
+      'fulltext (FTS5 ranked search over subject + sender name/address — for ' +
+      'partial-recall queries; no message bodies are searched). ' +
       'Returns explicit cache_miss error if the folder has not been synced — ' +
       'call imap_sync_folder_cache first.',
     inputSchema: {
@@ -91,10 +93,11 @@ export function cacheTools(
       mode: SearchModeSchema.describe(
         'by_domain: rows for one domain. ' +
         'by_address: rows for one exact address. ' +
-        'group_by_sender: top-N senders by message count.'
+        'group_by_sender: top-N senders by message count. ' +
+        'fulltext: FTS5 ranked search over subject + sender (value = query text).'
       ),
       value: z.string().optional()
-        .describe('Domain or address (required for by_domain/by_address modes)'),
+        .describe('Domain (by_domain), address (by_address), or query text (fulltext) — required for those modes'),
       since: z.string().optional()
         .describe('Lower bound: relative ("90d", "24h") or ISO date'),
       limit: z.number().int().positive().optional()
@@ -119,6 +122,10 @@ export function cacheTools(
           break;
         case 'group_by_sender':
           payload = await cache.groupBySender(accountId, folder, opts);
+          break;
+        case 'fulltext':
+          if (!value) throw new Error('fulltext mode requires value (the search query)');
+          payload = await cache.searchFullText(accountId, folder, value, opts);
           break;
       }
       return {


### PR DESCRIPTION
## #119 (Track B slice) — FTS5 full-text search over the local cache

A self-contained, **privacy-neutral** increment on the existing `messages_cache` header cache. The heavier parts of #119 (body cache, participants table, threading columns) remain deferred — this indexes only fields the cache already holds (no bodies fetched or stored).

### What's added
- **Migration 1.11.0 → 1.12.0**: `messages_cache_fts`, an **external-content FTS5** table over `subject + from_name + from_address`, kept in sync by `AFTER INSERT/UPDATE/DELETE` triggers (so `syncFolder`/`invalidate` need **zero changes**), plus a **backfill** of pre-existing rows. `node:sqlite` ships FTS5 (verified on Node 24). Down-migration included.
- **`MessageCacheService.searchFullText()`** — bm25-ranked `MATCH` joined back to `messages_cache`, with `since`/`until`/`limit`. Query input is **tokenized and quoted per term**, so FTS5 operators can't change semantics or throw (injection-safe).
- **`imap_search_cache` `fulltext` mode** (`value` = query text) — enables partial-recall search ("*something about a closing schedule from someone at a law firm*").

### Tests (9 new, 244 total)
Real `node:sqlite` temp-DB E2E: migration applies, subject/sender matches, implicit-AND, no-match, **injection safety**, `since` filter, `CacheMissError` on unsynced folder, and **delete-trigger** index sync.

### Still deferred on #119
Body-text FTS (needs a body-cache decision — disk/privacy tradeoff), the participants table, and threading columns. Tracked on #119 (kept open).
