### PR TITLE
release: v2.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.25.1] - 2026-06-22
+
+### Security
+- **Owner-only data-at-rest permissions** (#235) — the SQLite database was created at the process umask (typically `0644`, world-readable) while it caches plaintext subjects/senders; only the `.encryption-key` was `0600`. `DatabaseService` now enforces `~/.imap-mcp` → `0700` and `data.db` (+ any journal/WAL sidecars) → `0600`, with **repair-on-startup** for files created before this fix. Best-effort and logged; no-op on Windows (which doesn't model these modes).
+
 ## [2.25.0] - 2026-06-22
 
 Full-text search over the local message cache. Test suite 235 → 244.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Security patch: owner-only data-at-rest permissions (data dir 0700, data.db + sidecars 0600, repair-on-startup). Closes #235.