### PR TITLE
fix(web): show the real running version in the Web UI (was hardcoded)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,7 +52,7 @@
                     </div>
                     <div class="flex items-center space-x-4">
                         <div id="versionBadge" class="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
-                            <span id="versionText">v2.13.1</span>
+                            <span id="versionText">v…</span>
                         </div>
                         <button onclick="showProfile()" class="text-gray-600 hover:text-gray-900 flex items-center">
                             <span class="mr-2">👤</span>Profile
@@ -673,6 +673,6 @@
         </main>
     </div>
 
-    <script src="js/app.js?v=2.23.0"></script>
+    <script src="js/app.js?v=2.28.1"></script>
 </body>
 </html>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -269,6 +269,9 @@ async function loadProfile() {
       document.getElementById('profileDbPath').textContent = result.profile.databasePath;
       document.getElementById('profileDbSize').textContent = formatBytes(result.profile.databaseSize);
       document.getElementById('profileVersion').textContent = result.profile.version;
+      // Keep the header badge in sync with the real running version (#version-badge).
+      const badge = document.getElementById('versionText');
+      if (badge && result.profile.version) badge.textContent = 'v' + result.profile.version;
     }
   } catch (error) {
     console.error('Failed to load profile:', error);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -15,6 +15,7 @@ import { UserCheckService } from '../services/usercheck-service.js';
 import { emailProviders, getProviderByEmail } from '../providers/email-providers.js';
 import { dnsProviders } from '../providers/dns-providers.js';
 import { ImapAccount } from '../types/index.js';
+import { PACKAGE_VERSION } from '../utils/package-info.js';
 import crypto from 'crypto';
 
 /** Return a copy of `obj` with all `undefined`-valued keys removed. */
@@ -1006,7 +1007,7 @@ export class WebUIServer {
             userId: this.defaultUserId,
             databasePath: dbPath,
             databaseSize: dbSize,
-            version: '2.12.0'
+            version: PACKAGE_VERSION
           }
         });
       } catch (error) {
@@ -1316,7 +1317,7 @@ export class WebUIServer {
             userAccounts: accountCount
           },
           server: {
-            version: '2.9.0',
+            version: PACKAGE_VERSION,
             port: this.port,
             features: ['multi-tenant', 'account-sharing', 'encrypted-storage', 'usercheck-integration', 'confidence-scoring']
           }


### PR DESCRIPTION
The header badge (`v2.13.1`) and `/api/profile` / status endpoints (`2.12.0`/`2.9.0`) were hardcoded and never wired to package.json — so the UI showed a stale version. Wire all three to `PACKAGE_VERSION`; app.js fills the badge from `/api/profile`; bumped the app.js cache-bust.