### PR TITLE
feat: per-account email signatures (#257)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,12 +4,12 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**127 MCP tools** total.
+**129 MCP tools** total.
 
 ## Categories
 
 - [Users (MSP multi-tenant)](#users-msp-multitenant) — 3
-- [Account management](#account-management) — 15
+- [Account management](#account-management) — 17
 - [Bulk operations](#bulk-operations) — 15
 - [Size, export & quota](#size-export-quota) — 8
 - [Attachment staging](#attachment-staging) — 6
@@ -46,9 +46,11 @@
 | `imap_db_list_accounts` | List all IMAP accounts for a user |
 | `imap_db_remove_account` | Remove IMAP account from database |
 | `imap_disconnect` | Disconnect from an IMAP account |
+| `imap_get_account_signature` | Get the per-account email signature (plain text + HTML). |
 | `imap_list_accounts` | List all IMAP accounts for current user (from MCP_USER_ID environment variable) |
 | `imap_list_providers` | List all available email provider presets (Gmail, Outlook, Yahoo, etc.) with pre-configured IMAP/SMTP settings |
 | `imap_remove_account` | Remove an IMAP account from database |
+| `imap_set_account_signature` | Set the per-account email signature appended to outgoing messages (plain text and/or HTML). |
 | `imap_share_account` | Share an account with another user (MSP feature) |
 | `imap_test_account` | Test an existing account's IMAP connectivity using its stored credentials. |
 | `imap_unshare_account` | Revoke account access from a user |

--- a/scripts/gen-tool-catalog.mjs
+++ b/scripts/gen-tool-catalog.mjs
@@ -32,7 +32,7 @@ const outPath = path.join(repoRoot, 'docs', 'TOOL_CATALOG.md');
 // (e.g. *_chunked, db_*) ahead of broader ones.
 const CATEGORIES = [
   ['Users (MSP multi-tenant)', /^imap_(create_user|get_user|list_users)$/],
-  ['Account management', /^imap_(add_account|add_account_auto|add_account_with_provider|remove_account|list_accounts|connect|disconnect|test_account|share_account|unshare_account|list_providers|db_add_account|db_get_account|db_list_accounts|db_remove_account)$/],
+  ['Account management', /^imap_(add_account|add_account_auto|add_account_with_provider|remove_account|list_accounts|connect|disconnect|test_account|share_account|unshare_account|list_providers|set_account_signature|get_account_signature|db_add_account|db_get_account|db_list_accounts|db_remove_account)$/],
   ['Bulk operations', /^imap_bulk_/],
   ['Size, export & quota', /^imap_(get_email_sizes|get_largest_emails|export_email|export_folder|export_account|extract_attachments|get_attachment|get_quota)$/],
   ['Attachment staging', /^imap_(attachment_stage_|list_staged_attachments|get_outbox_dir)/],

--- a/src/database/migrations-manifest.json
+++ b/src/database/migrations-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.14.0",
+  "schemaVersion": "1.15.0",
   "description": "Release-indexed manifest of schema migrations. Each entry is applied in order via the `schema_version` ledger. A migration is complete when its `to` version is present in the ledger.",
   "migrations": [
     {
@@ -93,6 +93,13 @@
       "file": "schema_update_1.13.0_TO_1.14.0.sql",
       "rollbackFile": "schema_update_1.13.0_TO_1.14.0.down.sql",
       "description": "Add address_list_entries (per-user allow/deny lists, #69/#70)"
+    },
+    {
+      "from": "1.14.0",
+      "to": "1.15.0",
+      "file": "schema_update_1.14.0_TO_1.15.0.sql",
+      "rollbackFile": "schema_update_1.14.0_TO_1.15.0.down.sql",
+      "description": "Add per-account signature_text/signature_html (signatures)"
     }
   ]
 }

--- a/src/database/schema_update_1.14.0_TO_1.15.0.down.sql
+++ b/src/database/schema_update_1.14.0_TO_1.15.0.down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 1.14.0 → 1.15.0. SQLite < 3.35 cannot DROP COLUMN; on modern
+-- SQLite (node:sqlite) these succeed. Safe to no-op if unsupported.
+ALTER TABLE accounts DROP COLUMN signature_html;
+ALTER TABLE accounts DROP COLUMN signature_text;

--- a/src/database/schema_update_1.14.0_TO_1.15.0.sql
+++ b/src/database/schema_update_1.14.0_TO_1.15.0.sql
@@ -1,0 +1,9 @@
+-- Schema migration 1.14.0 → 1.15.0
+-- Per-account email signatures (plain-text + optional HTML), appended to
+-- outgoing mail by imap_send_email / reply / forward unless disabled.
+--
+-- Author: Colin Bitterfield <colin.bitterfield@templeofepiphany.com>
+-- Date: 2026-07-04
+
+ALTER TABLE accounts ADD COLUMN signature_text TEXT;
+ALTER TABLE accounts ADD COLUMN signature_html TEXT;

--- a/src/services/database-service.ts
+++ b/src/services/database-service.ts
@@ -471,8 +471,26 @@ export class DatabaseService {
       created_at: account.created_at,
       updated_at: account.updated_at,
       last_connected: account.last_connected,
-      is_active: account.is_active
+      is_active: account.is_active,
+      signature_text: (account as any).signature_text ?? null,
+      signature_html: (account as any).signature_html ?? null
     };
+  }
+
+  /** Set (or clear, with null) an account's plain-text and/or HTML signature (#signatures). */
+  setAccountSignature(accountId: string, sig: { text?: string | null; html?: string | null }): void {
+    const fields: string[] = [];
+    const values: any = { $id: accountId };
+    if (sig.text !== undefined) { fields.push('signature_text = $text'); values.$text = sig.text; }
+    if (sig.html !== undefined) { fields.push('signature_html = $html'); values.$html = sig.html; }
+    if (fields.length === 0) return;
+    this.db.prepare(`UPDATE accounts SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE account_id = $id`).run(values);
+  }
+
+  /** Get an account's signature (text + html), or null if the account is gone. */
+  getAccountSignature(accountId: string): { text: string | null; html: string | null } | null {
+    const row = this.db.prepare('SELECT signature_text, signature_html FROM accounts WHERE account_id = ?').get(accountId) as any;
+    return row ? { text: row.signature_text ?? null, html: row.signature_html ?? null } : null;
   }
 
   listAccountsForUser(userId: string): Account[] {

--- a/src/tools/account-tools.test.ts
+++ b/src/tools/account-tools.test.ts
@@ -66,10 +66,12 @@ describe('accountTools', () => {
       'imap_add_account_with_provider',
       'imap_connect',
       'imap_disconnect',
+      'imap_get_account_signature',
       'imap_get_outbox_dir',
       'imap_list_accounts',
       'imap_list_providers',
       'imap_remove_account',
+      'imap_set_account_signature',
       'imap_test_account',
     ]);
   });

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -424,4 +424,34 @@ export function accountTools(
       durationMs: result.durationMs,
     });
   })));
+
+  // Set an account's signature (appended to outgoing mail by imap_send_email).
+  server.registerTool('imap_set_account_signature', {
+    description:
+      'Set the per-account email signature appended to outgoing messages (plain text and/or HTML). ' +
+      'Pass clear:true to remove the signature. The signature is added after the body under the standard ' +
+      '"-- " delimiter; imap_send_email includeSignature:false suppresses it for a single send.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      text: z.string().optional().describe('Plain-text signature'),
+      html: z.string().optional().describe('HTML signature (optional; text is used for plain-text parts)'),
+      clear: z.boolean().optional().default(false).describe('Remove the signature (ignores text/html)'),
+    },
+  }, withErrorHandling(async ({ accountId, text, html, clear }) => {
+    if (!db.getAccount(accountId)) throw new AccountNotFoundError(accountId);
+    if (clear) db.setAccountSignature(accountId, { text: null, html: null });
+    else db.setAccountSignature(accountId, { text, html });
+    const sig = db.getAccountSignature(accountId);
+    return { content: [{ type: 'text', text: JSON.stringify({ success: true, accountId, signature: sig, cleared: !!clear }, null, 2) }] };
+  }));
+
+  // Get an account's signature.
+  server.registerTool('imap_get_account_signature', {
+    description: 'Get the per-account email signature (plain text + HTML).',
+    inputSchema: { accountId: z.string().describe('Account ID') },
+  }, withErrorHandling(async ({ accountId }) => {
+    const sig = db.getAccountSignature(accountId);
+    if (!sig) throw new AccountNotFoundError(accountId);
+    return { content: [{ type: 'text', text: JSON.stringify({ accountId, signature: sig, hasSignature: !!(sig.text || sig.html) }, null, 2) }] };
+  }));
 }

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -61,6 +61,8 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_list_providers':               READ_ONLY,
   'imap_share_account':                WRITE_LOCAL,
   'imap_unshare_account':              WRITE_LOCAL,
+  'imap_set_account_signature':        WRITE_LOCAL,
+  'imap_get_account_signature':        READ_ONLY,
 
   // ---- email-tools — search/get/list (read-remote) ----
   'imap_search_emails':                READ_REMOTE,

--- a/src/tools/email-signature.test.ts
+++ b/src/tools/email-signature.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for account signatures — applySignature helper + DB set/get (#signatures).
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { applySignature } from './email-tools.js';
+import { DatabaseService } from '../services/database-service.js';
+
+describe('applySignature', () => {
+  const sig = { text: 'Jane Doe\nAcme Corp', html: '<b>Jane Doe</b><br>Acme Corp' };
+
+  it('appends the text signature under the "-- " delimiter', () => {
+    const r = applySignature('Hello', undefined, sig, true);
+    expect(r.text).toBe('Hello\n\n-- \nJane Doe\nAcme Corp');
+  });
+
+  it('appends the html signature to the html part', () => {
+    const r = applySignature(undefined, '<p>Hi</p>', sig, true);
+    expect(r.html).toBe('<p>Hi</p><br><br>-- <br><b>Jane Doe</b><br>Acme Corp');
+  });
+
+  it('derives an html signature from a text-only sig when the body is html', () => {
+    const r = applySignature('Hi', '<p>Hi</p>', { text: 'A & B\n<x>' }, true);
+    expect(r.html).toBe('<p>Hi</p><br><br>-- <br>A &amp; B<br>&lt;x&gt;'); // escaped + newline→br
+    expect(r.text).toBe('Hi\n\n-- \nA & B\n<x>');
+  });
+
+  it('is a no-op when suppressed or no signature', () => {
+    expect(applySignature('Hi', undefined, sig, false)).toEqual({ text: 'Hi', html: undefined });
+    expect(applySignature('Hi', undefined, null, true)).toEqual({ text: 'Hi', html: undefined });
+    expect(applySignature('Hi', undefined, { text: null, html: null }, true)).toEqual({ text: 'Hi', html: undefined });
+  });
+});
+
+describe('DatabaseService signature methods', () => {
+  let tmpDir: string, db: DatabaseService;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'imap-sig-'));
+    db = new DatabaseService({ dbPath: path.join(tmpDir, 'data.db') });
+    db.getDb().exec('PRAGMA foreign_keys = OFF');
+    db.getDb().prepare(
+      `INSERT INTO accounts (account_id, user_id, name, host, port, username, password_encrypted, encryption_iv)
+       VALUES ('acc','u','Test','imap.x.com',993,'me@x.com','enc','iv')`
+    ).run();
+  });
+  afterEach(async () => { try { db.close(); } catch { /* */ } await fs.rm(tmpDir, { recursive: true, force: true }); });
+
+  it('sets, reads, and clears a signature', () => {
+    expect(db.getAccountSignature('acc')).toEqual({ text: null, html: null });
+    db.setAccountSignature('acc', { text: 'Sig', html: '<b>Sig</b>' });
+    expect(db.getAccountSignature('acc')).toEqual({ text: 'Sig', html: '<b>Sig</b>' });
+    db.setAccountSignature('acc', { text: null, html: null });
+    expect(db.getAccountSignature('acc')).toEqual({ text: null, html: null });
+  });
+
+  it('returns null for an unknown account', () => {
+    expect(db.getAccountSignature('nope')).toBeNull();
+  });
+});

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -47,6 +47,32 @@ function isPdfAttachment(filename: string, contentType: string): boolean {
   return attExt(filename) === 'pdf' || /\/pdf$/i.test(contentType || '');
 }
 
+const SIG_DELIM_TEXT = '\n\n-- \n';   // RFC 3676 signature delimiter
+const SIG_DELIM_HTML = '<br><br>-- <br>';
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Append an account's signature to the outgoing body (#signatures). Text sig
+ * goes on the text part; HTML sig on the html part (a text-only sig is escaped
+ * onto the html part when the message has an html body but no html sig).
+ */
+export function applySignature(
+  text: string | undefined,
+  html: string | undefined,
+  sig: { text?: string | null; html?: string | null } | null | undefined,
+  include: boolean | undefined,
+): { text: string | undefined; html: string | undefined } {
+  if (include === false || !sig || (!sig.text && !sig.html)) return { text, html };
+  let outText = text, outHtml = html;
+  if (sig.text) outText = (text ?? '') + SIG_DELIM_TEXT + sig.text;
+  if (sig.html) outHtml = (html ?? '') + SIG_DELIM_HTML + sig.html;
+  else if (sig.text && html !== undefined) outHtml = html + SIG_DELIM_HTML + escapeHtml(sig.text).replace(/\n/g, '<br>');
+  return { text: outText, html: outHtml };
+}
+
 function shouldUseHandle(mode: ResponseModeOpt, n: number): boolean {
   if (mode === 'inline') return false;
   if (mode === 'handle' || mode === 'file') return true;
@@ -1010,6 +1036,9 @@ export function emailTools(
         'ceiling (~10 MB) and is not on the server host. For small files in a Workspace/sandbox, ' +
         'prefer the inline `attachments` form — it avoids the multi-call staging dance.'
       ),
+      includeSignature: z.boolean().optional().default(true).describe(
+        'Append the account signature (set via imap_set_account_signature) to the body. Default true.'
+      ),
       appendToSent: z.boolean().optional().default(true).describe(
         'Append the sent message to the IMAP Sent folder after a successful SMTP send. Default true.'
       ),
@@ -1027,7 +1056,7 @@ export function emailTools(
     accountId, to, subject, text, html, cc, bcc, replyTo, attachments,
     attachmentPaths, attachmentContentTypes, attachmentFilenames,
     stagedAttachmentIds,
-    appendToSent, sentFolderOverride, forceAppendToSent, isReply,
+    includeSignature, appendToSent, sentFolderOverride, forceAppendToSent, isReply,
   }) => {
     const dbAccount = db.getDecryptedAccount(accountId);
     if (!dbAccount) {
@@ -1308,9 +1337,14 @@ export function emailTools(
       }
     }
 
+    // Append the account signature (if any) unless suppressed.
+    const { text: sigText, html: sigHtml } = applySignature(
+      text, html, db.getAccountSignature(accountId), includeSignature,
+    );
+
     const emailComposer = {
       from: account.user,
-      to, subject, text, html, cc, bcc, replyTo,
+      to, subject, text: sigText, html: sigHtml, cc, bcc, replyTo,
       attachments: [
         ...sanitizedInlineAttachments,
         ...validatedPathAttachments,

--- a/src/types/database-types.ts
+++ b/src/types/database-types.ts
@@ -40,6 +40,8 @@ export interface Account {
   updated_at: string;
   last_connected?: string;
   is_active: boolean;
+  signature_text?: string | null;
+  signature_html?: string | null;
 }
 
 export interface DecryptedAccount {
@@ -60,6 +62,8 @@ export interface DecryptedAccount {
   updated_at: string;
   last_connected?: string;
   is_active: boolean;
+  signature_text?: string | null;
+  signature_html?: string | null;
 }
 
 export interface UserAccount {


### PR DESCRIPTION
Per-account signature (text + optional HTML) appended to outgoing mail by `imap_send_email` under the standard `-- ` delimiter (`includeSignature:false` suppresses). Migration 1.14.0→1.15.0; `imap_set_account_signature` / `imap_get_account_signature`. 8 tests; tools 127→129. Closes #257.