### PR TITLE
feat: imap_test_categories — dry-run keyword-effectiveness analysis (#72)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,7 +4,7 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**119 MCP tools** total.
+**120 MCP tools** total.
 
 ## Categories
 
@@ -16,7 +16,7 @@
 - [Email operations](#email-operations) — 13
 - [Folder & mailbox operations](#folder-mailbox-operations) — 11
 - [Subscriptions & unsubscribe](#subscriptions-unsubscribe) — 9
-- [Categorization & scoring](#categorization-scoring) — 6
+- [Categorization & scoring](#categorization-scoring) — 7
 - [Spam & UserCheck](#spam-usercheck) — 9
 - [DNS firewall & domain checks](#dns-firewall-domain-checks) — 4
 - [Local cache](#local-cache) — 2
@@ -154,6 +154,7 @@
 | `imap_list_categories` | List all Quick Categories for a user, optionally filtered by account |
 | `imap_remove_keyword` | Remove a custom keyword from emails |
 | `imap_score_email_confidence` | Analyze email headers to detect spoofing and calculate confidence score (-100 to +100). |
+| `imap_test_categories` | Dry-run the Quick Categories against a folder WITHOUT moving any email: reports coverage (% that would be categorized), per-category counts + destination, which keyword triggered each match, emails matching multiple categories (conflicts),  |
 
 ## Spam & UserCheck
 

--- a/scripts/gen-tool-catalog.mjs
+++ b/scripts/gen-tool-catalog.mjs
@@ -39,7 +39,7 @@ const CATEGORIES = [
   ['Email operations', /^imap_(search_emails|get_email|get_latest_emails|mark_as_read|mark_as_unread|delete_email|copy_email|move_email|send_email|reply_to_email|forward_email|get_email_priority|set_email_priority)$/],
   ['Folder & mailbox operations', /^imap_(list_folders|folder_status|get_unread_count|create_folder|delete_folder|rename_folder|get_mailbox_status|subscribe_mailbox|unsubscribe_mailbox|list_subscribed_mailboxes|append_message)$/],
   ['Subscriptions & unsubscribe', /^imap_(extract_unsubscribe_links|get_unsubscribe_links|get_unsubscribe_links_for|execute_unsubscribe|get_subscription_summary|list_unsubscribe_candidates|mark_subscription_unsubscribed|update_subscription_category|update_subscription_notes)$/],
-  ['Categorization & scoring', /^imap_(add_keyword|remove_keyword|list_categories|apply_categories|analyze_folder_confidence|score_email_confidence)$/],
+  ['Categorization & scoring', /^imap_(add_keyword|remove_keyword|list_categories|apply_categories|test_categories|analyze_folder_confidence|score_email_confidence)$/],
   ['Spam & UserCheck', /^imap_(check_email_spam|check_emails_spam_bulk|check_emails_spam_bulk_start|check_folder_spam|scan_account_spam|scan_account_spam_start|add_usercheck_key|get_usercheck_key|delete_usercheck_key)$/],
   ['DNS firewall & domain checks', /^imap_(check_domain|check_domain_dns_firewall|scan_message_domains|test_quad9_dns)$/],
   ['Local cache', /^imap_(search_cache|sync_folder_cache)$/],

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -163,6 +163,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
 
   // ---- category-tools (5) ----
   'imap_list_categories':              READ_ONLY,
+  'imap_test_categories':              READ_REMOTE,         // dry-run analysis, no moves
   'imap_apply_categories':             WRITE_REMOTE,        // sets keyword flags on messages
   'imap_add_keyword':                  WRITE_REMOTE,
   'imap_remove_keyword':               WRITE_REMOTE,

--- a/src/tools/category-tools.test.ts
+++ b/src/tools/category-tools.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for evaluateCategories — the dry-run categorization analysis (#72).
+
+import { describe, expect, it } from 'vitest';
+import { evaluateCategories } from './category-tools.js';
+
+const CATS = [
+  { category_name: 'Newsletters', keywords: 'newsletter, digest', target_folder: 'INBOX/News' },
+  { category_name: 'Receipts', keywords: 'receipt; invoice', target_folder: 'INBOX/Receipts' },
+];
+
+describe('evaluateCategories (#72)', () => {
+  it('counts coverage, per-category, and uncategorized', () => {
+    const a = evaluateCategories([
+      { uid: 1, from: 'news@x.com', subject: 'Weekly newsletter' },
+      { uid: 2, from: 'shop@y.com', subject: 'Your invoice #42' },
+      { uid: 3, from: 'bob@z.com', subject: 'lunch?' },
+    ], CATS);
+    expect(a.total).toBe(3);
+    expect(a.categorized).toBe(2);
+    expect(a.uncategorized).toBe(1);
+    expect(a.coveragePercent).toBeCloseTo(66.7, 1);
+    expect(a.perCategory.Newsletters.count).toBe(1);
+    expect(a.perCategory.Receipts.count).toBe(1);
+    expect(a.uncategorizedList[0].uid).toBe(3);
+  });
+
+  it('reports the matched keyword + destination (first-match-wins)', () => {
+    const a = evaluateCategories([{ uid: 5, from: 'a@x.com', subject: 'Monthly digest' }], CATS);
+    expect(a.matched[0]).toMatchObject({ uid: 5, matchedCategory: 'Newsletters', matchedKeyword: 'digest', destination: 'INBOX/News' });
+  });
+
+  it('flags conflicts when an email matches multiple categories', () => {
+    const a = evaluateCategories([
+      { uid: 9, from: 'billing@x.com', subject: 'newsletter: your invoice is ready' }, // matches both
+    ], CATS);
+    expect(a.conflicts).toBe(1);
+    expect(a.matched[0].allCategories.sort()).toEqual(['Newsletters', 'Receipts']);
+    // destination follows category order (Newsletters first)
+    expect(a.matched[0].destination).toBe('INBOX/News');
+  });
+
+  it('matches against sender as well as subject, case-insensitively', () => {
+    const a = evaluateCategories([{ uid: 7, from: 'NEWSLETTER@brand.com', subject: 'Hi' }], CATS);
+    expect(a.categorized).toBe(1);
+    expect(a.matched[0].matchedCategory).toBe('Newsletters');
+  });
+
+  it('handles an empty email set', () => {
+    const a = evaluateCategories([], CATS);
+    expect(a).toMatchObject({ total: 0, categorized: 0, coveragePercent: 0, conflicts: 0 });
+  });
+});

--- a/src/tools/category-tools.ts
+++ b/src/tools/category-tools.ts
@@ -17,6 +17,67 @@ import { z } from 'zod';
 import { withErrorHandling } from '../utils/error-handler.js';
 import { getToolContext } from './tool-context.js';
 
+/** A category row as stored: name, comma/semicolon keyword list, destination. */
+interface CategoryRow { category_name: string; keywords: string; target_folder: string; }
+/** Minimal email shape the evaluator needs. */
+interface EvalEmail { uid: number; from?: string; subject?: string; date?: unknown; }
+
+/** Split a category's keyword string into normalized, non-empty terms. */
+function splitKeywords(keywords: string): string[] {
+  return (keywords || '').split(/[,;]/).map((k) => k.trim().toLowerCase()).filter((k) => k.length > 0);
+}
+
+/**
+ * Pure dry-run categorization analysis (#72): for each email find ALL matching
+ * categories (not just the first), so we can report coverage, conflicts
+ * (multi-category matches), per-category counts, and the uncategorized set —
+ * without moving anything. "Destination" mirrors imap_apply_categories'
+ * first-match-wins behavior (categories are evaluated in the given order).
+ */
+export function evaluateCategories(emails: EvalEmail[], categories: CategoryRow[]) {
+  const prepared = categories.map((c) => ({ name: c.category_name, target: c.target_folder, keywords: splitKeywords(c.keywords) }));
+  const perCategory: Record<string, { count: number; target: string }> = {};
+  for (const c of prepared) perCategory[c.name] = { count: 0, target: c.target };
+
+  const matched: Array<{ uid: number; subject: string; from: string; date: unknown; destination: string; matchedCategory: string; matchedKeyword: string; allCategories: string[] }> = [];
+  const uncategorized: Array<{ uid: number; subject: string; from: string; date: unknown }> = [];
+  let conflicts = 0;
+
+  for (const email of emails) {
+    const text = `${email.from || ''} ${email.subject || ''}`.toLowerCase();
+    const hits: Array<{ category: string; keyword: string; target: string }> = [];
+    for (const c of prepared) {
+      const kw = c.keywords.find((k) => text.includes(k));
+      if (kw) hits.push({ category: c.name, keyword: kw, target: c.target });
+    }
+    if (hits.length === 0) {
+      uncategorized.push({ uid: email.uid, subject: email.subject || '(no subject)', from: email.from || '', date: email.date });
+      continue;
+    }
+    const first = hits[0]; // first-match-wins destination (matches apply behavior)
+    perCategory[first.category].count++;
+    const distinct = [...new Set(hits.map((h) => h.category))];
+    if (distinct.length > 1) conflicts++;
+    matched.push({
+      uid: email.uid, subject: email.subject || '(no subject)', from: email.from || '', date: email.date,
+      destination: first.target, matchedCategory: first.category, matchedKeyword: first.keyword, allCategories: distinct,
+    });
+  }
+
+  const total = emails.length;
+  const categorized = matched.length;
+  return {
+    total,
+    categorized,
+    uncategorized: uncategorized.length,
+    coveragePercent: total > 0 ? Math.round((categorized / total) * 1000) / 10 : 0,
+    conflicts,
+    perCategory,
+    matched,
+    uncategorizedList: uncategorized,
+  };
+}
+
 export function categoryTools(
   server: McpServer,
   imapService: ImapService,
@@ -151,6 +212,59 @@ export function categoryTools(
           message: dryRun
             ? `Dry run complete. Found ${categorizedCount} emails that would be categorized.`
             : `Categorization complete. Moved ${categorizedCount} emails to target folders.`
+        }, null, 2)
+      }]
+    };
+  }));
+
+  // Test categorization without moving anything (#72)
+  server.registerTool('imap_test_categories', {
+    description:
+      'Dry-run the Quick Categories against a folder WITHOUT moving any email: reports coverage (% that would ' +
+      'be categorized), per-category counts + destination, which keyword triggered each match, emails matching ' +
+      'multiple categories (conflicts), and the uncategorized set. Use to tune keywords before imap_apply_categories.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder to test against (default: INBOX)'),
+      limit: z.number().optional().default(200).describe('Max most-recent emails to test (default 200, cap 1000)'),
+      unreadOnly: z.boolean().optional().default(false).describe('Test only unread emails'),
+      sampleSize: z.number().optional().default(50).describe('Max rows to include in each sample list (default 50)'),
+    }
+  }, withErrorHandling(async ({ accountId, folder, limit, unreadOnly, sampleSize }) => {
+    const { userId } = getToolContext(db);
+    const categories = db.getEnabledCategoriesForAccount(userId, accountId);
+    if (categories.length === 0) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, message: 'No enabled categories for this account. Create categories first in the Web UI.' }, null, 2) }] };
+    }
+
+    const cap = Math.min(limit ?? 200, 1000);
+    const all = await imapService.searchEmails(accountId, folder, unreadOnly ? { unreadOnly: true } : {});
+    const emails = all.length > cap ? [...all].sort((a, b) => b.uid - a.uid).slice(0, cap) : all;
+
+    const a = evaluateCategories(emails, categories as any);
+    const n = Math.max(0, sampleSize ?? 50);
+    const warnings: string[] = [];
+    if (all.length > cap) warnings.push(`Folder has ${all.length} emails; tested the ${cap} most recent.`);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          folder,
+          summary: {
+            tested: a.total,
+            categorized: a.categorized,
+            uncategorized: a.uncategorized,
+            coveragePercent: a.coveragePercent,
+            conflicts: a.conflicts,
+          },
+          perCategory: a.perCategory,
+          // Capped samples to protect the token budget; counts above are complete.
+          wouldMove: a.matched.slice(0, n).map((m) => ({ uid: m.uid, from: m.from, subject: m.subject, date: m.date, destination: m.destination, matchedKeyword: m.matchedKeyword, matchedCategory: m.matchedCategory, ...(m.allCategories.length > 1 ? { conflictsWith: m.allCategories } : {}) })),
+          uncategorizedSample: a.uncategorizedList.slice(0, n).map((u) => ({ uid: u.uid, from: u.from, subject: u.subject, date: u.date })),
+          warnings: warnings.length ? warnings : undefined,
+          note: 'Dry run — no emails were moved.',
         }, null, 2)
       }]
     };


### PR DESCRIPTION
Dry-run the Quick Categories against a folder without moving anything: coverage %, per-category counts + destination, the matched keyword, multi-category **conflicts**, and the uncategorized set. Pure tested `evaluateCategories()` helper (all-matches, first-match-wins destination). Capped sample lists; complete counts. READ_REMOTE. 5 tests; tools 119→120. Closes #72.