### PR TITLE
fix: UserCheck bulk scans dedupe by address + consult cache (#238)

### DIFF
--- a/src/services/usercheck-service.test.ts
+++ b/src/services/usercheck-service.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for normalizeAddress + the cache-aware / deduping checkEmailsBatch
+// (one UserCheck call per unique sending address). The HTTP/cache layer is
+// stubbed via a subclass so no network or DB is touched.
+
+import { describe, expect, it } from 'vitest';
+import { UserCheckService, normalizeAddress } from './usercheck-service.js';
+
+describe('normalizeAddress', () => {
+  it('extracts the address from a display-name header and lowercases it', () => {
+    expect(normalizeAddress('Alice Example <A@X.com>')).toBe('a@x.com');
+  });
+  it('passes through a bare address (lowercased, trimmed)', () => {
+    expect(normalizeAddress('  B@Y.COM ')).toBe('b@y.com');
+  });
+  it('returns empty string for empty input', () => {
+    expect(normalizeAddress('')).toBe('');
+  });
+});
+
+// Stub the API + cache layers; count actual "API" calls.
+class FakeUserCheck extends UserCheckService {
+  apiCalls: string[] = [];
+  store = new Map<string, any>();
+  constructor() { super({} as any); }
+  async checkEmail(_userId: string, email: string): Promise<any> {
+    this.apiCalls.push(email);
+    return { email, normalized_email: email, domain: email.split('@')[1] ?? '', isSpam: email.includes('spam'), spamScore: email.includes('spam') ? 1 : 0 };
+  }
+  async getCachedResult(email: string): Promise<any> { return this.store.get(email) ?? null; }
+  async cacheResult(email: string, result: any): Promise<void> { this.store.set(email, result); }
+}
+
+describe('UserCheckService.checkEmailsBatch — one call per unique sender', () => {
+  it('normalizes and dedupes so each address is checked once', async () => {
+    const svc = new FakeUserCheck();
+    const out = await svc.checkEmailsBatch('u', ['Alice <a@x.com>', 'a@x.com', 'A@X.COM', 'bob@y.com']);
+    expect(svc.apiCalls.sort()).toEqual(['a@x.com', 'bob@y.com']); // 2 calls, not 4
+    expect(out.map((r) => r.email).sort()).toEqual(['a@x.com', 'bob@y.com']);
+  });
+
+  it('consults the cache: cached senders cost no API call', async () => {
+    const svc = new FakeUserCheck();
+    svc.store.set('a@x.com', { email: 'a@x.com', isSpam: true, spamScore: 1 });
+    const out = await svc.checkEmailsBatch('u', ['a@x.com', 'bob@y.com']);
+    expect(svc.apiCalls).toEqual(['bob@y.com']); // a@x.com served from cache
+    expect(out.find((r) => r.email === 'a@x.com')?.cached).toBe(true);
+    expect(out.find((r) => r.email === 'bob@y.com')?.cached).toBe(false);
+  });
+
+  it('write-through caches freshly checked senders', async () => {
+    const svc = new FakeUserCheck();
+    await svc.checkEmailsBatch('u', ['c@z.com']);
+    expect(svc.store.has('c@z.com')).toBe(true);
+    // Second run hits the cache — no new API call.
+    await svc.checkEmailsBatch('u', ['c@z.com']);
+    expect(svc.apiCalls).toEqual(['c@z.com']); // still just the one
+  });
+
+  it('useCache:false bypasses the cache', async () => {
+    const svc = new FakeUserCheck();
+    svc.store.set('a@x.com', { email: 'a@x.com', isSpam: false, spamScore: 0 });
+    await svc.checkEmailsBatch('u', ['a@x.com'], {}, { useCache: false });
+    expect(svc.apiCalls).toEqual(['a@x.com']); // ignored the cache
+  });
+
+  it('returns empty for empty / all-blank input', async () => {
+    const svc = new FakeUserCheck();
+    expect(await svc.checkEmailsBatch('u', [])).toEqual([]);
+    expect(await svc.checkEmailsBatch('u', ['', '   '])).toEqual([]);
+    expect(svc.apiCalls).toEqual([]);
+  });
+});

--- a/src/services/usercheck-service.ts
+++ b/src/services/usercheck-service.ts
@@ -12,6 +12,17 @@
 
 import { DatabaseService } from './database-service.js';
 
+/**
+ * Normalize an address for UserCheck lookups + cache keys: extract the address
+ * from a "Display Name <addr>" header, strip surrounding whitespace, lowercase.
+ * Ensures one sender is checked/cached once regardless of header formatting.
+ */
+export function normalizeAddress(raw: string): string {
+  if (!raw) return '';
+  const m = raw.match(/<([^>]+)>/);
+  return (m ? m[1] : raw).trim().toLowerCase();
+}
+
 export interface UserCheckResult {
   email: string;
   normalized_email: string;
@@ -31,6 +42,7 @@ export interface UserCheckResult {
   isSpam: boolean;
   spamReason?: string;
   spamScore: number; // 0-1 (0 = not spam, 1 = definitely spam)
+  cached?: boolean;  // true when this result came from spam_cache, not the API
 }
 
 export interface UserCheckDomainResult {
@@ -221,26 +233,49 @@ export class UserCheckService {
   }
 
   /**
-   * Check multiple email addresses (sequential to avoid rate limits)
-   * Note: UserCheck doesn't have a batch endpoint, so we check one at a time
+   * Check multiple email addresses against UserCheck (sequential — there is no
+   * batch endpoint). UserCheck is billed/rate-limited per address, so this:
+   *   1. NORMALIZES each address ("Alice <a@X.com>" → "a@x.com") and DEDUPES,
+   *      so a sender appearing on many messages is checked at most once.
+   *   2. Consults the local spam_cache first (unless useCache:false), so a
+   *      sender already checked (this run, another folder, or within the TTL of
+   *      a prior run) costs zero API calls. Cache writes happen here too, so all
+   *      bulk callers share one cache-aware path.
+   * Results are keyed by the normalized address (the `email` field), so callers
+   * can map message → result via normalizeAddress(message.from).
    */
-  async checkEmailsBatch(userId: string, emails: string[], criteria: SpamCheckCriteria = {}): Promise<UserCheckResult[]> {
-    if (emails.length === 0) {
-      return [];
-    }
+  async checkEmailsBatch(
+    userId: string,
+    emails: string[],
+    criteria: SpamCheckCriteria = {},
+    options: { useCache?: boolean } = {},
+  ): Promise<UserCheckResult[]> {
+    const useCache = options.useCache !== false;
+    const unique = [...new Set(emails.map(normalizeAddress).filter(Boolean))];
+    if (unique.length === 0) return [];
 
     const results: UserCheckResult[] = [];
 
-    for (const email of emails) {
+    for (const addr of unique) {
       try {
-        const result = await this.checkEmail(userId, email, criteria);
-        results.push(result);
+        if (useCache) {
+          const cached = await this.getCachedResult(addr);
+          if (cached) {
+            results.push({ ...cached, email: addr, cached: true });
+            continue;
+          }
+        }
 
-        // Small delay to avoid rate limits (adjust as needed)
+        const result = await this.checkEmail(userId, addr, criteria);
+        // Write-through so the next folder / next run hits the cache.
+        await this.cacheResult(addr, result);
+        results.push({ ...result, email: addr, cached: false });
+
+        // Small delay to avoid rate limits — only paid for actual API calls.
         await new Promise(resolve => setTimeout(resolve, 100));
       } catch (error) {
-        // Continue with other emails even if one fails
-        console.error(`Failed to check ${email}:`, error);
+        // Continue with other addresses even if one fails.
+        console.error(`Failed to check ${addr}:`, error);
       }
     }
 

--- a/src/tools/usercheck-tools.ts
+++ b/src/tools/usercheck-tools.ts
@@ -16,7 +16,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { withErrorHandling } from '../utils/error-handler.js';
 import { resolveUserOrThrow } from '../utils/user-resolver.js';
-import { UserCheckService, SpamCheckCriteria } from '../services/usercheck-service.js';
+import { UserCheckService, SpamCheckCriteria, normalizeAddress } from '../services/usercheck-service.js';
 import { DatabaseService } from '../services/database-service.js';
 import { ImapService } from '../services/imap-service.js';
 
@@ -222,33 +222,10 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
       allowPublicDomains
     };
 
-    const results = [];
-    const emailsToCheck = [];
-
-    // Check cache first if enabled
-    if (useCache) {
-      for (const email of emails) {
-        const cached = await userCheck.getCachedResult(email);
-        if (cached) {
-          results.push({ ...cached, cached: true });
-        } else {
-          emailsToCheck.push(email);
-        }
-      }
-    } else {
-      emailsToCheck.push(...emails);
-    }
-
-    // Check remaining emails with UserCheck API
-    if (emailsToCheck.length > 0) {
-      const apiResults = await userCheck.checkEmailsBatch(userId, emailsToCheck, criteria);
-
-      // Cache all results
-      for (const result of apiResults) {
-        await userCheck.cacheResult(result.email, result);
-        results.push({ ...result, cached: false });
-      }
-    }
+    // checkEmailsBatch normalizes + dedupes addresses and consults the cache
+    // per address (write-through on miss), so each unique sender costs at most
+    // one UserCheck call. The per-result `cached` flag reflects cache vs API.
+    const results = await userCheck.checkEmailsBatch(userId, emails, criteria, { useCache });
 
     // Separate spam from legitimate
     const spam = results.filter(r => r.isSpam);
@@ -300,27 +277,19 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
     const allEmails = await imapService.searchEmails(accountId, folder, {});
     const emails = allEmails.slice(0, limit);
 
-    // Extract unique sender emails
-    const senderEmails = [...new Set(emails.map(e => e.from))];
+    // Unique, normalized senders (one check per address regardless of how many
+    // messages they sent or how the From header is formatted), capped at 1000.
+    const senderEmails = [...new Set(emails.map(e => normalizeAddress(e.from)))].slice(0, 1000);
 
-    // Batch check sender emails
-    const spamChecks = await userCheck.checkEmailsBatch(userId, senderEmails.slice(0, 1000), criteria);
+    // Cache-aware batch: cached senders cost no API call (write-through on miss).
+    const spamChecks = await userCheck.checkEmailsBatch(userId, senderEmails, criteria, { useCache });
 
-    // Create map of email -> spam status
+    // Map normalized-address -> result; look up each message by its normalized sender.
     const spamMap = new Map(spamChecks.map(r => [r.email, r]));
-
-    // Filter emails from spam senders
     const spamMessages = emails.filter(e => {
-      const check = spamMap.get(e.from);
+      const check = spamMap.get(normalizeAddress(e.from));
       return check && check.isSpam;
     });
-
-    // Cache results
-    for (const result of spamChecks) {
-      if (useCache) {
-        await userCheck.cacheResult(result.email, result);
-      }
-    }
 
     return {
       content: [{
@@ -339,7 +308,7 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
             from: e.from,
             subject: e.subject,
             date: e.date,
-            spamInfo: spamMap.get(e.from)
+            spamInfo: spamMap.get(normalizeAddress(e.from))
           }))
         }, null, 2)
       }]
@@ -356,9 +325,10 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
       checkBlocklisted: z.boolean().optional().default(true).describe('Flag blocklisted email addresses'),
       checkRoleAccount: z.boolean().optional().default(true).describe('Flag role-based email accounts'),
       checkMx: z.boolean().optional().default(true).describe('Check MX records'),
-      allowPublicDomains: z.boolean().optional().default(true).describe('Allow public email domains')
+      allowPublicDomains: z.boolean().optional().default(true).describe('Allow public email domains'),
+      useCache: z.boolean().optional().default(true).describe('Use cached results if available (a sender is checked once across folders/runs within the cache TTL)')
     }
-  }, withErrorHandling(async ({ userId: userIdRaw, accountId, maxEmailsPerFolder, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains }) => {
+  }, withErrorHandling(async ({ userId: userIdRaw, accountId, maxEmailsPerFolder, checkDisposable, checkBlocklisted, checkRoleAccount, checkMx, allowPublicDomains, useCache }) => {
     const userId = resolveUserOrThrow(db, userIdRaw);
     const criteria: SpamCheckCriteria = {
       checkDisposable,
@@ -383,18 +353,16 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
 
         if (emails.length === 0) continue;
 
-        // Extract unique sender emails
-        const senderEmails = [...new Set(emails.map(e => e.from))];
+        // Unique, normalized senders for this folder (capped at 1000). The
+        // cache makes a sender seen in an earlier folder/run cost no API call,
+        // so cross-folder duplicates are checked once per TTL.
+        const senderEmails = [...new Set(emails.map(e => normalizeAddress(e.from)))].slice(0, 1000);
 
-        // Batch check sender emails
-        const spamChecks = await userCheck.checkEmailsBatch(userId, senderEmails.slice(0, 1000), criteria);
+        const spamChecks = await userCheck.checkEmailsBatch(userId, senderEmails, criteria, { useCache });
 
-        // Create map of email -> spam status
         const spamMap = new Map(spamChecks.map(r => [r.email, r]));
-
-        // Filter emails from spam senders
         const spamMessages = emails.filter(e => {
-          const check = spamMap.get(e.from);
+          const check = spamMap.get(normalizeAddress(e.from));
           return check && check.isSpam;
         });
 
@@ -414,11 +382,7 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
             reason: s.spamReason
           }))
         });
-
-        // Cache results
-        for (const result of spamChecks) {
-          await userCheck.cacheResult(result.email, result);
-        }
+        // (Caching is handled write-through inside checkEmailsBatch.)
       } catch (error) {
         folderResults.push({
           folder: folder.name,


### PR DESCRIPTION
Each unique sender is now checked at most once per UserCheck run; cached senders (same run / other folder / within TTL) cost zero API calls. Centralizes normalize+dedupe+cache-read (write-through) in `checkEmailsBatch`; `imap_check_folder_spam` / `imap_scan_account_spam` key by normalized address (the latter gains `useCache` + cross-folder dedup); `imap_check_emails_spam_bulk` simplified to the cache-aware batch. 8 tests. Closes #238.