### PR TITLE
fix: Sent-copy auto-connects IMAP + surfaces real APPEND error (#261)

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -1547,16 +1547,25 @@ export class ImapService {
       // ImapFlow API: append(path, content, flags?, idate?). The 3rd & 4th
       // args are POSITIONAL — passing { flags, internalDate } as one object
       // (the previous shape here) silently breaks the APPEND.
-      const result = await client.append(
-        mailboxName,
-        messageContent,
-        options?.flags,
-        options?.internalDate
-      );
+      let result;
+      try {
+        result = await client.append(
+          mailboxName,
+          messageContent,
+          options?.flags,
+          options?.internalDate
+        );
+      } catch (e: any) {
+        // Surface the real server reason (e.g. [OVERQUOTA] mailbox full) instead
+        // of ImapFlow's generic "Command failed" (#261).
+        const code = e?.serverResponseCode ? ` [${e.serverResponseCode}]` : '';
+        const detail = e?.responseText || e?.response || e?.message || 'unknown error';
+        throw new Error(`APPEND to "${mailboxName}" failed${code}: ${detail}`);
+      }
 
       // Handle false return (failed append) or successful AppendResponseObject
       if (!result) {
-        throw new Error('APPEND command failed');
+        throw new Error(`APPEND to "${mailboxName}" failed: server returned no result`);
       }
 
       return {

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -1405,6 +1405,26 @@ export function emailTools(
     }
 
     // ---- 3. Resolve Sent folder ----
+    // The SMTP send self-connects, but resolving the Sent folder and APPENDing
+    // the copy need an active IMAP connection. Ensure one (idempotent — no-op
+    // if already connected) so archiving doesn't fail with "no-sent-folder-found"
+    // when the account hasn't been imap_connect'd first (#261).
+    try {
+      await imapService.connect(account);
+    } catch (e: any) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            ...baseResult,
+            result: 'sent_not_archived',
+            archiveSkipped: 'imap-connect-failed',
+            archiveError: e?.message,
+          }, null, 2)
+        }]
+      };
+    }
+
     let resolved;
     try {
       resolved = await sentFolder.resolveSentFolder(accountId, {


### PR DESCRIPTION
Live test showed sent mail wasn't landing in Sent. Fixes: (1) `appendMessage` surfaces the real server error (e.g. `[OVERQUOTA] mailbox full`) instead of "Command failed"; (2) `imap_send_email` auto-connects IMAP (idempotent) before Sent resolution/APPEND so it no longer fails with "no-sent-folder-found" when not pre-connected. Verified end-to-end against Hostinger. Refs #261.