### PR TITLE
feat: combined spam scan (UserCheck + DNS + allow/deny) + safe Junk-move (#264)

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,7 +4,7 @@
 > manifest by `scripts/gen-tool-catalog.mjs` (runs on `npm run build`).
 > The authoritative runtime list is always available via the `imap_list_tools` tool.
 
-**129 MCP tools** total.
+**130 MCP tools** total.
 
 ## Categories
 
@@ -17,7 +17,7 @@
 - [Folder & mailbox operations](#folder-mailbox-operations) — 11
 - [Subscriptions & unsubscribe](#subscriptions-unsubscribe) — 9
 - [Categorization & scoring](#categorization-scoring) — 8
-- [Spam & UserCheck](#spam-usercheck) — 9
+- [Spam & UserCheck](#spam-usercheck) — 10
 - [DNS firewall & domain checks](#dns-firewall-domain-checks) — 4
 - [Allow/deny lists](#allowdeny-lists) — 6
 - [Local cache](#local-cache) — 2
@@ -173,6 +173,7 @@
 | `imap_get_usercheck_key` | Get UserCheck API key information for a user |
 | `imap_scan_account_spam` | Scan entire IMAP account for spam using UserCheck, checking all folders |
 | `imap_scan_account_spam_start` | Start a resumable account-wide spam scan (UserCheck) as a tracked job. |
+| `imap_scan_messages_spam` | Scan a block of messages for spam against UserCheck (sender reputation), the DNS firewall (malicious link/domain), or both, and apply the per-user allow/deny lists (allowlisted sender is never flagged; denylisted is always flagged). |
 
 ## DNS firewall & domain checks
 

--- a/scripts/gen-tool-catalog.mjs
+++ b/scripts/gen-tool-catalog.mjs
@@ -40,7 +40,7 @@ const CATEGORIES = [
   ['Folder & mailbox operations', /^imap_(list_folders|folder_status|get_unread_count|create_folder|delete_folder|rename_folder|get_mailbox_status|subscribe_mailbox|unsubscribe_mailbox|list_subscribed_mailboxes|append_message)$/],
   ['Subscriptions & unsubscribe', /^imap_(extract_unsubscribe_links|get_unsubscribe_links|get_unsubscribe_links_for|execute_unsubscribe|get_subscription_summary|list_unsubscribe_candidates|mark_subscription_unsubscribed|update_subscription_category|update_subscription_notes)$/],
   ['Categorization & scoring', /^imap_(add_keyword|remove_keyword|list_categories|apply_categories|test_categories|recommend_keywords|analyze_folder_confidence|score_email_confidence)$/],
-  ['Spam & UserCheck', /^imap_(check_email_spam|check_emails_spam_bulk|check_emails_spam_bulk_start|check_folder_spam|scan_account_spam|scan_account_spam_start|add_usercheck_key|get_usercheck_key|delete_usercheck_key)$/],
+  ['Spam & UserCheck', /^imap_(check_email_spam|check_emails_spam_bulk|check_emails_spam_bulk_start|check_folder_spam|scan_account_spam|scan_account_spam_start|scan_messages_spam|add_usercheck_key|get_usercheck_key|delete_usercheck_key)$/],
   ['DNS firewall & domain checks', /^imap_(check_domain|check_domain_dns_firewall|scan_message_domains|test_quad9_dns)$/],
   ['Allow/deny lists', /^imap_(add_list_entry|remove_list_entry|list_entries|check_address|import_list|clear_list)$/],
   ['Local cache', /^imap_(search_cache|sync_folder_cache)$/],

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -216,6 +216,7 @@ export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   'imap_check_emails_spam_bulk':       READ_REMOTE,
   'imap_check_folder_spam':            READ_REMOTE,
   'imap_scan_account_spam':            READ_REMOTE,
+  'imap_scan_messages_spam':           WRITE_REMOTE,        // can move/flag; runs external checks
 
   // ---- dns-firewall-tools (6) ----
   'imap_check_domain':                 READ_REMOTE,

--- a/src/tools/dns-firewall-tools.ts
+++ b/src/tools/dns-firewall-tools.ts
@@ -105,9 +105,10 @@ export function dnsFirewallTools(
       accountId: z.string().describe('Account ID'),
       folderName: z.string().describe('Folder name'),
       uid: z.number().describe('Message UID'),
-      autoMarkSpam: z.boolean().optional().describe('Automatically mark as spam if malicious domains found (default: false)'),
+      autoMarkSpam: z.boolean().optional().describe('Move the message to the spam folder if malicious domains found (default: false)'),
+      spamFolder: z.string().optional().default('Junk').describe('Destination folder when autoMarkSpam is true (default: Junk)'),
     }
-  }, withErrorHandling(async ({ accountId, folderName, uid, autoMarkSpam }) => {
+  }, withErrorHandling(async ({ accountId, folderName, uid, autoMarkSpam, spamFolder }) => {
     // Fetch message content
     const message = await imapService.getEmailContent(accountId, folderName, uid);
 
@@ -117,13 +118,15 @@ export function dnsFirewallTools(
     // Validate domains
     const scanResult = await dnsFirewall.validateMessageDomains(uid, domains);
 
-    // Auto-mark as spam if requested and malicious domains found
+    // Move to the spam folder if requested and malicious domains found
+    // (safe/reversible — never a bare \Deleted).
+    const targetSpamFolder = spamFolder ?? 'Junk';
     if (autoMarkSpam && !scanResult.isSafe) {
       try {
-        await imapService.bulkMarkEmails(accountId, folderName, [uid], 'deleted');
-        console.error(`[DnsFirewall] Marked message ${uid} as spam (blocked domains: ${scanResult.blockedDomains.join(', ')})`);
+        await imapService.bulkMoveEmails(accountId, folderName, [uid], targetSpamFolder);
+        console.error(`[DnsFirewall] Moved message ${uid} to ${targetSpamFolder} (blocked domains: ${scanResult.blockedDomains.join(', ')})`);
       } catch (error) {
-        console.error(`[DnsFirewall] Failed to mark message ${uid} as spam:`, error);
+        console.error(`[DnsFirewall] Failed to move message ${uid} to spam folder:`, error);
       }
     }
 
@@ -150,9 +153,10 @@ export function dnsFirewallTools(
       accountId: z.string().describe('Account ID'),
       folderName: z.string().describe('Folder name'),
       uids: z.array(z.number()).describe('Array of message UIDs to scan'),
-      autoMarkSpam: z.boolean().optional().describe('Automatically mark as spam if malicious domains found (default: false)'),
+      autoMarkSpam: z.boolean().optional().describe('Move messages with malicious domains to the spam folder (default: false)'),
+      spamFolder: z.string().optional().default('Junk').describe('Destination folder when autoMarkSpam is true (default: Junk)'),
     }
-  }, withErrorHandling(async ({ accountId, folderName, uids, autoMarkSpam }) => {
+  }, withErrorHandling(async ({ accountId, folderName, uids, autoMarkSpam, spamFolder }) => {
     const results = [];
     const spamUIDs: number[] = [];
 
@@ -189,15 +193,17 @@ export function dnsFirewallTools(
       }
     }
 
-    // Auto-mark spam messages if requested
+    // Move flagged messages to the spam folder if requested (safe/reversible —
+    // never a bare \Deleted).
     let markedCount = 0;
+    const targetSpamFolder = spamFolder ?? 'Junk';
     if (autoMarkSpam && spamUIDs.length > 0) {
       try {
-        await imapService.bulkMarkEmails(accountId, folderName, spamUIDs, 'deleted');
+        await imapService.bulkMoveEmails(accountId, folderName, spamUIDs, targetSpamFolder);
         markedCount = spamUIDs.length;
-        console.error(`[DnsFirewall] Marked ${markedCount} messages as spam`);
+        console.error(`[DnsFirewall] Moved ${markedCount} messages to ${targetSpamFolder}`);
       } catch (error) {
-        console.error(`[DnsFirewall] Failed to mark messages as spam:`, error);
+        console.error(`[DnsFirewall] Failed to move messages to spam folder:`, error);
       }
     }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -24,6 +24,7 @@ import { registerScoringTools } from './scoring-tools.js';
 import { registerSubscriptionTools } from './subscription-tools.js';
 import { capabilityTools } from './capability-tools.js';
 import { dnsFirewallTools } from './dns-firewall-tools.js';
+import { spamScanTools } from './spam-scan-tools.js';
 import { categoryTools } from './category-tools.js';
 import { resultTools } from './result-tools.js';
 import { cacheTools } from './cache-tools.js';
@@ -100,6 +101,9 @@ export function registerTools(
 
   // Register DNS Firewall tools (Issue #59)
   dnsFirewallTools(server, imapService, db);
+
+  // Combined spam scan (UserCheck + DNS firewall + allow/deny) over a block of messages
+  spamScanTools(server, imapService, db);
 
   // Register UserCheck SPAM detection tools (Issues #3, #17, #18)
   userCheckTools(server, db, imapService, bulkJobs);

--- a/src/tools/spam-scan-tools.ts
+++ b/src/tools/spam-scan-tools.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// spam-scan-tools.ts — combined spam scan over a block of messages (#261 follow-up).
+//
+// One route that runs each message against UserCheck (sender reputation) and/or
+// the DNS firewall (malicious link/domain), with the per-user allow/deny lists
+// applied as overrides (allowlisted → never spam; denylisted → always spam).
+// Optional safe action: move flagged messages to a Junk folder (default) or flag
+// them — never a bare \Deleted.
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { withErrorHandling } from '../utils/error-handler.js';
+import { DatabaseService } from '../services/database-service.js';
+import { ImapService } from '../services/imap-service.js';
+import { UserCheckService, SpamCheckCriteria, normalizeAddress } from '../services/usercheck-service.js';
+import { DnsFirewallService } from '../services/dns-firewall-service.js';
+import { DomainExtractionService } from '../services/domain-extraction-service.js';
+import { AddressListService } from '../services/address-list-service.js';
+import { resolveUserOrThrow } from '../utils/user-resolver.js';
+
+export function spamScanTools(server: McpServer, imapService: ImapService, db: DatabaseService): void {
+  const userCheck = new UserCheckService(db);
+  const dnsFirewall = new DnsFirewallService(db);
+  const domainExtractor = new DomainExtractionService();
+  const lists = new AddressListService(db);
+
+  server.registerTool('imap_scan_messages_spam', {
+    description:
+      'Scan a block of messages for spam against UserCheck (sender reputation), the DNS firewall (malicious ' +
+      'link/domain), or both, and apply the per-user allow/deny lists (allowlisted sender is never flagged; ' +
+      'denylisted is always flagged). Returns a per-message verdict with reasons. Optional action moves flagged ' +
+      'messages to a Junk folder (safe/reversible) or flags them — it never sets \\Deleted.',
+    inputSchema: {
+      userId: z.string().describe('User ID (UUID or username)'),
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().default('INBOX').describe('Folder to scan (default: INBOX)'),
+      uids: z.array(z.number()).optional().describe('Specific UIDs; omit to scan the most recent messages'),
+      limit: z.number().optional().default(50).describe('Max most-recent messages when uids omitted (default 50, cap 200)'),
+      engines: z.enum(['usercheck', 'dns', 'both']).optional().default('both').describe('Which anti-spam engine(s) to run'),
+      action: z.enum(['report', 'move', 'flag']).optional().default('report').describe("Action on flagged messages: report (default), move (to spamFolder), or flag (\\Flagged)"),
+      spamFolder: z.string().optional().default('Junk').describe('Destination folder for action=move (default: Junk)'),
+      useCache: z.boolean().optional().default(true).describe('Use the UserCheck spam_cache (default true)'),
+      checkDisposable: z.boolean().optional().default(true),
+      checkBlocklisted: z.boolean().optional().default(true),
+      checkRoleAccount: z.boolean().optional().default(true),
+      checkMx: z.boolean().optional().default(true),
+      allowPublicDomains: z.boolean().optional().default(true),
+    },
+  }, withErrorHandling(async (args) => {
+    const userId = resolveUserOrThrow(db, args.userId);
+    const { accountId, folder } = args;
+    const cap = Math.min(args.limit ?? 50, 200);
+    const runUserCheck = args.engines === 'usercheck' || args.engines === 'both';
+    const runDns = args.engines === 'dns' || args.engines === 'both';
+    const criteria: SpamCheckCriteria = {
+      checkDisposable: args.checkDisposable, checkBlocklisted: args.checkBlocklisted,
+      checkRoleAccount: args.checkRoleAccount, checkMx: args.checkMx, allowPublicDomains: args.allowPublicDomains,
+    };
+
+    const all = await imapService.searchEmails(accountId, folder, {});
+    const msgs = args.uids && args.uids.length > 0
+      ? all.filter((m) => args.uids!.includes(m.uid))
+      : [...all].sort((a, b) => b.uid - a.uid).slice(0, cap);
+
+    const warnings: string[] = [];
+    let ucEnabled = runUserCheck;
+    const results: any[] = [];
+
+    for (const m of msgs) {
+      const from = m.from || '';
+      const addr = normalizeAddress(from);
+      const reasons: string[] = [];
+      let spam = false;
+      let source: string[] = [];
+
+      // 1. Allow/deny overrides win outright.
+      const listed = lists.check(userId, from);
+      if (listed.verdict === 'allow') {
+        results.push({ uid: m.uid, from, subject: m.subject, verdict: 'clean', source: ['allowlist'], matched: listed.matchedValue });
+        continue;
+      }
+      if (listed.verdict === 'deny') {
+        results.push({ uid: m.uid, from, subject: m.subject, verdict: 'spam', source: ['denylist'], matched: listed.matchedValue });
+        continue;
+      }
+
+      // 2. UserCheck (sender reputation).
+      if (ucEnabled && addr) {
+        try {
+          const cached = args.useCache !== false ? await userCheck.getCachedResult(addr) : null;
+          const uc = cached ?? await (async () => { const r = await userCheck.checkEmail(userId, addr, criteria); await userCheck.cacheResult(addr, r); return r; })();
+          if (uc.isSpam) { spam = true; source.push('usercheck'); reasons.push(`sender: ${uc.spamReason || 'flagged by UserCheck'}`); }
+        } catch (e: any) {
+          ucEnabled = false; // usually a missing/invalid API key — stop hammering it
+          warnings.push(`UserCheck disabled: ${e?.message || e}. Add a key with imap_add_usercheck_key.`);
+        }
+      }
+
+      // 3. DNS firewall (malicious link/domain in the message).
+      let blockedDomains: string[] = [];
+      if (runDns) {
+        try {
+          const content = await imapService.getEmailContent(accountId, folder, m.uid);
+          const domains = domainExtractor.extractAllDomains(content);
+          const scan = await dnsFirewall.validateMessageDomains(m.uid, domains);
+          if (!scan.isSafe) { spam = true; source.push('dns'); blockedDomains = scan.blockedDomains; reasons.push(`malicious domain(s): ${scan.blockedDomains.join(', ')}`); }
+        } catch (e: any) {
+          reasons.push(`dns-scan error: ${e?.message || e}`);
+        }
+      }
+
+      results.push({ uid: m.uid, from, subject: m.subject, verdict: spam ? 'spam' : 'clean', source: source.length ? source : ['clean'], reasons, ...(blockedDomains.length ? { blockedDomains } : {}) });
+    }
+
+    // Action on flagged messages.
+    const spamUids = results.filter((r) => r.verdict === 'spam').map((r) => r.uid);
+    let actionResult: any = { action: args.action ?? 'report', affected: 0 };
+    if (spamUids.length > 0 && args.action === 'move') {
+      await imapService.bulkMoveEmails(accountId, folder, spamUids, args.spamFolder ?? 'Junk');
+      actionResult = { action: 'move', to: args.spamFolder ?? 'Junk', affected: spamUids.length };
+    } else if (spamUids.length > 0 && args.action === 'flag') {
+      await imapService.bulkMarkEmails(accountId, folder, spamUids, 'flagged');
+      actionResult = { action: 'flag', affected: spamUids.length };
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          folder,
+          engines: args.engines ?? 'both',
+          summary: { scanned: results.length, spam: spamUids.length, clean: results.length - spamUids.length },
+          action: actionResult,
+          messages: results,
+          ...(warnings.length ? { warnings } : {}),
+        }, null, 2)
+      }]
+    };
+  }));
+}


### PR DESCRIPTION
New `imap_scan_messages_spam`: scan a block of messages against UserCheck and/or the DNS firewall, with allow/deny overrides (allowlisted never spam; denylisted always). Optional action **moves flagged to Junk** (never \Deleted) or flags. Also fixes the DNS-firewall auto-mark to move-to-Junk instead of \Deleted. Fix #1 + Fix #2 + the combined route. Tools 129→130. Closes #264.