### PR TITLE
release: v2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.25.0] - 2026-06-22
+
+Full-text search over the local message cache. Test suite 235 → 244.
+
+### Added
+- **`imap_search_cache` `fulltext` mode** (#119, Track B slice) — FTS5-ranked full-text search over the locally cached **subject + sender name + sender address** for partial-recall queries ("something about a closing schedule from someone at a law firm"). Privacy-neutral: no message bodies are fetched or stored. Query input is tokenized and quoted per term, so FTS5 operators in input are safe.
+
+### Database
+- **Migration 1.11.0 → 1.12.0** — adds `messages_cache_fts`, an external-content FTS5 index kept in sync with `messages_cache` by triggers, with a backfill of existing rows. Down-migration included. (Applied automatically on startup; `node:sqlite` ships FTS5.)
+
 ## [2.24.0] - 2026-06-22
 
 Completes attachment preview with PDF text extraction. Test suite 229 → 235.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
FTS5 full-text search over the local message cache: imap_search_cache fulltext mode + migration 1.11.0→1.12.0 (messages_cache_fts, trigger-synced, backfilled). Privacy-neutral. Tests 235→244. (#119 Track B slice)