### PR TITLE
chore: directory submission prep — tool titles, hints, privacy policy (#248)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,82 @@
+# Privacy Policy — IMAP MCP Pro
+
+**Last updated:** 2026-07-04
+**Publisher:** Temple of Epiphany
+**Contact:** colin.bitterfield@templeofepiphany.com
+
+IMAP MCP Pro is a **local** Model Context Protocol (MCP) server that runs on your
+own device (as a Claude Desktop `.mcpb` extension or a local process). It connects
+directly to the email accounts *you* configure. This policy describes what data it
+handles, where that data lives, and when — if ever — data leaves your machine.
+
+## Summary
+
+- **Runs locally.** All processing happens on your device. The publisher operates
+  no servers and receives none of your data.
+- **No telemetry or analytics.** The extension collects no usage data and phones
+  home to no one.
+- **Your data stays local** unless *you* enable an optional integration or perform
+  an action (sending mail, a spam/DNS lookup) that inherently contacts a third
+  party you chose.
+
+## What data is processed
+
+- **Email account credentials** (username, password/app-password, host/port, and
+  SMTP settings) that you enter.
+- **Email content and metadata** (headers, subjects, senders, bodies, attachments,
+  flags, folder structure) fetched from *your* mail servers when you ask Claude to
+  search, read, organize, export, or send mail.
+- **Optional API keys** you supply for integrations (e.g. a UserCheck API key).
+
+## Where data is stored
+
+- Everything is stored **on your device**, under `~/.imap-mcp/`:
+  - Credentials are **encrypted at rest with AES-256-GCM** using a file-based key
+    (`~/.imap-mcp/.encryption-key`, mode `0600`).
+  - The local SQLite database, cache, staged uploads, and exported files are
+    written with **owner-only permissions** (`0700`/`0600`).
+- The publisher never receives, stores, or has access to any of this.
+
+## When data leaves your device (only at your direction)
+
+- **Your mail servers** — the IMAP/SMTP servers you configure receive your
+  credentials and the commands/messages needed to read and send your mail. This is
+  the core function of the tool.
+- **UserCheck (optional)** — if you configure a UserCheck API key and run a spam
+  check, sender email addresses are sent to `usercheck.com` to assess reputation.
+  Results are cached locally.
+- **DNS-over-HTTPS provider (optional)** — DNS-firewall checks send domain names to
+  the configured provider (default: Quad9, `dns.quad9.net`) over HTTPS.
+- **Anthropic / Claude** — as an MCP tool, results you request are returned to the
+  Claude client you are using, subject to Anthropic's own privacy terms.
+
+No other third parties receive your data, and nothing is sent to the publisher.
+
+## Data retention & deletion
+
+- Data persists **locally** only until you delete it. You are in full control:
+  - Remove an account, clear the local cache/lists, or delete `~/.imap-mcp/`.
+  - Uninstalling the extension and removing that directory erases all local state.
+- There is **no server-side retention** because there is no server operated by the
+  publisher.
+
+## Security
+
+Credentials are encrypted at rest (AES-256-GCM); the data directory and database
+are owner-only. See [`SECURITY.md`](SECURITY.md) for the full security posture and
+how to report a vulnerability.
+
+## Children & sensitive data
+
+IMAP MCP Pro is a general-purpose email tool and is not directed at children. It
+does not intentionally process special-category data beyond whatever exists in the
+mailboxes you connect.
+
+## Changes
+
+Material changes to this policy will be recorded here and in
+[`CHANGELOG.md`](CHANGELOG.md).
+
+## Contact
+
+Questions about this policy: **colin.bitterfield@templeofepiphany.com**

--- a/README.md
+++ b/README.md
@@ -613,6 +613,20 @@ The restore script stops the service before replacing files and restarts it auto
 - Database is stored at `~/.imap-mcp/data.db`
 - Never commit or share your encryption keys or database
 
+## Privacy Policy
+
+IMAP MCP Pro runs **entirely on your device** and sends **no data to the
+publisher** — there is no telemetry and no server operated by us. It processes
+only the email accounts you configure; credentials are encrypted at rest
+(AES-256-GCM) and all local files are owner-only. Data leaves your machine only
+at your direction: to your own IMAP/SMTP servers, to optional integrations you
+enable (UserCheck for spam checks, a DNS-over-HTTPS provider for firewall
+checks), and to the Claude client you use. Data persists locally only until you
+delete it (remove an account, clear the cache, or delete `~/.imap-mcp/`).
+
+Full policy — data collected, storage, third-party sharing, retention, and
+contact: **[PRIVACY.md](PRIVACY.md)**.
+
 ## Development
 
 ### Running in Development Mode

--- a/dxt/manifest.template.json
+++ b/dxt/manifest.template.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/Temple-of-Epiphany/imap-mcp-pro",
   "documentation": "https://github.com/Temple-of-Epiphany/imap-mcp-pro#readme",
   "support": "https://github.com/Temple-of-Epiphany/imap-mcp-pro/issues",
+  "privacy_policies": ["https://github.com/Temple-of-Epiphany/imap-mcp-pro/blob/main/PRIVACY.md"],
   "icon": "icon.png",
   "screenshots": [],
   "keywords": ["email", "imap", "smtp", "mailbox", "mcp", "spam", "outlook", "gmail"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,8 +303,10 @@ async function buildToolsManifest(): Promise<unknown> {
   const internal = (tmpServer as any)._registeredTools as Record<string, any> | undefined;
   const tools: Array<{
     name: string;
+    title?: string;
     description?: string;
     inputSchema: unknown;
+    annotations?: unknown;
   }> = [];
 
   if (internal) {
@@ -328,8 +330,11 @@ async function buildToolsManifest(): Promise<unknown> {
 
       tools.push({
         name,
+        // Directory requirement: every tool has a human-readable title + hints.
+        title: t?.title ?? t?.annotations?.title ?? undefined,
         description: t?.description ?? undefined,
         inputSchema: inputSchemaJson,
+        annotations: t?.annotations ?? undefined,
       });
     }
   }

--- a/src/tools/annotations.test.ts
+++ b/src/tools/annotations.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for tool titles + annotation hints — required for the Anthropic
+// directory ("all tools must include a title and a read-only/destructive hint").
+
+import { describe, expect, it } from 'vitest';
+import { titleFromName, getAnnotations } from './annotations.js';
+
+describe('titleFromName', () => {
+  it.each([
+    ['imap_search_emails', 'Search Emails'],
+    ['imap_get_smtp_metrics', 'Get SMTP Metrics'],
+    ['imap_test_quad9_dns', 'Test Quad9 DNS'],
+    ['imap_bulk_job_status', 'Bulk Job Status'],
+    ['imap_add_usercheck_key', 'Add UserCheck Key'],
+    ['imap_import_list', 'Import List'],
+    ['imap_get_quota', 'Get Quota'],
+  ])('%s → %s', (name, title) => {
+    expect(titleFromName(name)).toBe(title);
+  });
+
+  it('never produces an empty title', () => {
+    for (const n of ['imap_about', 'imap_results', 'imap_help']) {
+      expect(titleFromName(n).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('getAnnotations always yields a read-only or destructive hint', () => {
+  it.each([
+    'imap_search_emails', 'imap_delete_email', 'imap_add_list_entry', 'imap_check_address',
+    'imap_scan_account_spam_start', 'imap_bulk_job_cancel', 'imap_test_categories',
+    'imap_some_unknown_future_tool', // fallback path
+  ])('%s has a defined hint', (name) => {
+    const a = getAnnotations(name);
+    expect(a.readOnlyHint === true || a.destructiveHint === true).toBe(true);
+  });
+});

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -44,9 +44,10 @@ const READ_REMOTE: ToolAnnotations = { readOnlyHint: true, destructiveHint: fals
 const WRITE_LOCAL: ToolAnnotations = { readOnlyHint: false, destructiveHint: true };
 const WRITE_REMOTE: ToolAnnotations = { readOnlyHint: false, destructiveHint: true, openWorldHint: true };
 
-/** Connect/disconnect: not really destructive (idempotent), not really
- *  read-only (state changes, but transient and recoverable). */
-const NEUTRAL_IDEMPOTENT: ToolAnnotations = { idempotentHint: true, openWorldHint: true };
+/** Connect/disconnect/reload: state changes (so not read-only) but not
+ *  destructive of user data. Both hints are set explicitly (false) so every
+ *  tool carries an applicable read-only/destructive hint per the directory. */
+const NEUTRAL_IDEMPOTENT: ToolAnnotations = { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true };
 
 export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   // ---- account-tools (8) ----
@@ -238,4 +239,26 @@ function fallbackFromName(name: string): ToolAnnotations {
 
 export function getAnnotations(toolName: string): ToolAnnotations {
   return TOOL_ANNOTATIONS[toolName] ?? fallbackFromName(toolName);
+}
+
+// Acronyms/proper-nouns to preserve when title-casing a tool name.
+const TITLE_ACRONYMS: Record<string, string> = {
+  imap: 'IMAP', smtp: 'SMTP', dns: 'DNS', uid: 'UID', url: 'URL', eml: 'EML', ui: 'UI',
+  id: 'ID', ip: 'IP', mx: 'MX', tls: 'TLS', quad9: 'Quad9', usercheck: 'UserCheck',
+  fts: 'FTS', csv: 'CSV', vcf: 'VCF', api: 'API', rfc9051: 'RFC 9051',
+};
+
+/**
+ * Human-readable display title derived from a tool name — required for the
+ * Anthropic directory ("all tools must include a title"). e.g.
+ * `imap_search_emails` → "Search Emails", `imap_get_smtp_metrics` → "Get SMTP
+ * Metrics". A tool may still override this by passing its own `title`.
+ */
+export function titleFromName(name: string): string {
+  return name
+    .replace(/^imap_/, '')
+    .split('_')
+    .filter(Boolean)
+    .map((w) => TITLE_ACRONYMS[w] ?? (w.charAt(0).toUpperCase() + w.slice(1)))
+    .join(' ');
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -28,7 +28,7 @@ import { categoryTools } from './category-tools.js';
 import { resultTools } from './result-tools.js';
 import { cacheTools } from './cache-tools.js';
 import { skillsTools } from './skills-tools.js';
-import { getAnnotations } from './annotations.js';
+import { getAnnotations, titleFromName } from './annotations.js';
 
 /**
  * Wrap server.registerTool so every call gets MCP annotations injected
@@ -42,9 +42,14 @@ import { getAnnotations } from './annotations.js';
 function withAnnotations<T extends McpServer>(server: T): () => void {
   const original = (server as any).registerTool.bind(server);
   (server as any).registerTool = (name: string, config: any, handler: any) => {
+    // Every tool gets a human-readable title (Anthropic directory requirement),
+    // auto-derived from its name unless the call site set one. Applied at both
+    // the top level and in annotations so either read path sees it.
+    const title = config?.title ?? config?.annotations?.title ?? titleFromName(name);
     const merged = {
       ...config,
-      annotations: { ...getAnnotations(name), ...(config?.annotations ?? {}) },
+      title,
+      annotations: { title, ...getAnnotations(name), ...(config?.annotations ?? {}) },
     };
     return original(name, merged, handler);
   };


### PR DESCRIPTION
Meets the Anthropic **Desktop Extensions** directory requirements: every tool now has a **title** (auto-derived in `withAnnotations`) + an applicable read-only/destructive **hint** (incl. the neutral connect/disconnect/reload tools); adds **PRIVACY.md** + `privacy_policies` manifest URL + a README Privacy section. 16 new tests; 283→299. Closes #248.