### PR TITLE
chore: purely-descriptive tool descriptions for directory review (#248)

### DIFF
--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -258,7 +258,7 @@ export function accountTools(
 
   // Add account using a named provider preset
   server.registerTool('imap_add_account_with_provider', {
-    description: 'Add a new IMAP account using a provider preset (auto-fills IMAP/SMTP settings). Use imap_list_providers to see available providers.',
+    description: 'Add a new IMAP account using a provider preset (auto-fills IMAP/SMTP settings). Available providers are listed by imap_list_providers.',
     inputSchema: {
       providerId: z.string().describe('Provider ID (e.g., "gmail", "outlook", "yahoo"). Use imap_list_providers to see all options.'),
       name: z.string().describe('Friendly name for the account'),

--- a/src/tools/bulk-job-tools.ts
+++ b/src/tools/bulk-job-tools.ts
@@ -46,7 +46,7 @@ export function bulkJobTools(server: McpServer, jobs: BulkJobService, db: Databa
   server.registerTool('imap_bulk_jobs', {
     description:
       'List persistent bulk-operation jobs (long-running scans) with status and progress. ' +
-      'Filter by status; scope to a user. Use imap_bulk_job_status for one job\'s detail.',
+      'Filter by status; scope to a user. Per-job detail is available from imap_bulk_job_status.',
     inputSchema: {
       userId: z.string().optional().describe('Scope to this user (UUID or username); omit for all'),
       status: StatusSchema.optional().describe('Filter by status'),

--- a/src/tools/cache-tools.ts
+++ b/src/tools/cache-tools.ts
@@ -58,7 +58,7 @@ export function cacheTools(
       'Populate the local message header cache for one folder. Idempotent: ' +
       'subsequent calls only fetch new UIDs since the last sync. Returns ' +
       'row counts + duration. UIDVALIDITY change triggers a full resync. ' +
-      'Required before imap_search_cache will return results.',
+      'imap_search_cache returns results only for folders that have been synced here.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().describe('Folder name (e.g. "INBOX")'),
@@ -85,8 +85,8 @@ export function cacheTools(
       'from_address match), group_by_sender (top-N senders by message count), ' +
       'fulltext (FTS5 ranked search over subject + sender name/address — for ' +
       'partial-recall queries; no message bodies are searched). ' +
-      'Returns explicit cache_miss error if the folder has not been synced — ' +
-      'call imap_sync_folder_cache first.',
+      'Returns an explicit cache_miss error for a folder that has not been synced ' +
+      '(see imap_sync_folder_cache).',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().describe('Folder name'),

--- a/src/tools/category-tools.ts
+++ b/src/tools/category-tools.ts
@@ -296,7 +296,7 @@ export function categoryTools(
     description:
       'Dry-run the Quick Categories against a folder WITHOUT moving any email: reports coverage (% that would ' +
       'be categorized), per-category counts + destination, which keyword triggered each match, emails matching ' +
-      'multiple categories (conflicts), and the uncategorized set. Use to tune keywords before imap_apply_categories.',
+      'multiple categories (conflicts), and the uncategorized set. Helps tune keywords ahead of imap_apply_categories.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder to test against (default: INBOX)'),

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -264,7 +264,7 @@ export function emailTools(
       'Search for emails in a folder. Default limit is 50. ' +
       'Inline mode (default for small results) caps at 100 to prevent token overflow; ' +
       "set responseMode='handle' or 'file' to return a resultId for larger sets (up to 10,000). " +
-      "Use imap_results action='get' to page through handle results.",
+      "Handle results are paged through imap_results (action='get').",
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name (default: INBOX)'),
@@ -549,7 +549,7 @@ export function emailTools(
       'Set the priority (high / normal / low) of one or more messages. Because IMAP messages are immutable, ' +
       'this is stored as a custom IMAP keyword ($Priority-High / $Priority-Low) via STORE, not by rewriting the ' +
       'X-Priority header; "normal" clears the keyword. Some servers may not allow custom keywords — the result ' +
-      'reports whether the server accepted it. To set real priority headers on outgoing mail, use imap_send_email.',
+      'reports whether the server accepted it. Real priority headers on outgoing mail are set by imap_send_email.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder containing the messages (default: INBOX)'),

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -175,8 +175,8 @@ export function folderTools(
   server.registerTool('imap_get_quota', {
     description:
       'Report account storage quota — used / limit / percent — via the IMAP QUOTA extension (RFC 9208). ' +
-      'Returns supported:false when the server does not advertise QUOTA. (For a single mailbox size, ' +
-      'use imap_get_mailbox_status, which reports SIZE via STATUS=SIZE.)',
+      'Returns supported:false when the server does not advertise QUOTA. (A single mailbox\'s size ' +
+      'is reported by imap_get_mailbox_status via STATUS=SIZE.)',
     inputSchema: {
       accountId,
       mailbox: z.string().optional().default('INBOX').describe('Mailbox whose quota root to query (default: INBOX)'),

--- a/src/tools/meta-tools.ts
+++ b/src/tools/meta-tools.ts
@@ -589,8 +589,8 @@ export function metaTools(server: McpServer, webUIManager?: WebUIManager): void 
     description:
       'Show IMAP MCP Pro capabilities and copy-paste workflow recipes, by category. Start with no argument (or ' +
       'category="overview") for the topic list. Categories: overview, getting-started, reading, sending, ' +
-      'organizing, cleanup, subscriptions, security, bulk, workflows, admin. For the exhaustive tool list use ' +
-      'imap_list_tools.',
+      'organizing, cleanup, subscriptions, security, bulk, workflows, admin. The exhaustive tool list is available ' +
+      'from imap_list_tools.',
     inputSchema: {
       category: z.enum([
         'overview', 'getting-started', 'reading', 'sending', 'organizing',

--- a/src/tools/skills-tools.ts
+++ b/src/tools/skills-tools.ts
@@ -91,8 +91,8 @@ export function skillsTools(
       'to ~/.claude/skills/imap-mcp-pro/{name}/, preserves files when the ' +
       'on-disk version is already at or ahead of remote unless force=true. ' +
       'Skills not present in the bundled manifest are rejected (the manifest ' +
-      'is the allowlist). Always pair with imap_check_skill_updates first to ' +
-      'see what would change.',
+      'is the allowlist). imap_check_skill_updates reports what would change ' +
+      'before any update is applied.',
     inputSchema: {
       skills: z.array(z.string()).min(1)
         .describe('Skill names to update (must be in the bundled manifest). Required and non-empty.'),

--- a/src/tools/subscription-tools.ts
+++ b/src/tools/subscription-tools.ts
@@ -38,8 +38,8 @@ export function registerSubscriptionTools(
     description:
       'Read-only: for a block of messages (explicit UIDs, or a folder scan up to `limit`), return per ' +
       'message the unsubscribe links found in BOTH the List-Unsubscribe header and the body, along with ' +
-      'sender, recipient, and subject. Does NOT write to the subscriptions database or send anything — ' +
-      'use imap_extract_unsubscribe_links for the stored/managed flow, or imap_execute_unsubscribe to act.',
+      'sender, recipient, and subject. Does NOT write to the subscriptions database or send anything; ' +
+      'the stored/managed flow is imap_extract_unsubscribe_links, and imap_execute_unsubscribe performs an unsubscribe.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name (default: INBOX)'),


### PR DESCRIPTION
Reworded 11 tool descriptions from imperative cross-tool directives ("use/call X first") to descriptive statements, per the Anthropic directory rule ("describe what the tool does; don't tell Claude how to behave"). No behavior change; 299 tests pass. Refs #248.