### PR TITLE
feat: imap_recommend_keywords — keyword candidates from folder analysis (#73)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,7 +4,7 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**120 MCP tools** total.
+**121 MCP tools** total.
 
 ## Categories
 
@@ -16,7 +16,7 @@
 - [Email operations](#email-operations) — 13
 - [Folder & mailbox operations](#folder-mailbox-operations) — 11
 - [Subscriptions & unsubscribe](#subscriptions-unsubscribe) — 9
-- [Categorization & scoring](#categorization-scoring) — 7
+- [Categorization & scoring](#categorization-scoring) — 8
 - [Spam & UserCheck](#spam-usercheck) — 9
 - [DNS firewall & domain checks](#dns-firewall-domain-checks) — 4
 - [Local cache](#local-cache) — 2
@@ -152,6 +152,7 @@
 | `imap_analyze_folder_confidence` | Analyze all emails in a folder and provide confidence statistics. |
 | `imap_apply_categories` | Apply Quick Categories to emails in a folder. |
 | `imap_list_categories` | List all Quick Categories for a user, optionally filtered by account |
+| `imap_recommend_keywords` | Analyze a folder and return candidate category keywords for Claude to turn into recommendations: top sender domains, top senders, and frequent subject terms + bigrams — each flagged whether an existing category keyword already covers it. |
 | `imap_remove_keyword` | Remove a custom keyword from emails |
 | `imap_score_email_confidence` | Analyze email headers to detect spoofing and calculate confidence score (-100 to +100). |
 | `imap_test_categories` | Dry-run the Quick Categories against a folder WITHOUT moving any email: reports coverage (% that would be categorized), per-category counts + destination, which keyword triggered each match, emails matching multiple categories (conflicts),  |

--- a/scripts/gen-tool-catalog.mjs
+++ b/scripts/gen-tool-catalog.mjs
@@ -39,7 +39,7 @@ const CATEGORIES = [
   ['Email operations', /^imap_(search_emails|get_email|get_latest_emails|mark_as_read|mark_as_unread|delete_email|copy_email|move_email|send_email|reply_to_email|forward_email|get_email_priority|set_email_priority)$/],
   ['Folder & mailbox operations', /^imap_(list_folders|folder_status|get_unread_count|create_folder|delete_folder|rename_folder|get_mailbox_status|subscribe_mailbox|unsubscribe_mailbox|list_subscribed_mailboxes|append_message)$/],
   ['Subscriptions & unsubscribe', /^imap_(extract_unsubscribe_links|get_unsubscribe_links|get_unsubscribe_links_for|execute_unsubscribe|get_subscription_summary|list_unsubscribe_candidates|mark_subscription_unsubscribed|update_subscription_category|update_subscription_notes)$/],
-  ['Categorization & scoring', /^imap_(add_keyword|remove_keyword|list_categories|apply_categories|test_categories|analyze_folder_confidence|score_email_confidence)$/],
+  ['Categorization & scoring', /^imap_(add_keyword|remove_keyword|list_categories|apply_categories|test_categories|recommend_keywords|analyze_folder_confidence|score_email_confidence)$/],
   ['Spam & UserCheck', /^imap_(check_email_spam|check_emails_spam_bulk|check_emails_spam_bulk_start|check_folder_spam|scan_account_spam|scan_account_spam_start|add_usercheck_key|get_usercheck_key|delete_usercheck_key)$/],
   ['DNS firewall & domain checks', /^imap_(check_domain|check_domain_dns_firewall|scan_message_domains|test_quad9_dns)$/],
   ['Local cache', /^imap_(search_cache|sync_folder_cache)$/],

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -164,6 +164,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   // ---- category-tools (5) ----
   'imap_list_categories':              READ_ONLY,
   'imap_test_categories':              READ_REMOTE,         // dry-run analysis, no moves
+  'imap_recommend_keywords':           READ_REMOTE,         // folder analysis, no moves
   'imap_apply_categories':             WRITE_REMOTE,        // sets keyword flags on messages
   'imap_add_keyword':                  WRITE_REMOTE,
   'imap_remove_keyword':               WRITE_REMOTE,

--- a/src/tools/category-tools.test.ts
+++ b/src/tools/category-tools.test.ts
@@ -3,7 +3,7 @@
 // Tests for evaluateCategories — the dry-run categorization analysis (#72).
 
 import { describe, expect, it } from 'vitest';
-import { evaluateCategories } from './category-tools.js';
+import { evaluateCategories, recommendKeywords } from './category-tools.js';
 
 const CATS = [
   { category_name: 'Newsletters', keywords: 'newsletter, digest', target_folder: 'INBOX/News' },
@@ -50,5 +50,42 @@ describe('evaluateCategories (#72)', () => {
   it('handles an empty email set', () => {
     const a = evaluateCategories([], CATS);
     expect(a).toMatchObject({ total: 0, categorized: 0, coveragePercent: 0, conflicts: 0 });
+  });
+});
+
+describe('recommendKeywords (#73)', () => {
+  const SAMPLE = [
+    { from: 'News <news@acme.com>', subject: 'Weekly product update' },
+    { from: 'deals@acme.com', subject: 'Weekly product deals' },
+    { from: 'Bob <bob@other.com>', subject: 'lunch' },
+    { from: 'sales@acme.com', subject: 'product launch' },
+  ];
+
+  it('ranks top sender domains by frequency', () => {
+    const r = recommendKeywords(SAMPLE, { minCount: 1 });
+    expect(r.topDomains[0]).toMatchObject({ domain: 'acme.com', count: 3 });
+    expect(r.sampled).toBe(4);
+  });
+
+  it('mines frequent subject terms and bigrams above minCount', () => {
+    const r = recommendKeywords(SAMPLE, { minCount: 2 });
+    const terms = r.subjectTerms.map((t) => t.term);
+    expect(terms).toContain('product');          // appears 3x
+    expect(terms).toContain('weekly product');   // bigram appears 2x
+    expect(terms).not.toContain('lunch');         // only once → below minCount
+  });
+
+  it('flags candidates already covered by existing keywords', () => {
+    const r = recommendKeywords(SAMPLE, { minCount: 1, existingKeywords: ['acme.com'] });
+    expect(r.topDomains.find((d) => d.domain === 'acme.com')?.covered).toBe(true);
+    expect(r.suggestedKeywords).not.toContain('acme.com'); // covered → not suggested
+  });
+
+  it('drops stopwords and pure numbers from subject terms', () => {
+    const r = recommendKeywords([{ from: 'a@x.com', subject: 'Your 2026 the order' }, { from: 'b@x.com', subject: 'your 2026 order' }], { minCount: 2 });
+    const terms = r.subjectTerms.map((t) => t.term);
+    expect(terms).toContain('order');
+    expect(terms).not.toContain('your'); // stopword
+    expect(terms).not.toContain('2026'); // pure number
   });
 });

--- a/src/tools/category-tools.ts
+++ b/src/tools/category-tools.ts
@@ -78,6 +78,80 @@ export function evaluateCategories(emails: EvalEmail[], categories: CategoryRow[
   };
 }
 
+// Common words to ignore when mining subject lines for keyword candidates.
+const KEYWORD_STOPWORDS = new Set([
+  're', 'fwd', 'fw', 'the', 'a', 'an', 'and', 'or', 'of', 'to', 'for', 'in', 'on', 'at', 'is', 'are', 'be',
+  'your', 'you', 'we', 'our', 'us', 'my', 'me', 'it', 'this', 'that', 'with', 'from', 'by', 'as', 'has', 'have',
+  'will', 'can', 'new', 'now', 'get', 'please', 'thanks', 'thank', 'hi', 'hello', 'no', 'yes', 'not', 'do', 'all',
+]);
+
+function domainOf(rawFrom: string): string | null {
+  const m = (rawFrom || '').match(/<([^>]+)>/);
+  const addr = (m ? m[1] : rawFrom).trim().toLowerCase();
+  const at = addr.lastIndexOf('@');
+  return at >= 0 && at < addr.length - 1 ? addr.slice(at + 1) : null;
+}
+function addressOf(rawFrom: string): string | null {
+  const m = (rawFrom || '').match(/<([^>]+)>/);
+  const addr = (m ? m[1] : rawFrom).trim().toLowerCase();
+  return addr.includes('@') ? addr : null;
+}
+function topN<T extends { count: number }>(map: Map<string, number>, make: (k: string, c: number) => T, n: number, minCount: number): T[] {
+  return [...map.entries()].filter(([, c]) => c >= minCount).sort((a, b) => b[1] - a[1]).slice(0, n).map(([k, c]) => make(k, c));
+}
+
+/**
+ * Mine a sample of emails for category-keyword candidates (#73, data-for-Claude):
+ * top sender domains, top senders, and frequent subject terms + bigrams, each
+ * flagged as already-covered by existing keywords. Returns structured stats for
+ * the client (Claude) to turn into recommendations — the server does not call an
+ * LLM. Pure + deterministic.
+ */
+export function recommendKeywords(
+  emails: Array<{ from?: string; subject?: string }>,
+  opts: { topN?: number; minCount?: number; existingKeywords?: string[] } = {},
+) {
+  const n = opts.topN ?? 20;
+  const minCount = opts.minCount ?? 2;
+  const covered = new Set((opts.existingKeywords ?? []).map((k) => k.toLowerCase().trim()).filter(Boolean));
+
+  const domains = new Map<string, number>();
+  const senders = new Map<string, number>();
+  const terms = new Map<string, number>();
+
+  for (const e of emails) {
+    const d = domainOf(e.from || '');
+    if (d) domains.set(d, (domains.get(d) ?? 0) + 1);
+    const a = addressOf(e.from || '');
+    if (a) senders.set(a, (senders.get(a) ?? 0) + 1);
+
+    const tokens = (e.subject || '')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length >= 3 && !/^\d+$/.test(t) && !KEYWORD_STOPWORDS.has(t));
+    for (let i = 0; i < tokens.length; i++) {
+      terms.set(tokens[i], (terms.get(tokens[i]) ?? 0) + 1);
+      if (i + 1 < tokens.length) {
+        const bigram = `${tokens[i]} ${tokens[i + 1]}`;
+        terms.set(bigram, (terms.get(bigram) ?? 0) + 1);
+      }
+    }
+  }
+
+  const isCovered = (k: string) => covered.has(k.toLowerCase());
+  const topDomains = topN(domains, (domain, count) => ({ domain, count, covered: isCovered(domain) }), n, minCount);
+  const topSenders = topN(senders, (address, count) => ({ address, count, covered: isCovered(address) }), n, minCount);
+  const subjectTerms = topN(terms, (term, count) => ({ term, count, covered: isCovered(term) }), n, minCount);
+
+  // Suggested = the highest-signal not-yet-covered candidates (domains weighted first).
+  const suggested = [
+    ...topDomains.filter((d) => !d.covered).slice(0, 10).map((d) => d.domain),
+    ...subjectTerms.filter((t) => !t.covered).slice(0, 10).map((t) => t.term),
+  ];
+
+  return { sampled: emails.length, topDomains, topSenders, subjectTerms, suggestedKeywords: [...new Set(suggested)] };
+}
+
 export function categoryTools(
   server: McpServer,
   imapService: ImapService,
@@ -265,6 +339,52 @@ export function categoryTools(
           uncategorizedSample: a.uncategorizedList.slice(0, n).map((u) => ({ uid: u.uid, from: u.from, subject: u.subject, date: u.date })),
           warnings: warnings.length ? warnings : undefined,
           note: 'Dry run — no emails were moved.',
+        }, null, 2)
+      }]
+    };
+  }));
+
+  // Recommend category keywords from a folder's mail (#73, data-for-Claude)
+  server.registerTool('imap_recommend_keywords', {
+    description:
+      'Analyze a folder and return candidate category keywords for Claude to turn into recommendations: top ' +
+      'sender domains, top senders, and frequent subject terms + bigrams — each flagged whether an existing ' +
+      'category keyword already covers it. The server does no AI itself; it returns structured stats so the ' +
+      'assistant can propose categories/keywords. Read-only.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder to analyze (default: INBOX)'),
+      limit: z.number().optional().default(500).describe('Max most-recent emails to sample (default 500, cap 2000)'),
+      topN: z.number().optional().default(20).describe('How many candidates to return per category (default 20)'),
+      minCount: z.number().optional().default(2).describe('Ignore candidates seen fewer than this many times (default 2)'),
+    }
+  }, withErrorHandling(async ({ accountId, folder, limit, topN: topCount, minCount }) => {
+    const { userId } = getToolContext(db);
+    const cap = Math.min(limit ?? 500, 2000);
+    const all = await imapService.searchEmails(accountId, folder, {});
+    const emails = all.length > cap ? [...all].sort((a, b) => b.uid - a.uid).slice(0, cap) : all;
+
+    // Existing keywords (across this account's categories) to flag coverage.
+    const existingKeywords: string[] = [];
+    try {
+      for (const c of db.getEnabledCategoriesForAccount(userId, accountId) as any[]) {
+        existingKeywords.push(...splitKeywords(c.keywords));
+      }
+    } catch { /* categories optional */ }
+
+    const rec = recommendKeywords(emails, { topN: topCount ?? 20, minCount: minCount ?? 2, existingKeywords });
+    const warnings = all.length > cap ? [`Folder has ${all.length} emails; analyzed the ${cap} most recent.`] : undefined;
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          folder,
+          ...rec,
+          existingKeywordCount: existingKeywords.length,
+          warnings,
+          note: 'Candidates only — review and apply via the Web UI or imap_add_keyword. "covered" means an existing category keyword already matches.',
         }, null, 2)
       }]
     };


### PR DESCRIPTION
Data-for-Claude (#73): analyze a folder → top sender domains, top senders, frequent subject terms + bigrams (stopword/number-filtered, bigrams, minCount), each flagged as already-covered, plus a `suggestedKeywords` shortlist. The server runs no LLM — it returns structured stats for Claude to recommend from. Pure tested helper; READ_REMOTE; 4 tests; tools 120→121. Closes #73.