### PR TITLE
feat: async/resumable spam scans on the job machine (#117 Phase 2)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,20 +4,20 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**116 MCP tools** total.
+**119 MCP tools** total.
 
 ## Categories
 
 - [Users (MSP multi-tenant)](#users-msp-multitenant) — 3
 - [Account management](#account-management) — 15
-- [Bulk operations](#bulk-operations) — 14
+- [Bulk operations](#bulk-operations) — 15
 - [Size, export & quota](#size-export-quota) — 8
 - [Attachment staging](#attachment-staging) — 6
 - [Email operations](#email-operations) — 13
 - [Folder & mailbox operations](#folder-mailbox-operations) — 11
 - [Subscriptions & unsubscribe](#subscriptions-unsubscribe) — 9
 - [Categorization & scoring](#categorization-scoring) — 6
-- [Spam & UserCheck](#spam-usercheck) — 7
+- [Spam & UserCheck](#spam-usercheck) — 9
 - [DNS firewall & domain checks](#dns-firewall-domain-checks) — 4
 - [Local cache](#local-cache) — 2
 - [Capabilities, diagnostics & metrics](#capabilities-diagnostics-metrics) — 11
@@ -63,6 +63,7 @@
 | `imap_bulk_get_emails` | Bulk fetch multiple emails at once. |
 | `imap_bulk_get_emails_chunked` | Bulk fetch emails with chunking for large operations (1000+ messages). |
 | `imap_bulk_job_cancel` | Request cancellation of a running/queued bulk job. |
+| `imap_bulk_job_resume` | Resume a paused, failed, or cancelled bulk job from where it stopped — only unprocessed items are run (already-checked senders are skipped). |
 | `imap_bulk_job_status` | Get one bulk job's detail: status, done/total progress, error count, ETA, and last error. |
 | `imap_bulk_jobs` | List persistent bulk-operation jobs (long-running scans) with status and progress. |
 | `imap_bulk_mark_emails` | Bulk mark multiple emails with standard IMAP flags. |
@@ -161,10 +162,12 @@
 | `imap_add_usercheck_key` | Add a UserCheck API key for a user (admin or own user only) |
 | `imap_check_email_spam` | Check a single email address against UserCheck for spam |
 | `imap_check_emails_spam_bulk` | Check multiple email addresses against UserCheck for spam (max 1000) |
+| `imap_check_emails_spam_bulk_start` | Start a resumable bulk spam check of a list of email addresses (UserCheck) as a tracked job. |
 | `imap_check_folder_spam` | Check all emails in a folder against UserCheck and return spam messages |
 | `imap_delete_usercheck_key` | Delete a UserCheck API key |
 | `imap_get_usercheck_key` | Get UserCheck API key information for a user |
 | `imap_scan_account_spam` | Scan entire IMAP account for spam using UserCheck, checking all folders |
+| `imap_scan_account_spam_start` | Start a resumable account-wide spam scan (UserCheck) as a tracked job. |
 
 ## DNS firewall & domain checks
 

--- a/scripts/gen-tool-catalog.mjs
+++ b/scripts/gen-tool-catalog.mjs
@@ -40,7 +40,7 @@ const CATEGORIES = [
   ['Folder & mailbox operations', /^imap_(list_folders|folder_status|get_unread_count|create_folder|delete_folder|rename_folder|get_mailbox_status|subscribe_mailbox|unsubscribe_mailbox|list_subscribed_mailboxes|append_message)$/],
   ['Subscriptions & unsubscribe', /^imap_(extract_unsubscribe_links|get_unsubscribe_links|get_unsubscribe_links_for|execute_unsubscribe|get_subscription_summary|list_unsubscribe_candidates|mark_subscription_unsubscribed|update_subscription_category|update_subscription_notes)$/],
   ['Categorization & scoring', /^imap_(add_keyword|remove_keyword|list_categories|apply_categories|analyze_folder_confidence|score_email_confidence)$/],
-  ['Spam & UserCheck', /^imap_(check_email_spam|check_emails_spam_bulk|check_folder_spam|scan_account_spam|add_usercheck_key|get_usercheck_key|delete_usercheck_key)$/],
+  ['Spam & UserCheck', /^imap_(check_email_spam|check_emails_spam_bulk|check_emails_spam_bulk_start|check_folder_spam|scan_account_spam|scan_account_spam_start|add_usercheck_key|get_usercheck_key|delete_usercheck_key)$/],
   ['DNS firewall & domain checks', /^imap_(check_domain|check_domain_dns_firewall|scan_message_domains|test_quad9_dns)$/],
   ['Local cache', /^imap_(search_cache|sync_folder_cache)$/],
   ['Capabilities, diagnostics & metrics', /^imap_(get_capabilities|test_smtp|test_sent_folder|list_unarchived_sends|get_metrics|get_operation_metrics|reset_metrics|get_smtp_metrics|reset_smtp_metrics|get_circuit_breaker|reset_circuit_breaker)$/],

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -141,6 +141,9 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_bulk_jobs':                    READ_ONLY,
   'imap_bulk_job_status':              READ_ONLY,
   'imap_bulk_job_cancel':              WRITE_LOCAL,
+  'imap_bulk_job_resume':              READ_REMOTE,
+  'imap_scan_account_spam_start':      READ_REMOTE,
+  'imap_check_emails_spam_bulk_start': READ_REMOTE,
 
   // ---- meta-tools (8) ----
   'imap_about':                        READ_ONLY,

--- a/src/tools/bulk-runners.test.ts
+++ b/src/tools/bulk-runners.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for the bulk-runner registry + the 30s sync-shim behavior (#117 Phase 2).
+// Real BulkJobService on a temp DB; UserCheck + IMAP are stubbed.
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseService } from '../services/database-service.js';
+import { BulkJobService } from '../services/bulk-job-service.js';
+import { BULK_RUNNERS, runJobWithBudget, RunnerDeps } from './bulk-runners.js';
+
+let tmpDir: string, db: DatabaseService, jobs: BulkJobService;
+
+const deps: RunnerDeps = {
+  imapService: {
+    listFolders: async () => [{ name: 'INBOX' }, { name: 'Sent' }],
+    searchEmails: async (_a: string, folder: string) =>
+      folder === 'INBOX'
+        ? [{ from: 'Spammer <a@spam.com>' }, { from: 'a@spam.com' }, { from: 'Bob <bob@x.com>' }]
+        : [{ from: 'bob@x.com' }],
+  } as any,
+  userCheck: {
+    getCachedResult: async () => null,
+    checkEmail: async (_u: string, email: string) => ({ email, isSpam: email.includes('spam'), spamScore: email.includes('spam') ? 1 : 0 }),
+    cacheResult: async () => {},
+  } as any,
+};
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imap-runner-'));
+  db = new DatabaseService({ dbPath: path.join(tmpDir, 'data.db') });
+  db.getDb().exec('PRAGMA foreign_keys = OFF');
+  jobs = new BulkJobService(db);
+});
+afterEach(async () => {
+  try { db.close(); } catch { /* ignore */ }
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function parse(res: any) { return JSON.parse(res.content[0].text); }
+
+describe('BULK_RUNNERS.deriveItems', () => {
+  it('scan_account_spam: unique normalized senders across folders', async () => {
+    const items = await BULK_RUNNERS.imap_scan_account_spam.deriveItems('u', { accountId: 'acc', maxEmailsPerFolder: 100 }, deps);
+    expect(items.sort()).toEqual(['a@spam.com', 'bob@x.com']); // deduped across INBOX+Sent, normalized
+  });
+
+  it('check_emails_spam_bulk: dedupes/normalizes the input list', async () => {
+    const items = await BULK_RUNNERS.imap_check_emails_spam_bulk.deriveItems('u', { emails: ['A <a@x.com>', 'a@x.com', 'b@y.com'] }, deps);
+    expect(items.sort()).toEqual(['a@x.com', 'b@y.com']);
+  });
+});
+
+describe('runJobWithBudget (sync shim)', () => {
+  it('returns the full summary when the job finishes within budget', async () => {
+    const params = { accountId: 'acc' };
+    const runner = BULK_RUNNERS.imap_scan_account_spam;
+    const items = await runner.deriveItems('u', params, deps);
+    const jobId = jobs.createJob({ userId: 'u', accountId: 'acc', toolName: 'imap_scan_account_spam', params, totalItems: items.length });
+    const out = parse(await runJobWithBudget(jobs, jobId, items, (k) => runner.processOne('u', k, params, deps), (jid) => runner.summarize(jid, params, jobs), 5000));
+    expect(out.mode).toBe('completed');
+    expect(out.status).toBe('done');
+    expect(out.summary.sendersChecked).toBe(2);
+    expect(out.summary.spamSenders).toBe(1); // a@spam.com
+  });
+
+  it('returns a running envelope when the budget elapses, then finishes in the background', async () => {
+    const params = { accountId: 'acc' };
+    const items = ['s1@x.com', 's2@x.com', 's3@x.com'];
+    const jobId = jobs.createJob({ userId: 'u', accountId: 'acc', toolName: 'imap_scan_account_spam', params, totalItems: items.length });
+    const slow = async (k: string) => { await new Promise((r) => setTimeout(r, 40)); return { outcome: 'ok' as const, result: { email: k, isSpam: false } }; };
+    const out = parse(await runJobWithBudget(jobs, jobId, items, slow, (jid) => BULK_RUNNERS.imap_scan_account_spam.summarize(jid, params, jobs), 5));
+    expect(out.mode).toBe('running');
+    expect(out.jobId).toBe(jobId);
+    // Background run continues; wait it out and confirm completion.
+    await new Promise((r) => setTimeout(r, 250));
+    expect(jobs.getJob(jobId)!.status).toBe('done');
+    expect(jobs.getJob(jobId)!.doneItems).toBe(3);
+  });
+});

--- a/src/tools/bulk-runners.ts
+++ b/src/tools/bulk-runners.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// bulk-runners.ts — wires specific bulk tools to the BulkJobService (#117).
+//
+// Each runner knows how to (a) derive its work items from the persisted job
+// params and (b) process one item. Both the start tools and imap_bulk_job_resume
+// use this registry, so resume is tool-agnostic: re-derive items from params,
+// then runJob() skips everything already processed.
+//
+// Execution: a job is started and run with a time budget (sync shim). If it
+// finishes within the budget the caller gets the full summary; otherwise it gets
+// a job_id envelope and the run continues in the background (this process stays
+// alive as the long-lived MCP server). Cancellation is cooperative via the job
+// status. Per-item dedup across folders/runs is further short-circuited by the
+// UserCheck spam_cache.
+
+import { BulkJobService, ItemResult, BulkJob } from '../services/bulk-job-service.js';
+import { ImapService } from '../services/imap-service.js';
+import { UserCheckService, SpamCheckCriteria, normalizeAddress } from '../services/usercheck-service.js';
+
+export interface RunnerDeps {
+  imapService: ImapService;
+  userCheck: UserCheckService;
+}
+
+export interface BulkRunner {
+  /** Re-derive the work items (item keys) for a job from its stored params. */
+  deriveItems(userId: string, params: any, deps: RunnerDeps): Promise<string[]>;
+  /** Process one item key; throw to record an error and continue. */
+  processOne(userId: string, itemKey: string, params: any, deps: RunnerDeps): Promise<ItemResult>;
+  /** Build the final result summary from the recorded items. */
+  summarize(jobId: string, params: any, jobs: BulkJobService): unknown;
+}
+
+function criteriaOf(params: any): SpamCheckCriteria {
+  return {
+    checkDisposable: params?.checkDisposable ?? true,
+    checkBlocklisted: params?.checkBlocklisted ?? true,
+    checkRoleAccount: params?.checkRoleAccount ?? true,
+    checkMx: params?.checkMx ?? true,
+    allowPublicDomains: params?.allowPublicDomains ?? true,
+  };
+}
+
+/** Check one sender address, cache-first (write-through). Result carries spam verdict. */
+async function checkOneSender(userId: string, addr: string, params: any, deps: RunnerDeps): Promise<ItemResult> {
+  const useCache = params?.useCache !== false;
+  if (useCache) {
+    const cached = await deps.userCheck.getCachedResult(addr);
+    if (cached) return { outcome: 'ok', result: { ...cached, email: addr, cached: true } };
+  }
+  const result = await deps.userCheck.checkEmail(userId, addr, criteriaOf(params));
+  await deps.userCheck.cacheResult(addr, result);
+  return { outcome: 'ok', result: { ...result, email: addr, cached: false } };
+}
+
+/** Summarize spam results recorded on a job: counts + the flagged senders. */
+function summarizeSpam(jobId: string, jobs: BulkJobService) {
+  const items = jobs.items(jobId);
+  const spamSenders = items
+    .filter((i) => (i.result as any)?.isSpam)
+    .map((i) => ({ email: i.itemKey, spamScore: (i.result as any)?.spamScore, reason: (i.result as any)?.spamReason }));
+  return {
+    sendersChecked: items.length,
+    spamSenders: spamSenders.length,
+    errors: items.filter((i) => i.outcome === 'error').length,
+    topSpamSenders: spamSenders.sort((a, b) => (b.spamScore ?? 0) - (a.spamScore ?? 0)).slice(0, 20),
+  };
+}
+
+export const BULK_RUNNERS: Record<string, BulkRunner> = {
+  imap_scan_account_spam: {
+    async deriveItems(_userId, params, deps) {
+      const folders = await deps.imapService.listFolders(params.accountId);
+      const perFolder = params?.maxEmailsPerFolder ?? 100;
+      const senders = new Set<string>();
+      for (const folder of folders) {
+        try {
+          const all = await deps.imapService.searchEmails(params.accountId, folder.name, {});
+          for (const e of all.slice(0, perFolder)) {
+            const addr = normalizeAddress(e.from);
+            if (addr) senders.add(addr);
+          }
+        } catch { /* skip unreadable folder */ }
+      }
+      return [...senders];
+    },
+    processOne(userId, itemKey, params, deps) { return checkOneSender(userId, itemKey, params, deps); },
+    summarize(jobId, _params, jobs) { return summarizeSpam(jobId, jobs); },
+  },
+
+  imap_check_emails_spam_bulk: {
+    async deriveItems(_userId, params) {
+      const senders = new Set<string>();
+      for (const raw of (params?.emails ?? [])) {
+        const addr = normalizeAddress(raw);
+        if (addr) senders.add(addr);
+      }
+      return [...senders];
+    },
+    processOne(userId, itemKey, params, deps) { return checkOneSender(userId, itemKey, params, deps); },
+    summarize(jobId, _params, jobs) { return summarizeSpam(jobId, jobs); },
+  },
+};
+
+/** Outcome envelope returned by the start/resume tools. */
+function envelope(jobs: BulkJobService, jobId: string, completed: boolean) {
+  const job = jobs.getJob(jobId)!;
+  const base = {
+    jobId,
+    toolName: job.toolName,
+    status: job.status,
+    progress: { done: job.doneItems, total: job.totalItems, errors: job.errorItems },
+  };
+  return completed
+    ? { ...base, mode: 'completed', summary: job.resultSummary }
+    : {
+        ...base,
+        mode: 'running',
+        hint: 'Still running. Poll imap_bulk_job_status, or imap_bulk_job_resume / imap_bulk_job_cancel.',
+      };
+}
+
+/**
+ * Run a job with a sync time budget. Returns when the job finishes OR the budget
+ * elapses (whichever first); on timeout the run continues in the background.
+ */
+export async function runJobWithBudget(
+  jobs: BulkJobService,
+  jobId: string,
+  items: string[],
+  processOne: (key: string) => Promise<ItemResult>,
+  summarize: (jobId: string) => unknown,
+  budgetMs: number,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+  let finished = false;
+  const run: Promise<BulkJob | null> = jobs
+    .runJob(jobId, items, (k) => k, processOne, { summarize })
+    .then((j) => { finished = true; return j; })
+    .catch((err) => { finished = true; jobs.fail(jobId, err instanceof Error ? err.message : String(err)); return null; });
+
+  await Promise.race([run, new Promise((res) => setTimeout(res, budgetMs))]);
+  // If the budget elapsed first, leave `run` executing in the background.
+  return { content: [{ type: 'text', text: JSON.stringify(envelope(jobs, jobId, finished), null, 2) }] };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -69,6 +69,10 @@ export function registerTools(
   // so re-entrant calls (e.g. from buildToolsManifest) start fresh.
   const restoreRegisterTool = withAnnotations(server);
 
+  // One shared BulkJobService instance (Issue #117) backs both the job
+  // management tools and the async *_start / resume tools in userCheckTools.
+  const bulkJobs = new BulkJobService(db);
+
   // Register user & database management tools (v2.6.0 - SQLite3 integration)
   userTools(server, db);
 
@@ -92,7 +96,7 @@ export function registerTools(
   dnsFirewallTools(server, imapService, db);
 
   // Register UserCheck SPAM detection tools (Issues #3, #17, #18)
-  userCheckTools(server, db, imapService);
+  userCheckTools(server, db, imapService, bulkJobs);
 
   // Register confidence scoring tools (Issue #42)
   registerScoringTools(server, imapService);
@@ -119,8 +123,8 @@ export function registerTools(
   // Register admin/lifecycle tools (Issue #84 - runtime reset without restart)
   adminTools(server, imapService, smtpService);
 
-  // Register bulk-job management tools (Issue #117 - job persistence)
-  bulkJobTools(server, new BulkJobService(db), db);
+  // Register bulk-job management tools (Issue #117 - job persistence).
+  bulkJobTools(server, bulkJobs, db);
 
   // Register meta/discovery tools (passes webUIManager so meta-tools can expose
   // the imap_open_web_ui MCP tool when the embedded Web UI is available).

--- a/src/tools/usercheck-tools.ts
+++ b/src/tools/usercheck-tools.ts
@@ -19,9 +19,13 @@ import { resolveUserOrThrow } from '../utils/user-resolver.js';
 import { UserCheckService, SpamCheckCriteria, normalizeAddress } from '../services/usercheck-service.js';
 import { DatabaseService } from '../services/database-service.js';
 import { ImapService } from '../services/imap-service.js';
+import { BulkJobService } from '../services/bulk-job-service.js';
+import { BULK_RUNNERS, runJobWithBudget, RunnerDeps } from './bulk-runners.js';
 
-export function userCheckTools(server: McpServer, db: DatabaseService, imapService: ImapService): void {
+export function userCheckTools(server: McpServer, db: DatabaseService, imapService: ImapService, jobs: BulkJobService): void {
   const userCheck = new UserCheckService(db);
+  const runnerDeps: RunnerDeps = { imapService, userCheck };
+  const DEFAULT_BUDGET_MS = 30000;
 
   // ===== UserCheck API Key Management Tools =====
 
@@ -406,5 +410,110 @@ export function userCheckTools(server: McpServer, db: DatabaseService, imapServi
         }, null, 2)
       }]
     };
+  }));
+
+  // ---------------------------------------------------------------------------
+  // Async / resumable variants (Issue #117). Each starts a persistent job and
+  // runs it with a 30s sync budget: if the scan finishes in time you get the
+  // full summary; otherwise a job_id to poll (imap_bulk_job_status), cancel
+  // (imap_bulk_job_cancel), or resume (imap_bulk_job_resume). UserCheck is
+  // called once per unique sender; spam_cache short-circuits repeats.
+  // The original synchronous tools above are unchanged.
+  // ---------------------------------------------------------------------------
+
+  server.registerTool('imap_scan_account_spam_start', {
+    description:
+      'Start a resumable account-wide spam scan (UserCheck) as a tracked job. Scans every folder, dedupes ' +
+      'senders to unique addresses, and checks each once (cached senders cost no API call). Returns the full ' +
+      'summary if it completes within ~30s, otherwise a jobId to poll/resume/cancel. Unlike imap_scan_account_spam ' +
+      'this has no 1000-sender cap and survives interruption.',
+    inputSchema: {
+      userId: z.string().describe('User ID (UUID or username) with an active UserCheck API key'),
+      accountId: z.string().describe('IMAP account ID'),
+      maxEmailsPerFolder: z.number().optional().default(100).describe('Max emails to sample per folder for sender extraction'),
+      checkDisposable: z.boolean().optional().default(true),
+      checkBlocklisted: z.boolean().optional().default(true),
+      checkRoleAccount: z.boolean().optional().default(true),
+      checkMx: z.boolean().optional().default(true),
+      allowPublicDomains: z.boolean().optional().default(true),
+      useCache: z.boolean().optional().default(true).describe('Skip senders already in spam_cache (default true)'),
+      budgetMs: z.number().optional().default(30000).describe('Sync wait budget before returning a jobId (default 30000)'),
+    },
+  }, withErrorHandling(async (args) => {
+    const userId = resolveUserOrThrow(db, args.userId);
+    const params = {
+      accountId: args.accountId, maxEmailsPerFolder: args.maxEmailsPerFolder,
+      checkDisposable: args.checkDisposable, checkBlocklisted: args.checkBlocklisted,
+      checkRoleAccount: args.checkRoleAccount, checkMx: args.checkMx,
+      allowPublicDomains: args.allowPublicDomains, useCache: args.useCache,
+    };
+    const runner = BULK_RUNNERS.imap_scan_account_spam;
+    const items = await runner.deriveItems(userId, params, runnerDeps);
+    const jobId = jobs.createJob({ userId, accountId: args.accountId, toolName: 'imap_scan_account_spam', params, totalItems: items.length });
+    return runJobWithBudget(jobs, jobId, items,
+      (k) => runner.processOne(userId, k, params, runnerDeps),
+      (jid) => runner.summarize(jid, params, jobs),
+      args.budgetMs ?? DEFAULT_BUDGET_MS);
+  }));
+
+  server.registerTool('imap_check_emails_spam_bulk_start', {
+    description:
+      'Start a resumable bulk spam check of a list of email addresses (UserCheck) as a tracked job. Dedupes ' +
+      'to unique addresses, one check each (cache-first). Returns the full summary if done within ~30s, else a ' +
+      'jobId to poll/resume/cancel.',
+    inputSchema: {
+      userId: z.string().describe('User ID (UUID or username) with an active UserCheck API key'),
+      accountId: z.string().optional().default('').describe('Optional account ID for grouping the job'),
+      emails: z.array(z.string()).min(1).describe('Email addresses to check'),
+      checkDisposable: z.boolean().optional().default(true),
+      checkBlocklisted: z.boolean().optional().default(true),
+      checkRoleAccount: z.boolean().optional().default(true),
+      checkMx: z.boolean().optional().default(true),
+      allowPublicDomains: z.boolean().optional().default(true),
+      useCache: z.boolean().optional().default(true),
+      budgetMs: z.number().optional().default(30000),
+    },
+  }, withErrorHandling(async (args) => {
+    const userId = resolveUserOrThrow(db, args.userId);
+    const params = {
+      emails: args.emails, checkDisposable: args.checkDisposable, checkBlocklisted: args.checkBlocklisted,
+      checkRoleAccount: args.checkRoleAccount, checkMx: args.checkMx,
+      allowPublicDomains: args.allowPublicDomains, useCache: args.useCache,
+    };
+    const runner = BULK_RUNNERS.imap_check_emails_spam_bulk;
+    const items = await runner.deriveItems(userId, params, runnerDeps);
+    const jobId = jobs.createJob({ userId, accountId: args.accountId || 'n/a', toolName: 'imap_check_emails_spam_bulk', params, totalItems: items.length });
+    return runJobWithBudget(jobs, jobId, items,
+      (k) => runner.processOne(userId, k, params, runnerDeps),
+      (jid) => runner.summarize(jid, params, jobs),
+      args.budgetMs ?? DEFAULT_BUDGET_MS);
+  }));
+
+  server.registerTool('imap_bulk_job_resume', {
+    description:
+      'Resume a paused, failed, or cancelled bulk job from where it stopped — only unprocessed items are run ' +
+      '(already-checked senders are skipped). Re-derives the work from the job\'s saved params. Returns the full ' +
+      'summary if it finishes within ~30s, else the jobId to keep polling.',
+    inputSchema: {
+      jobId: z.string().describe('Job ID from a *_start tool'),
+      budgetMs: z.number().optional().default(30000),
+    },
+  }, withErrorHandling(async ({ jobId, budgetMs }) => {
+    const job = jobs.getJob(jobId);
+    if (!job) {
+      return { content: [{ type: 'text', text: JSON.stringify({ error: 'job_not_found', jobId }, null, 2) }], isError: true };
+    }
+    if (job.status === 'done') {
+      return { content: [{ type: 'text', text: JSON.stringify({ jobId, status: 'done', note: 'Job already complete.', summary: job.resultSummary }, null, 2) }] };
+    }
+    const runner = BULK_RUNNERS[job.toolName];
+    if (!runner) {
+      return { content: [{ type: 'text', text: JSON.stringify({ error: 'not_resumable', jobId, toolName: job.toolName }, null, 2) }], isError: true };
+    }
+    const items = await runner.deriveItems(job.userId, job.params as any, runnerDeps);
+    return runJobWithBudget(jobs, jobId, items,
+      (k) => runner.processOne(job.userId, k, job.params as any, runnerDeps),
+      (jid) => runner.summarize(jid, job.params as any, jobs),
+      budgetMs ?? DEFAULT_BUDGET_MS);
   }));
 }


### PR DESCRIPTION
Wires the two UserCheck bulk tools to the job machine: `imap_scan_account_spam_start` / `imap_check_emails_spam_bulk_start` (30s sync shim → full summary or jobId+background run) + `imap_bulk_job_resume` (re-derives work, runs only unprocessed items). BULK_RUNNERS registry makes resume tool-agnostic. Existing sync tools unchanged (no shape regression); the start variants lift the 1000-sender cap. Tools 116→119; 4 new tests (265 total). **Closes #117** (acceptance met; unified external_check_cache dropped as redundant per #238; A.3 other-tool refactors can follow).