### PR TITLE
release: v2.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.29.1] - 2026-07-04
+
+### Fixed
+- **Sent-folder copy** (#261): `imap_send_email` now ensures an IMAP connection before resolving the Sent folder and APPEND (it previously failed with `no-sent-folder-found` when the account had not been connected first — the SMTP send self-connects, but the Sent-copy needs IMAP). APPEND failures now surface the real server response (e.g. `[OVERQUOTA] Quota exceeded (mailbox for user is full)`) instead of a generic "Command failed".
+
 ## [2.29.0] - 2026-07-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Sent-copy: auto-connect IMAP before append; surface the real APPEND error (OVERQUOTA etc.). #261