### PR TITLE
fix(security): owner-only perms on data dir + DB file (#235)

### DIFF
--- a/src/services/database-service-perms.test.ts
+++ b/src/services/database-service-perms.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for owner-only data-at-rest permissions on the DB file + data dir (#235).
+// POSIX-only: Windows does not model 0600/0700 modes, so the assertions are
+// skipped there (chmod still runs harmlessly).
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { promises as fs, statSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseService } from './database-service.js';
+
+const posix = process.platform !== 'win32';
+const mode = (p: string) => statSync(p).mode & 0o777;
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imap-perms-'));
+});
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe.skipIf(!posix)('DatabaseService data-at-rest permissions (#235)', () => {
+  it('creates the DB file 0600 and the data dir 0700', () => {
+    const dbDir = path.join(tmpDir, 'store');
+    const dbPath = path.join(dbDir, 'data.db');
+    const db = new DatabaseService({ dbPath });
+    try {
+      expect(mode(dbPath)).toBe(0o600);
+      expect(mode(dbDir)).toBe(0o700);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('repairs a world-readable DB file on startup', async () => {
+    const dbPath = path.join(tmpDir, 'data.db');
+    // First construction creates a valid SQLite file (now 0600).
+    new DatabaseService({ dbPath }).close();
+    // Loosen it as if it predated the fix.
+    await fs.chmod(dbPath, 0o644);
+    expect(mode(dbPath)).toBe(0o644);
+    // Reopen → repaired.
+    const db = new DatabaseService({ dbPath });
+    try {
+      expect(mode(dbPath)).toBe(0o600);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/services/database-service.ts
+++ b/src/services/database-service.ts
@@ -47,9 +47,9 @@ export class DatabaseService {
     const dbPath = config?.dbPath || path.join(os.homedir(), '.imap-mcp', 'data.db');
     const dbDir = path.dirname(dbPath);
 
-    // Create directory if it doesn't exist
+    // Create directory if it doesn't exist (owner-only).
     if (!fs.existsSync(dbDir)) {
-      fs.mkdirSync(dbDir, { recursive: true });
+      fs.mkdirSync(dbDir, { recursive: true, mode: 0o700 });
     }
 
     // node:sqlite — same SQLite file format as better-sqlite3, so the
@@ -59,6 +59,13 @@ export class DatabaseService {
     // .node binaries get rejected by library-validation.
     this.db = new DatabaseSync(dbPath);
 
+    // SECURITY (#235): the data directory and DB file hold plaintext metadata
+    // (cached subjects/senders) and the encryption key — all owner-only data at
+    // rest. The DB file is created at the process umask (often 0644), so tighten
+    // it (and the dir + any journal/WAL sidecars) here, with repair-on-startup
+    // for files that predate this fix. Mirrors the key-file handling below.
+    this.secureStorage(dbPath, dbDir);
+
     // Set up encryption key
     this.encryptionKey = this.getOrCreateEncryptionKey(dbDir);
 
@@ -66,6 +73,36 @@ export class DatabaseService {
     this.initializeSchema();
 
     console.error('[DatabaseService] Initialized at:', dbPath);
+  }
+
+  /**
+   * SECURITY (#235): enforce owner-only permissions on the data directory
+   * (0700) and the SQLite database file plus any journal/WAL sidecars (0600).
+   * Repairs looser permissions on existing files, logging the change — the same
+   * pattern getOrCreateEncryptionKey uses for the key file.
+   */
+  private secureStorage(dbPath: string, dbDir: string): void {
+    this.enforceMode(dbDir, 0o700, 'data directory');
+    this.enforceMode(dbPath, 0o600, 'database file');
+    for (const suffix of ['-journal', '-wal', '-shm']) {
+      this.enforceMode(dbPath + suffix, 0o600, `database sidecar (${suffix})`);
+    }
+  }
+
+  /** chmod `target` to `expected` if it exists and differs. Best-effort; logs. */
+  private enforceMode(target: string, expected: number, label: string): void {
+    try {
+      if (!fs.existsSync(target)) return;
+      const mode = fs.statSync(target).mode & 0o777;
+      if (mode !== expected) {
+        fs.chmodSync(target, expected);
+        console.error(
+          `[SECURITY] Tightened ${label} permissions ${mode.toString(8)} -> ${expected.toString(8)}: ${target}`
+        );
+      }
+    } catch (err) {
+      console.error(`[SECURITY WARNING] Could not set ${label} permissions on ${target}:`, err);
+    }
   }
 
   /**


### PR DESCRIPTION
DatabaseService now enforces owner-only data-at-rest: data dir → 0700, `data.db` + journal/WAL sidecars → 0600, with **repair-on-startup** for files created before this fix (mirrors the existing `.encryption-key` 0600 handling). Best-effort + logged; no-op on Windows. The cache holds plaintext subjects/senders, so this closes the world-readable exposure. 2 POSIX-gated tests (fresh create 0600/0700; 0644 repaired to 0600). Closes #235.