### PR TITLE
feat: per-user allow/deny address lists — backend + tools (#69/#70)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,7 +4,7 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**121 MCP tools** total.
+**127 MCP tools** total.
 
 ## Categories
 
@@ -19,6 +19,7 @@
 - [Categorization & scoring](#categorization-scoring) — 8
 - [Spam & UserCheck](#spam-usercheck) — 9
 - [DNS firewall & domain checks](#dns-firewall-domain-checks) — 4
+- [Allow/deny lists](#allowdeny-lists) — 6
 - [Local cache](#local-cache) — 2
 - [Capabilities, diagnostics & metrics](#capabilities-diagnostics-metrics) — 11
 - [Meta & discovery](#meta-discovery) — 6
@@ -179,6 +180,17 @@
 | `imap_check_domain_dns_firewall` | Check if a domain is blocked by DNS firewall (Quad9 threat intelligence) |
 | `imap_scan_message_domains` | Extract and validate all domains from an email message against DNS firewall |
 | `imap_test_quad9_dns` | Verify Quad9 DNS threat-blocking is active. |
+
+## Allow/deny lists
+
+| Tool | Description |
+| --- | --- |
+| `imap_add_list_entry` | Add an entry to a per-user allow or deny list. |
+| `imap_check_address` | Check a sender (a plain address, or a full From header with display name) against the user's allow/deny lists. |
+| `imap_clear_list` | Remove ALL entries from a user's allow or deny list. |
+| `imap_import_list` | Bulk-import addresses into an allow/deny list from CSV or vCard (.vcf — including Apple Contacts exports). |
+| `imap_list_entries` | List a user's allow/deny entries (optionally filtered to one list). |
+| `imap_remove_list_entry` | Remove an entry from a per-user allow or deny list (matches the normalized value). |
 
 ## Local cache
 

--- a/scripts/gen-tool-catalog.mjs
+++ b/scripts/gen-tool-catalog.mjs
@@ -42,6 +42,7 @@ const CATEGORIES = [
   ['Categorization & scoring', /^imap_(add_keyword|remove_keyword|list_categories|apply_categories|test_categories|recommend_keywords|analyze_folder_confidence|score_email_confidence)$/],
   ['Spam & UserCheck', /^imap_(check_email_spam|check_emails_spam_bulk|check_emails_spam_bulk_start|check_folder_spam|scan_account_spam|scan_account_spam_start|add_usercheck_key|get_usercheck_key|delete_usercheck_key)$/],
   ['DNS firewall & domain checks', /^imap_(check_domain|check_domain_dns_firewall|scan_message_domains|test_quad9_dns)$/],
+  ['Allow/deny lists', /^imap_(add_list_entry|remove_list_entry|list_entries|check_address|import_list|clear_list)$/],
   ['Local cache', /^imap_(search_cache|sync_folder_cache)$/],
   ['Capabilities, diagnostics & metrics', /^imap_(get_capabilities|test_smtp|test_sent_folder|list_unarchived_sends|get_metrics|get_operation_metrics|reset_metrics|get_smtp_metrics|reset_smtp_metrics|get_circuit_breaker|reset_circuit_breaker)$/],
   ['Meta & discovery', /^imap_(about|list_tools|help|check_skill_updates|update_skills|results)$/],

--- a/src/database/migrations-manifest.json
+++ b/src/database/migrations-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.13.0",
+  "schemaVersion": "1.14.0",
   "description": "Release-indexed manifest of schema migrations. Each entry is applied in order via the `schema_version` ledger. A migration is complete when its `to` version is present in the ledger.",
   "migrations": [
     {
@@ -86,6 +86,13 @@
       "file": "schema_update_1.12.0_TO_1.13.0.sql",
       "rollbackFile": "schema_update_1.12.0_TO_1.13.0.down.sql",
       "description": "Add bulk_operations + bulk_operation_items for job persistence (Track A, Issue #117)"
+    },
+    {
+      "from": "1.13.0",
+      "to": "1.14.0",
+      "file": "schema_update_1.13.0_TO_1.14.0.sql",
+      "rollbackFile": "schema_update_1.13.0_TO_1.14.0.down.sql",
+      "description": "Add address_list_entries (per-user allow/deny lists, #69/#70)"
     }
   ]
 }

--- a/src/database/schema_update_1.13.0_TO_1.14.0.down.sql
+++ b/src/database/schema_update_1.13.0_TO_1.14.0.down.sql
@@ -1,0 +1,3 @@
+-- Rollback for schema 1.13.0 → 1.14.0 (#69/#70: address allow/deny lists)
+DROP INDEX IF EXISTS idx_address_list_user_type;
+DROP TABLE IF EXISTS address_list_entries;

--- a/src/database/schema_update_1.13.0_TO_1.14.0.sql
+++ b/src/database/schema_update_1.13.0_TO_1.14.0.sql
@@ -1,0 +1,23 @@
+-- Schema migration 1.13.0 → 1.14.0
+-- Per-user allow/deny address lists (#69/#70).
+--
+-- One row per (user, list, value). `value` is a normalized email address or a
+-- bare domain; `value_type` says which. Lists are per-user (multi-tenant ready);
+-- consulted by imap_check_address and, later, the spam/DNS decision paths.
+--
+-- Author: Colin Bitterfield
+-- Email: colin.bitterfield@templeofepiphany.com
+-- Date: 2026-06-24
+
+CREATE TABLE IF NOT EXISTS address_list_entries (
+  user_id     TEXT NOT NULL,
+  list_type   TEXT NOT NULL CHECK (list_type IN ('allow','deny')),
+  value       TEXT NOT NULL,    -- normalized: lowercase email or bare domain
+  value_type  TEXT NOT NULL CHECK (value_type IN ('email','domain')),
+  note        TEXT,
+  created_at  INTEGER NOT NULL,
+  PRIMARY KEY (user_id, list_type, value)
+);
+
+CREATE INDEX IF NOT EXISTS idx_address_list_user_type
+  ON address_list_entries(user_id, list_type);

--- a/src/services/address-list-service.test.ts
+++ b/src/services/address-list-service.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for AddressListService + parsers (#69/#70) on a real node:sqlite temp DB.
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseService } from './database-service.js';
+import { AddressListService, normalizeListValue, parseCsvEmails, parseVcfEmails } from './address-list-service.js';
+
+describe('normalizeListValue', () => {
+  it('extracts + lowercases an email from a display-name header', () => {
+    expect(normalizeListValue('Alice <A@X.com>')).toEqual({ value: 'a@x.com', valueType: 'email' });
+  });
+  it('treats @domain and bare domain as domain entries', () => {
+    expect(normalizeListValue('@Spam.com')).toEqual({ value: 'spam.com', valueType: 'domain' });
+    expect(normalizeListValue('Example.COM')).toEqual({ value: 'example.com', valueType: 'domain' });
+  });
+  it('rejects non-addresses', () => {
+    expect(normalizeListValue('notanaddress')).toBeNull();
+    expect(normalizeListValue('')).toBeNull();
+  });
+});
+
+describe('parsers', () => {
+  it('parseCsvEmails pulls + dedupes emails from freeform CSV', () => {
+    expect(parseCsvEmails('Name,Email\nBob,bob@x.com\nAlice,alice@y.com\ndup,BOB@x.com').sort()).toEqual(['alice@y.com', 'bob@x.com']);
+  });
+  it('parseVcfEmails reads vCard EMAIL lines', () => {
+    const vcf = 'BEGIN:VCARD\nFN:Bob\nEMAIL;TYPE=INTERNET:bob@x.com\nEND:VCARD\nBEGIN:VCARD\nEMAIL:carol@z.com\nEND:VCARD';
+    expect(parseVcfEmails(vcf).sort()).toEqual(['bob@x.com', 'carol@z.com']);
+  });
+});
+
+describe('AddressListService', () => {
+  let tmpDir: string, db: DatabaseService, svc: AddressListService;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imap-lists-'));
+    db = new DatabaseService({ dbPath: path.join(tmpDir, 'data.db') });
+    svc = new AddressListService(db);
+  });
+  afterEach(async () => { try { db.close(); } catch { /* */ } await fs.rm(tmpDir, { recursive: true, force: true }); });
+
+  it('adds, lists, and removes entries', () => {
+    svc.addEntry('u', 'deny', 'Spammer <s@bad.com>');
+    svc.addEntry('u', 'allow', 'good.com');
+    expect(svc.listEntries('u').length).toBe(2);
+    expect(svc.listEntries('u', 'deny')[0]).toMatchObject({ value: 's@bad.com', valueType: 'email' });
+    expect(svc.removeEntry('u', 'deny', 's@bad.com')).toBe(true);
+    expect(svc.listEntries('u', 'deny').length).toBe(0);
+  });
+
+  it('check: email beats domain, allow beats deny', () => {
+    svc.addEntry('u', 'deny', 'bad.com');           // domain deny
+    svc.addEntry('u', 'allow', 'vip@bad.com');       // email allow on same domain
+    expect(svc.check('u', 'vip@bad.com').verdict).toBe('allow');   // email-level allow wins
+    expect(svc.check('u', 'other@bad.com').verdict).toBe('deny');  // falls to domain deny
+    expect(svc.check('u', 'who@elsewhere.com').verdict).toBeNull();
+  });
+
+  it('imports from CSV and is scoped per user', () => {
+    const res = svc.importEntries('u', 'deny', parseCsvEmails('a@x.com\nb@y.com\nnope'), 'imported');
+    expect(res.added).toBe(2);
+    expect(svc.listEntries('u', 'deny').length).toBe(2);
+    expect(svc.listEntries('other').length).toBe(0); // per-user isolation
+  });
+
+  it('clear removes a whole list', () => {
+    svc.addEntry('u', 'allow', 'a@x.com');
+    svc.addEntry('u', 'allow', 'b@x.com');
+    expect(svc.clear('u', 'allow')).toBe(2);
+    expect(svc.listEntries('u', 'allow').length).toBe(0);
+  });
+});

--- a/src/services/address-list-service.ts
+++ b/src/services/address-list-service.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// AddressListService — per-user allow/deny lists of emails/domains (#69/#70).
+//
+// Entries are normalized email addresses or bare domains. check() resolves a
+// sender to a verdict with email-beats-domain specificity and allow-beats-deny
+// at each level (so an explicitly allowed sender is never treated as denied).
+//
+// Author:  Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+// Part of: IMAP MCP Pro (Temple of Epiphany)
+
+import { DatabaseService } from './database-service.js';
+
+export type ListType = 'allow' | 'deny';
+export type ValueType = 'email' | 'domain';
+export type Verdict = 'allow' | 'deny' | null;
+
+export interface ListEntry { listType: ListType; value: string; valueType: ValueType; note: string | null; createdAt: number; }
+
+/** Extract a normalized address from a possibly-display-name header value. */
+export function normalizeListValue(raw: string): { value: string; valueType: ValueType } | null {
+  if (!raw) return null;
+  const m = raw.match(/<([^>]+)>/);
+  let v = (m ? m[1] : raw).trim().toLowerCase();
+  // A leading '@domain' or bare 'domain.tld' is treated as a domain entry.
+  if (v.startsWith('@')) v = v.slice(1);
+  if (!v) return null;
+  if (v.includes('@')) {
+    const at = v.lastIndexOf('@');
+    if (at === 0 || at === v.length - 1) return null;
+    return { value: v, valueType: 'email' };
+  }
+  // Bare token with a dot → domain; otherwise reject (not a usable entry).
+  return v.includes('.') ? { value: v, valueType: 'domain' } : null;
+}
+
+/** Pull email addresses out of CSV text (any column / freeform). */
+export function parseCsvEmails(text: string): string[] {
+  const re = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+  return [...new Set((text.match(re) ?? []).map((e) => e.toLowerCase()))];
+}
+
+/** Pull email addresses out of vCard (.vcf) text — EMAIL lines (Apple Contacts export). */
+export function parseVcfEmails(text: string): string[] {
+  const out = new Set<string>();
+  for (const line of text.split(/\r?\n/)) {
+    const m = /^EMAIL[^:]*:(.+)$/i.exec(line.trim());
+    if (m) {
+      const addr = m[1].trim().toLowerCase();
+      if (addr.includes('@')) out.add(addr);
+    }
+  }
+  return [...out];
+}
+
+export class AddressListService {
+  constructor(private db: DatabaseService) {}
+
+  addEntry(userId: string, listType: ListType, rawValue: string, note?: string): ListEntry | null {
+    const norm = normalizeListValue(rawValue);
+    if (!norm) return null;
+    this.db.getDb().prepare(
+      `INSERT OR REPLACE INTO address_list_entries (user_id, list_type, value, value_type, note, created_at)
+       VALUES ($u, $t, $v, $vt, $n, $c)`
+    ).run({ $u: userId, $t: listType, $v: norm.value, $vt: norm.valueType, $n: note ?? null, $c: Date.now() });
+    return { listType, value: norm.value, valueType: norm.valueType, note: note ?? null, createdAt: Date.now() };
+  }
+
+  removeEntry(userId: string, listType: ListType, rawValue: string): boolean {
+    const norm = normalizeListValue(rawValue);
+    if (!norm) return false;
+    const info = this.db.getDb().prepare(
+      `DELETE FROM address_list_entries WHERE user_id = $u AND list_type = $t AND value = $v`
+    ).run({ $u: userId, $t: listType, $v: norm.value });
+    return Number(info.changes ?? 0) > 0;
+  }
+
+  listEntries(userId: string, listType?: ListType): ListEntry[] {
+    const params: Record<string, unknown> = { $u: userId };
+    let where = 'user_id = $u';
+    if (listType) { where += ' AND list_type = $t'; params.$t = listType; }
+    const rows = this.db.getDb().prepare(
+      `SELECT list_type, value, value_type, note, created_at FROM address_list_entries WHERE ${where} ORDER BY list_type, value`
+    ).all(params as any) as any[];
+    return rows.map((r) => ({ listType: r.list_type, value: r.value, valueType: r.value_type, note: r.note ?? null, createdAt: r.created_at }));
+  }
+
+  clear(userId: string, listType: ListType): number {
+    const info = this.db.getDb().prepare(
+      `DELETE FROM address_list_entries WHERE user_id = $u AND list_type = $t`
+    ).run({ $u: userId, $t: listType });
+    return Number(info.changes ?? 0);
+  }
+
+  /** Bulk add normalized addresses; returns added/skipped counts. */
+  importEntries(userId: string, listType: ListType, rawValues: string[], note?: string): { added: number; skipped: number } {
+    let added = 0, skipped = 0;
+    const raw = this.db.getDb();
+    raw.exec('BEGIN');
+    try {
+      for (const v of rawValues) {
+        if (this.addEntry(userId, listType, v, note)) added++; else skipped++;
+      }
+      raw.exec('COMMIT');
+    } catch (e) { try { raw.exec('ROLLBACK'); } catch { /* ignore */ } throw e; }
+    return { added, skipped };
+  }
+
+  /**
+   * Resolve a sender to a verdict. Email match beats domain match; at each level
+   * an allow entry beats a deny entry (an explicitly allowed sender is never
+   * denied). Returns the verdict + what matched, or null when unlisted.
+   */
+  check(userId: string, rawFrom: string): { verdict: Verdict; matchedValue: string | null; matchedType: ValueType | null } {
+    const norm = normalizeListValue(rawFrom);
+    if (!norm) return { verdict: null, matchedValue: null, matchedType: null };
+    const email = norm.valueType === 'email' ? norm.value : null;
+    const domain = norm.valueType === 'email' ? norm.value.slice(norm.value.lastIndexOf('@') + 1) : norm.value;
+
+    const rows = this.db.getDb().prepare(
+      `SELECT list_type, value, value_type FROM address_list_entries
+       WHERE user_id = $u AND (($et = 1 AND value = $email) OR (value = $domain AND value_type = 'domain'))`
+    ).all({ $u: userId, $email: email, $domain: domain, $et: email ? 1 : 0 }) as any[];
+
+    const has = (lt: ListType, vt: ValueType) => rows.find((r) => r.list_type === lt && r.value_type === vt);
+    // email level (allow then deny), then domain level (allow then deny)
+    for (const vt of ['email', 'domain'] as ValueType[]) {
+      const a = has('allow', vt); if (a) return { verdict: 'allow', matchedValue: a.value, matchedType: vt };
+      const d = has('deny', vt); if (d) return { verdict: 'deny', matchedValue: d.value, matchedType: vt };
+    }
+    return { verdict: null, matchedValue: null, matchedType: null };
+  }
+}

--- a/src/tools/address-list-tools.ts
+++ b/src/tools/address-list-tools.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// address-list-tools.ts — per-user allow/deny list management (#69/#70).
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { withErrorHandling } from '../utils/error-handler.js';
+import { DatabaseService } from '../services/database-service.js';
+import { resolveUserOrThrow } from '../utils/user-resolver.js';
+import { AddressListService, parseCsvEmails, parseVcfEmails } from '../services/address-list-service.js';
+
+const ListTypeSchema = z.enum(['allow', 'deny']);
+
+function json(obj: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(obj, null, 2) }] };
+}
+
+export function addressListTools(server: McpServer, db: DatabaseService): void {
+  const lists = new AddressListService(db);
+
+  server.registerTool('imap_add_list_entry', {
+    description:
+      'Add an entry to a per-user allow or deny list. Value may be an email address or a bare/`@`-prefixed domain ' +
+      '(e.g. "a@x.com" or "x.com"). Allow entries protect a sender; deny entries flag one. Normalized + deduped.',
+    inputSchema: {
+      userId: z.string().describe('User ID (UUID or username)'),
+      listType: ListTypeSchema.describe('allow or deny'),
+      value: z.string().describe('Email address or domain'),
+      note: z.string().optional().describe('Optional note'),
+    },
+  }, withErrorHandling(async ({ userId, listType, value, note }) => {
+    const uid = resolveUserOrThrow(db, userId);
+    const entry = lists.addEntry(uid, listType, value, note);
+    return entry
+      ? json({ success: true, added: entry })
+      : json({ success: false, message: `"${value}" is not a valid email address or domain.` });
+  }));
+
+  server.registerTool('imap_remove_list_entry', {
+    description: 'Remove an entry from a per-user allow or deny list (matches the normalized value).',
+    inputSchema: {
+      userId: z.string().describe('User ID (UUID or username)'),
+      listType: ListTypeSchema,
+      value: z.string().describe('Email address or domain to remove'),
+    },
+  }, withErrorHandling(async ({ userId, listType, value }) => {
+    const uid = resolveUserOrThrow(db, userId);
+    return json({ success: lists.removeEntry(uid, listType, value), value });
+  }));
+
+  server.registerTool('imap_list_entries', {
+    description: 'List a user\'s allow/deny entries (optionally filtered to one list).',
+    inputSchema: {
+      userId: z.string().describe('User ID (UUID or username)'),
+      listType: ListTypeSchema.optional().describe('Filter to allow or deny; omit for both'),
+    },
+  }, withErrorHandling(async ({ userId, listType }) => {
+    const uid = resolveUserOrThrow(db, userId);
+    const entries = lists.listEntries(uid, listType);
+    return json({ count: entries.length, entries });
+  }));
+
+  server.registerTool('imap_check_address', {
+    description:
+      'Check a sender (a plain address, or a full From header with display name) against the user\'s allow/deny lists. Returns the verdict ' +
+      '(allow / deny / null) and what matched. Email matches beat domain matches; allow beats deny at each level.',
+    inputSchema: {
+      userId: z.string().describe('User ID (UUID or username)'),
+      from: z.string().describe('Sender address or From header'),
+    },
+  }, withErrorHandling(async ({ userId, from }) => {
+    const uid = resolveUserOrThrow(db, userId);
+    return json({ from, ...lists.check(uid, from) });
+  }));
+
+  server.registerTool('imap_import_list', {
+    description:
+      'Bulk-import addresses into an allow/deny list from CSV or vCard (.vcf — including Apple Contacts exports). ' +
+      'Emails are extracted from the content (any CSV column; vCard EMAIL lines), normalized, and deduped.',
+    inputSchema: {
+      userId: z.string().describe('User ID (UUID or username)'),
+      listType: ListTypeSchema,
+      format: z.enum(['csv', 'vcf', 'auto']).optional().default('auto').describe('Source format (auto-detects vCard by BEGIN:VCARD)'),
+      content: z.string().describe('Raw file content (CSV or vCard text)'),
+      note: z.string().optional().describe('Optional note applied to all imported entries'),
+    },
+  }, withErrorHandling(async ({ userId, listType, format, content, note }) => {
+    const uid = resolveUserOrThrow(db, userId);
+    const fmt = format === 'auto' || !format ? (/BEGIN:VCARD/i.test(content) ? 'vcf' : 'csv') : format;
+    const emails = fmt === 'vcf' ? parseVcfEmails(content) : parseCsvEmails(content);
+    if (emails.length === 0) return json({ success: false, format: fmt, message: 'No email addresses found in the content.' });
+    const res = lists.importEntries(uid, listType, emails, note);
+    return json({ success: true, format: fmt, found: emails.length, ...res });
+  }));
+
+  server.registerTool('imap_clear_list', {
+    description: 'Remove ALL entries from a user\'s allow or deny list. Irreversible.',
+    inputSchema: {
+      userId: z.string().describe('User ID (UUID or username)'),
+      listType: ListTypeSchema,
+    },
+  }, withErrorHandling(async ({ userId, listType }) => {
+    const uid = resolveUserOrThrow(db, userId);
+    return json({ success: true, listType, removed: lists.clear(uid, listType) });
+  }));
+}

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -137,6 +137,14 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   // ---- admin-tools (1) ----
   'imap_server_reload':                NEUTRAL_IDEMPOTENT,
 
+  // ---- address-list-tools (6) ----
+  'imap_add_list_entry':               WRITE_LOCAL,
+  'imap_remove_list_entry':            WRITE_LOCAL,
+  'imap_list_entries':                 READ_ONLY,
+  'imap_check_address':                READ_ONLY,
+  'imap_import_list':                  WRITE_LOCAL,
+  'imap_clear_list':                   WRITE_LOCAL,
+
   // ---- bulk-job-tools (3) ----
   'imap_bulk_jobs':                    READ_ONLY,
   'imap_bulk_job_status':              READ_ONLY,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,6 +16,7 @@ import { folderTools } from './folder-tools.js';
 import { metaTools } from './meta-tools.js';
 import { adminTools } from './admin-tools.js';
 import { bulkJobTools } from './bulk-job-tools.js';
+import { addressListTools } from './address-list-tools.js';
 import { BulkJobService } from '../services/bulk-job-service.js';
 import { userTools } from './user-tools.js';
 import { userCheckTools } from './usercheck-tools.js';
@@ -125,6 +126,9 @@ export function registerTools(
 
   // Register bulk-job management tools (Issue #117 - job persistence).
   bulkJobTools(server, bulkJobs, db);
+
+  // Register per-user allow/deny list tools (Issues #69/#70)
+  addressListTools(server, db);
 
   // Register meta/discovery tools (passes webUIManager so meta-tools can expose
   // the imap_open_web_ui MCP tool when the embedded Web UI is available).


### PR DESCRIPTION
Per-user allow/deny lists of emails/domains. Migration 1.13.0→1.14.0 (`address_list_entries`), `AddressListService` (add/remove/list/clear, verdict resolution — email beats domain, allow beats deny; CSV + vCard/.vcf import incl. Apple Contacts), and 6 tools. 13 tests; tools 121→127. Web UI editor (#70) follows. Refs #69 #70.