### PR TITLE
feat: bulk job persistence — schema + service + job tools (#117 Phase 1)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,13 +4,13 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**113 MCP tools** total.
+**116 MCP tools** total.
 
 ## Categories
 
 - [Users (MSP multi-tenant)](#users-msp-multitenant) — 3
 - [Account management](#account-management) — 15
-- [Bulk operations](#bulk-operations) — 11
+- [Bulk operations](#bulk-operations) — 14
 - [Size, export & quota](#size-export-quota) — 8
 - [Attachment staging](#attachment-staging) — 6
 - [Email operations](#email-operations) — 13
@@ -62,6 +62,9 @@
 | `imap_bulk_delete_emails_chunked` | Bulk delete emails with chunking for large operations (1000+ messages). |
 | `imap_bulk_get_emails` | Bulk fetch multiple emails at once. |
 | `imap_bulk_get_emails_chunked` | Bulk fetch emails with chunking for large operations (1000+ messages). |
+| `imap_bulk_job_cancel` | Request cancellation of a running/queued bulk job. |
+| `imap_bulk_job_status` | Get one bulk job's detail: status, done/total progress, error count, ETA, and last error. |
+| `imap_bulk_jobs` | List persistent bulk-operation jobs (long-running scans) with status and progress. |
 | `imap_bulk_mark_emails` | Bulk mark multiple emails with standard IMAP flags. |
 | `imap_bulk_mark_emails_chunked` | Bulk mark emails with chunking for large operations (1000+ messages). |
 | `imap_bulk_move_emails` | Bulk move multiple emails to another folder (copy + delete) |
@@ -99,7 +102,7 @@
 | `imap_copy_email` | Copy an email to another folder |
 | `imap_delete_email` | Delete an email (moves to trash or expunges) |
 | `imap_forward_email` | Forward an existing email |
-| `imap_get_email` | Get the full content of an email or just headers |
+| `imap_get_email` | Get the full content of an email (or just headers). |
 | `imap_get_email_priority` | Get the resolved priority of a message: our $Priority-* keyword if set (the explicit user setting), otherwise the compose-time X-Priority / Importance / X-MSMail-Priority header, otherwise normal. |
 | `imap_get_latest_emails` | Get the latest emails from a folder. |
 | `imap_mark_as_read` | Mark an email as read |

--- a/src/database/migrations-manifest.json
+++ b/src/database/migrations-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.12.0",
+  "schemaVersion": "1.13.0",
   "description": "Release-indexed manifest of schema migrations. Each entry is applied in order via the `schema_version` ledger. A migration is complete when its `to` version is present in the ledger.",
   "migrations": [
     {
@@ -79,6 +79,13 @@
       "file": "schema_update_1.11.0_TO_1.12.0.sql",
       "rollbackFile": "schema_update_1.11.0_TO_1.12.0.down.sql",
       "description": "Add messages_cache_fts FTS5 full-text index over subject + sender (Track B, Issue #119)"
+    },
+    {
+      "from": "1.12.0",
+      "to": "1.13.0",
+      "file": "schema_update_1.12.0_TO_1.13.0.sql",
+      "rollbackFile": "schema_update_1.12.0_TO_1.13.0.down.sql",
+      "description": "Add bulk_operations + bulk_operation_items for job persistence (Track A, Issue #117)"
     }
   ]
 }

--- a/src/database/schema_update_1.12.0_TO_1.13.0.down.sql
+++ b/src/database/schema_update_1.12.0_TO_1.13.0.down.sql
@@ -1,0 +1,5 @@
+-- Rollback for schema 1.12.0 → 1.13.0 (#117: bulk job persistence)
+DROP INDEX IF EXISTS idx_bulk_operation_items_job;
+DROP TABLE IF EXISTS bulk_operation_items;
+DROP INDEX IF EXISTS idx_bulk_operations_user_status;
+DROP TABLE IF EXISTS bulk_operations;

--- a/src/database/schema_update_1.12.0_TO_1.13.0.sql
+++ b/src/database/schema_update_1.12.0_TO_1.13.0.sql
@@ -1,0 +1,50 @@
+-- Schema migration 1.12.0 → 1.13.0
+-- Track A (#117): persistent job state for long-running bulk operations.
+--
+-- Adds two tables so a bulk scan can be polled, cancelled, and resumed:
+--   bulk_operations       one row per job (status, progress, params, summary)
+--   bulk_operation_items  one row per processed item (resume cursor + dedup)
+--
+-- Stores only JOB STATE, never message content (that's #119, Track B). Items
+-- are keyed by a stable item_key (e.g. a normalized sender address) so a
+-- resumed job skips everything already processed.
+--
+-- Author: Colin Bitterfield
+-- Email: colin.bitterfield@templeofepiphany.com
+-- Date: 2026-06-23
+
+CREATE TABLE IF NOT EXISTS bulk_operations (
+  job_id              TEXT PRIMARY KEY,
+  user_id             TEXT NOT NULL,
+  account_id          TEXT NOT NULL,
+  tool_name           TEXT NOT NULL,
+  params_json         TEXT NOT NULL,
+  status              TEXT NOT NULL CHECK (status IN
+                        ('queued','running','paused','done','failed','cancelled')),
+  total_items         INTEGER,
+  done_items          INTEGER NOT NULL DEFAULT 0,
+  error_items         INTEGER NOT NULL DEFAULT 0,
+  created_at          INTEGER NOT NULL,
+  started_at          INTEGER,
+  finished_at         INTEGER,
+  last_error          TEXT,
+  result_summary_json TEXT,
+  FOREIGN KEY (account_id) REFERENCES accounts(account_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_bulk_operations_user_status
+  ON bulk_operations(user_id, status, created_at);
+
+CREATE TABLE IF NOT EXISTS bulk_operation_items (
+  job_id          TEXT NOT NULL,
+  item_key        TEXT NOT NULL,    -- normalized sender, UID, domain, etc.
+  processed_at    INTEGER,
+  outcome         TEXT CHECK (outcome IN ('ok','skip','error')),
+  result_json     TEXT,
+  error_text      TEXT,
+  PRIMARY KEY (job_id, item_key),
+  FOREIGN KEY (job_id) REFERENCES bulk_operations(job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_bulk_operation_items_job
+  ON bulk_operation_items(job_id, processed_at);

--- a/src/services/bulk-job-service.test.ts
+++ b/src/services/bulk-job-service.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// End-to-end tests for BulkJobService (#117) against a real node:sqlite temp DB
+// — exercises the 1.13.0 migration, create/record/run, resume (skip processed),
+// cooperative cancellation, and error counting.
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseService } from './database-service.js';
+import { BulkJobService } from './bulk-job-service.js';
+
+let tmpDir: string;
+let db: DatabaseService;
+let jobs: BulkJobService;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imap-jobs-'));
+  db = new DatabaseService({ dbPath: path.join(tmpDir, 'data.db') });
+  db.getDb().exec('PRAGMA foreign_keys = OFF'); // skip the accounts FK fixture
+  jobs = new BulkJobService(db);
+});
+afterEach(async () => {
+  try { db.close(); } catch { /* ignore */ }
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function newJob() {
+  return jobs.createJob({ userId: 'u', accountId: 'acc', toolName: 'imap_test', params: { folder: 'INBOX' } });
+}
+
+describe('BulkJobService (#117)', () => {
+  it('creates a queued job', () => {
+    const id = newJob();
+    const job = jobs.getJob(id)!;
+    expect(job.status).toBe('queued');
+    expect(job.toolName).toBe('imap_test');
+    expect((job.params as any).folder).toBe('INBOX');
+  });
+
+  it('runs a job to completion, recording every item', async () => {
+    const id = newJob();
+    const seen: string[] = [];
+    const job = await jobs.runJob(id, ['a', 'b', 'c'], (x) => x, async (x) => { seen.push(x); return { outcome: 'ok', result: x.toUpperCase() }; });
+    expect(seen).toEqual(['a', 'b', 'c']);
+    expect(job.status).toBe('done');
+    expect(job.totalItems).toBe(3);
+    expect(job.doneItems).toBe(3);
+    expect(jobs.items(id).find((i) => i.itemKey === 'b')?.result).toBe('B');
+  });
+
+  it('resumes: skips already-processed items', async () => {
+    const id = newJob();
+    // First pass processes a, b then "dies".
+    await jobs.runJob(id, ['a', 'b'], (x) => x, async () => ({ outcome: 'ok' }));
+    // Resume over the full set — only c and d should be processed.
+    const seen: string[] = [];
+    const job = await jobs.runJob(id, ['a', 'b', 'c', 'd'], (x) => x, async (x) => { seen.push(x); return { outcome: 'ok' }; });
+    expect(seen).toEqual(['c', 'd']);
+    expect(job.doneItems).toBe(4);
+    expect(job.status).toBe('done');
+  });
+
+  it('stops at the next checkpoint when cancelled mid-run', async () => {
+    const id = newJob();
+    const seen: string[] = [];
+    const job = await jobs.runJob(id, ['a', 'b', 'c', 'd'], (x) => x, async (x) => {
+      seen.push(x);
+      if (x === 'b') jobs.cancel(id); // cancel after processing b
+      return { outcome: 'ok' };
+    });
+    expect(seen).toEqual(['a', 'b']);   // c, d never processed
+    expect(job.status).toBe('cancelled');
+    expect(job.doneItems).toBe(2);
+  });
+
+  it('counts errors and continues', async () => {
+    const id = newJob();
+    const job = await jobs.runJob(id, ['ok1', 'boom', 'ok2'], (x) => x, async (x) => {
+      if (x === 'boom') throw new Error('kaboom');
+      return { outcome: 'ok' };
+    });
+    expect(job.status).toBe('done');
+    expect(job.doneItems).toBe(3);
+    expect(job.errorItems).toBe(1);
+    expect(jobs.items(id).find((i) => i.itemKey === 'boom')?.error).toMatch(/kaboom/);
+  });
+
+  it('cancel() is a no-op on a finished job', async () => {
+    const id = newJob();
+    await jobs.runJob(id, ['a'], (x) => x, async () => ({ outcome: 'ok' }));
+    expect(jobs.cancel(id)).toBe(false);
+    expect(jobs.getJob(id)!.status).toBe('done');
+  });
+
+  it('lists and filters jobs', async () => {
+    const a = newJob();
+    const b = newJob();
+    await jobs.runJob(a, ['x'], (x) => x, async () => ({ outcome: 'ok' }));
+    expect(jobs.listJobs({ userId: 'u' }).length).toBe(2);
+    expect(jobs.listJobs({ status: 'done' }).map((j) => j.jobId)).toEqual([a]);
+    expect(jobs.listJobs({ status: 'queued' }).map((j) => j.jobId)).toEqual([b]);
+  });
+});

--- a/src/services/bulk-job-service.ts
+++ b/src/services/bulk-job-service.ts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// BulkJobService — persistent job state for long-running bulk operations (#117).
+//
+// Persists JOB STATE (not message content) in SQLite so a bulk scan can be
+// polled, cancelled, and resumed. Items are keyed by a stable item_key (e.g. a
+// normalized sender address); a resumed job skips every already-processed key.
+//
+// Execution model: in-process. A tool starts a job and calls runJob(); it may
+// await with a time budget (sync shim) or let it continue in the background.
+// Cancellation is cooperative — runJob re-reads the job status each item and
+// stops at the next checkpoint when it sees 'cancelled'.
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+// Part of: IMAP MCP Pro (Temple of Epiphany)
+
+import crypto from 'crypto';
+import { DatabaseService } from './database-service.js';
+
+export type JobStatus = 'queued' | 'running' | 'paused' | 'done' | 'failed' | 'cancelled';
+export type ItemOutcome = 'ok' | 'skip' | 'error';
+
+export interface BulkJob {
+  jobId: string;
+  userId: string;
+  accountId: string;
+  toolName: string;
+  params: unknown;
+  status: JobStatus;
+  totalItems: number | null;
+  doneItems: number;
+  errorItems: number;
+  createdAt: number;
+  startedAt: number | null;
+  finishedAt: number | null;
+  lastError: string | null;
+  resultSummary: unknown | null;
+}
+
+export interface ItemResult {
+  outcome: ItemOutcome;
+  result?: unknown;
+  error?: string;
+}
+
+const TERMINAL: ReadonlySet<JobStatus> = new Set(['done', 'failed', 'cancelled']);
+
+function rowToJob(r: any): BulkJob {
+  return {
+    jobId: r.job_id,
+    userId: r.user_id,
+    accountId: r.account_id,
+    toolName: r.tool_name,
+    params: r.params_json ? safeParse(r.params_json) : null,
+    status: r.status,
+    totalItems: r.total_items ?? null,
+    doneItems: r.done_items ?? 0,
+    errorItems: r.error_items ?? 0,
+    createdAt: r.created_at,
+    startedAt: r.started_at ?? null,
+    finishedAt: r.finished_at ?? null,
+    lastError: r.last_error ?? null,
+    resultSummary: r.result_summary_json ? safeParse(r.result_summary_json) : null,
+  };
+}
+
+function safeParse(s: string): unknown {
+  try { return JSON.parse(s); } catch { return null; }
+}
+
+export class BulkJobService {
+  constructor(private db: DatabaseService, private nowFn: () => number = () => Date.now()) {}
+
+  /** Create a queued job; returns its id. */
+  createJob(input: { userId: string; accountId: string; toolName: string; params: unknown; totalItems?: number }): string {
+    const jobId = crypto.randomUUID();
+    this.db.getDb().prepare(
+      `INSERT INTO bulk_operations
+        (job_id, user_id, account_id, tool_name, params_json, status, total_items, created_at)
+       VALUES ($id, $u, $a, $t, $p, 'queued', $total, $now)`
+    ).run({
+      $id: jobId, $u: input.userId, $a: input.accountId, $t: input.toolName,
+      $p: JSON.stringify(input.params ?? {}), $total: input.totalItems ?? null, $now: this.nowFn(),
+    });
+    return jobId;
+  }
+
+  getJob(jobId: string): BulkJob | null {
+    const r = this.db.getDb().prepare(`SELECT * FROM bulk_operations WHERE job_id = $id`).get({ $id: jobId }) as any;
+    return r ? rowToJob(r) : null;
+  }
+
+  listJobs(opts: { userId?: string; status?: JobStatus; limit?: number } = {}): BulkJob[] {
+    const params: Record<string, unknown> = { $limit: Math.min(opts.limit ?? 50, 500) };
+    const where: string[] = [];
+    if (opts.userId) { where.push('user_id = $u'); params.$u = opts.userId; }
+    if (opts.status) { where.push('status = $s'); params.$s = opts.status; }
+    const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+    const rows = this.db.getDb().prepare(
+      `SELECT * FROM bulk_operations ${clause} ORDER BY created_at DESC LIMIT $limit`
+    ).all(params as any) as any[];
+    return rows.map(rowToJob);
+  }
+
+  /** Flip a non-terminal job to 'cancelled'. Returns true if it changed. */
+  cancel(jobId: string): boolean {
+    const job = this.getJob(jobId);
+    if (!job || TERMINAL.has(job.status)) return false;
+    this.db.getDb().prepare(
+      `UPDATE bulk_operations SET status = 'cancelled', finished_at = $now WHERE job_id = $id`
+    ).run({ $id: jobId, $now: this.nowFn() });
+    return true;
+  }
+
+  /** Current status, or null if the job is gone. */
+  statusOf(jobId: string): JobStatus | null {
+    const r = this.db.getDb().prepare(`SELECT status FROM bulk_operations WHERE job_id = $id`).get({ $id: jobId }) as any;
+    return r ? (r.status as JobStatus) : null;
+  }
+
+  /** Keys already processed (for resume dedup). */
+  processedKeys(jobId: string): Set<string> {
+    const rows = this.db.getDb().prepare(
+      `SELECT item_key FROM bulk_operation_items WHERE job_id = $id AND processed_at IS NOT NULL`
+    ).all({ $id: jobId }) as Array<{ item_key: string }>;
+    return new Set(rows.map((r) => r.item_key));
+  }
+
+  /** Record one processed item + bump the job's done/error counters atomically. */
+  recordItem(jobId: string, itemKey: string, res: ItemResult): void {
+    const raw = this.db.getDb();
+    raw.exec('BEGIN');
+    try {
+      raw.prepare(
+        `INSERT OR REPLACE INTO bulk_operation_items
+          (job_id, item_key, processed_at, outcome, result_json, error_text)
+         VALUES ($j, $k, $now, $o, $r, $e)`
+      ).run({
+        $j: jobId, $k: itemKey, $now: this.nowFn(), $o: res.outcome,
+        $r: res.result === undefined ? null : JSON.stringify(res.result),
+        $e: res.error ?? null,
+      });
+      raw.prepare(
+        `UPDATE bulk_operations
+           SET done_items = done_items + 1,
+               error_items = error_items + $err
+         WHERE job_id = $j`
+      ).run({ $j: jobId, $err: res.outcome === 'error' ? 1 : 0 });
+      raw.exec('COMMIT');
+    } catch (e) {
+      try { raw.exec('ROLLBACK'); } catch { /* ignore */ }
+      throw e;
+    }
+  }
+
+  /**
+   * Run (or resume) a job: process each item not already done, checkpointing
+   * after each, and stop cooperatively if the job is cancelled. Sets the job
+   * 'running' on entry and to 'done'/'failed'/'cancelled' on exit. Safe to call
+   * again on a non-terminal job to resume from the last unprocessed item.
+   */
+  async runJob<T>(
+    jobId: string,
+    items: T[],
+    keyOf: (item: T) => string,
+    processOne: (item: T) => Promise<ItemResult>,
+    opts: { summarize?: (jobId: string) => unknown } = {},
+  ): Promise<BulkJob> {
+    const raw = this.db.getDb();
+    const already = this.processedKeys(jobId);
+    const pending = items.filter((it) => !already.has(keyOf(it)));
+
+    raw.prepare(
+      `UPDATE bulk_operations SET status = 'running', started_at = COALESCE(started_at, $now), total_items = $total WHERE job_id = $id`
+    ).run({ $id: jobId, $now: this.nowFn(), $total: items.length });
+
+    for (const item of pending) {
+      if (this.statusOf(jobId) === 'cancelled') break;
+      try {
+        const res = await processOne(item);
+        this.recordItem(jobId, keyOf(item), res);
+      } catch (e) {
+        this.recordItem(jobId, keyOf(item), { outcome: 'error', error: e instanceof Error ? e.message : String(e) });
+      }
+    }
+
+    // Finalize — don't override a cancellation that landed mid-loop.
+    const finalStatus: JobStatus = this.statusOf(jobId) === 'cancelled' ? 'cancelled' : 'done';
+    const summary = opts.summarize ? opts.summarize(jobId) : null;
+    raw.prepare(
+      `UPDATE bulk_operations
+         SET status = $s, finished_at = $now, result_summary_json = $sum
+       WHERE job_id = $id`
+    ).run({ $id: jobId, $s: finalStatus, $now: this.nowFn(), $sum: summary === null ? null : JSON.stringify(summary) });
+
+    return this.getJob(jobId)!;
+  }
+
+  /** Mark a job failed with an error message (for setup failures before/at run). */
+  fail(jobId: string, error: string): void {
+    this.db.getDb().prepare(
+      `UPDATE bulk_operations SET status = 'failed', finished_at = $now, last_error = $e WHERE job_id = $id`
+    ).run({ $id: jobId, $now: this.nowFn(), $e: error });
+  }
+
+  /** Read each recorded item (e.g. to assemble a final result from a resumed job). */
+  items(jobId: string): Array<{ itemKey: string; outcome: ItemOutcome | null; result: unknown; error: string | null }> {
+    const rows = this.db.getDb().prepare(
+      `SELECT item_key, outcome, result_json, error_text FROM bulk_operation_items WHERE job_id = $id`
+    ).all({ $id: jobId }) as any[];
+    return rows.map((r) => ({
+      itemKey: r.item_key,
+      outcome: r.outcome ?? null,
+      result: r.result_json ? safeParse(r.result_json) : null,
+      error: r.error_text ?? null,
+    }));
+  }
+}

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -137,6 +137,11 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   // ---- admin-tools (1) ----
   'imap_server_reload':                NEUTRAL_IDEMPOTENT,
 
+  // ---- bulk-job-tools (3) ----
+  'imap_bulk_jobs':                    READ_ONLY,
+  'imap_bulk_job_status':              READ_ONLY,
+  'imap_bulk_job_cancel':              WRITE_LOCAL,
+
   // ---- meta-tools (8) ----
   'imap_about':                        READ_ONLY,
   'imap_list_tools':                   READ_ONLY,

--- a/src/tools/bulk-job-tools.ts
+++ b/src/tools/bulk-job-tools.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// bulk-job-tools.ts — inspect/cancel persistent bulk jobs (#117).
+//   imap_bulk_jobs        list jobs (status, progress)
+//   imap_bulk_job_status  one job's detail (progress, ETA, last error)
+//   imap_bulk_job_cancel  request cancellation (stops at next checkpoint)
+//
+// Job creation + resume live with the bulk tools that own the work (Phase 2).
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { withErrorHandling } from '../utils/error-handler.js';
+import { BulkJobService, BulkJob } from '../services/bulk-job-service.js';
+import { DatabaseService } from '../services/database-service.js';
+import { resolveUserOrThrow } from '../utils/user-resolver.js';
+
+const StatusSchema = z.enum(['queued', 'running', 'paused', 'done', 'failed', 'cancelled']);
+
+/** Shape a job for tool output with derived progress + ETA. */
+function view(job: BulkJob, now: number) {
+  const pct = job.totalItems && job.totalItems > 0
+    ? Math.round((job.doneItems / job.totalItems) * 1000) / 10
+    : null;
+  const elapsedMs = job.startedAt ? (job.finishedAt ?? now) - job.startedAt : null;
+  let etaMs: number | null = null;
+  if (job.status === 'running' && elapsedMs && job.doneItems > 0 && job.totalItems) {
+    const perItem = elapsedMs / job.doneItems;
+    etaMs = Math.max(0, Math.round(perItem * (job.totalItems - job.doneItems)));
+  }
+  return {
+    jobId: job.jobId,
+    toolName: job.toolName,
+    accountId: job.accountId,
+    status: job.status,
+    progress: { done: job.doneItems, total: job.totalItems, errors: job.errorItems, percent: pct },
+    createdAt: new Date(job.createdAt).toISOString(),
+    startedAt: job.startedAt ? new Date(job.startedAt).toISOString() : null,
+    finishedAt: job.finishedAt ? new Date(job.finishedAt).toISOString() : null,
+    elapsedMs,
+    etaMs,
+    lastError: job.lastError,
+  };
+}
+
+export function bulkJobTools(server: McpServer, jobs: BulkJobService, db: DatabaseService): void {
+  server.registerTool('imap_bulk_jobs', {
+    description:
+      'List persistent bulk-operation jobs (long-running scans) with status and progress. ' +
+      'Filter by status; scope to a user. Use imap_bulk_job_status for one job\'s detail.',
+    inputSchema: {
+      userId: z.string().optional().describe('Scope to this user (UUID or username); omit for all'),
+      status: StatusSchema.optional().describe('Filter by status'),
+      limit: z.number().int().positive().optional().describe('Max jobs (default 50, cap 500)'),
+    },
+  }, withErrorHandling(async ({ userId, status, limit }) => {
+    const uid = userId ? resolveUserOrThrow(db, userId) : undefined;
+    const now = Date.now();
+    const list = jobs.listJobs({ userId: uid, status, limit }).map((j) => view(j, now));
+    return { content: [{ type: 'text', text: JSON.stringify({ count: list.length, jobs: list }, null, 2) }] };
+  }));
+
+  server.registerTool('imap_bulk_job_status', {
+    description: 'Get one bulk job\'s detail: status, done/total progress, error count, ETA, and last error.',
+    inputSchema: { jobId: z.string().describe('Job ID returned by a *_start tool') },
+  }, withErrorHandling(async ({ jobId }) => {
+    const job = jobs.getJob(jobId);
+    if (!job) {
+      return { content: [{ type: 'text', text: JSON.stringify({ error: 'job_not_found', jobId }, null, 2) }], isError: true };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(view(job, Date.now()), null, 2) }] };
+  }));
+
+  server.registerTool('imap_bulk_job_cancel', {
+    description:
+      'Request cancellation of a running/queued bulk job. The worker stops at its next checkpoint ' +
+      '(no half-applied state); already-processed items are kept so the job can be resumed later.',
+    inputSchema: { jobId: z.string().describe('Job ID to cancel') },
+  }, withErrorHandling(async ({ jobId }) => {
+    const changed = jobs.cancel(jobId);
+    const job = jobs.getJob(jobId);
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          jobId,
+          cancelled: changed,
+          status: job?.status ?? 'unknown',
+          note: changed
+            ? 'Cancellation requested; the worker will stop at its next checkpoint.'
+            : (job ? `Job is already ${job.status}; nothing to cancel.` : 'Job not found.'),
+        }, null, 2),
+      }],
+    };
+  }));
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,6 +15,8 @@ import { emailTools } from './email-tools.js';
 import { folderTools } from './folder-tools.js';
 import { metaTools } from './meta-tools.js';
 import { adminTools } from './admin-tools.js';
+import { bulkJobTools } from './bulk-job-tools.js';
+import { BulkJobService } from '../services/bulk-job-service.js';
 import { userTools } from './user-tools.js';
 import { userCheckTools } from './usercheck-tools.js';
 import { registerScoringTools } from './scoring-tools.js';
@@ -116,6 +118,9 @@ export function registerTools(
 
   // Register admin/lifecycle tools (Issue #84 - runtime reset without restart)
   adminTools(server, imapService, smtpService);
+
+  // Register bulk-job management tools (Issue #117 - job persistence)
+  bulkJobTools(server, new BulkJobService(db), db);
 
   // Register meta/discovery tools (passes webUIManager so meta-tools can expose
   // the imap_open_web_ui MCP tool when the embedded Web UI is available).


### PR DESCRIPTION
Foundation for resumable/cancellable bulk ops (job state only; message content is #119). Migration 1.12.0→1.13.0 (`bulk_operations` + `bulk_operation_items`), `BulkJobService` (create/get/list/cancel + checkpointing + resume-dedup + cooperative-cancel `runJob`), and `imap_bulk_jobs` / `imap_bulk_job_status` / `imap_bulk_job_cancel`. 7 E2E tests on a real temp DB. Tools 113→116. Phase 2 wires the spam tools + 30s shim + resume. Refs #117.