### PR TITLE
fix: bundled skill never auto-installs from the .mcpb (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.30.1] - 2026-07-04
+
+### Fixed
+- **Bundled skill now auto-installs from the `.mcpb`** (#268) — the skills installer resolved its bundle directory to `<__dirname>/../skills`, which in the packaged extension pointed at the nonexistent `server/skills` (the manifest actually ships at `server/dist/skills/manifest.json`). The `#120` self-install and `imap_check_skill_updates` / `imap_update_skills` therefore silently no-op'd inside Claude Desktop. `resolveBundleSkillsDir()` now prefers the `dist/skills` layout (correct for both `node dist` and the bundle) and falls back to the repo-root `../skills` only for `tsx` dev, choosing whichever actually contains `manifest.json`.
+
 ## [2.30.0] - 2026-07-04
 
 ### Added

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -173,7 +173,7 @@
 | `imap_get_usercheck_key` | Get UserCheck API key information for a user |
 | `imap_scan_account_spam` | Scan entire IMAP account for spam using UserCheck, checking all folders |
 | `imap_scan_account_spam_start` | Start a resumable account-wide spam scan (UserCheck) as a tracked job. |
-| `imap_scan_messages_spam` | Scan a block of messages for spam against UserCheck (sender reputation), the DNS firewall (malicious link/domain), or both, and apply the per-user allow/deny lists (allowlisted sender is never flagged; denylisted is always flagged). |
+| `imap_scan_messages_spam` | Scan a block of messages for spam with up to three independently-toggleable engines and the per-user allow/deny lists. |
 
 ## DNS firewall & domain checks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.23.0",
+  "version": "2.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.23.0",
+      "version": "2.30.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import dotenv from 'dotenv';
 import path from 'path';
+import { existsSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { ImapService } from './services/imap-service.js';
 import { DatabaseService } from './services/database-service.js';
@@ -23,6 +24,22 @@ import { dispatchCli, EXIT_CODES } from './config/cli.js';
 import { loadConfig, ConfigError } from './config/loader.js';
 import { logEvent, timeStage, SERVER_CAPABILITIES } from './startup.js';
 import { PACKAGE_VERSION } from './utils/package-info.js';
+
+// Resolve the bundled-skills directory across every runtime layout (#268).
+// postbuild copies skills/ -> dist/skills/, and the .mcpb ships only dist/
+// (as server/dist/), so in the packaged extension the manifest lives at
+// <__dirname>/skills. Under `npm run dev` (tsx src/index.ts) there is no
+// src/skills, so fall back to the repo-root <__dirname>/../skills. Pick
+// whichever actually contains manifest.json; default to the dist layout so
+// the installer's own "absent -> no-op" path handles a truly missing bundle.
+function resolveBundleSkillsDir(dirname: string): string {
+  const distLayout = path.join(dirname, 'skills');
+  const repoLayout = path.join(dirname, '..', 'skills');
+  if (existsSync(path.join(repoLayout, 'manifest.json')) && !existsSync(path.join(distLayout, 'manifest.json'))) {
+    return repoLayout;
+  }
+  return distLayout;
+}
 
 // Filter stdout to keep stray library chatter (npm-style version banners,
 // dotenv config dumps, etc.) from corrupting the JSON-RPC stream that
@@ -148,7 +165,7 @@ const {
     // 6e. v2.17.4 (#138): skill installer — same instance used for the
     //     post-handshake bundle install AND for the imap_check_skill_updates
     //     / imap_update_skills tools. No network calls at construction time.
-    const bundleSkillsDir = path.join(__dirname, '..', 'skills');
+    const bundleSkillsDir = resolveBundleSkillsDir(__dirname);
     const skillsInstaller = new SkillsInstallerService(bundleSkillsDir);
 
     // 6f. v2.17.10 (#150): Web UI manager — owns the embedded WebUIServer
@@ -290,7 +307,7 @@ async function buildToolsManifest(): Promise<unknown> {
     stagingDir: path.join(os.homedir(), '.imap-mcp', 'staging'),
   });
   const tmpMessageCache = new MessageCacheService(tmpDb, tmpImap);
-  const tmpBundleSkillsDir = path.join(__dirname, '..', 'skills');
+  const tmpBundleSkillsDir = resolveBundleSkillsDir(__dirname);
   const tmpSkillsInstaller = new SkillsInstallerService(tmpBundleSkillsDir);
   registerTools(
     tmpServer, tmpImap, tmpDb, tmpSmtp, tmpResults, tmpWorkerPool,


### PR DESCRIPTION
Closes #268.

## Problem
The skills installer resolved its bundle dir as `path.join(__dirname, '..', 'skills')`. `postbuild` copies `skills/` → `dist/skills/`, and the `.mcpb` ships only `dist/` (as `server/dist/`), so in the packaged extension that path pointed at the nonexistent **`server/skills`** — the manifest actually lives at **`server/dist/skills/manifest.json`**. The installer swallows a missing bundle dir, so the #120 self-install and `imap_check_skill_updates` / `imap_update_skills` **silently no-op'd inside Claude Desktop**. It only appeared to work under `tsx` dev, where the repo's source `skills/` happens to sit at `../skills`.

## Fix
`resolveBundleSkillsDir()` (used at both call sites) prefers `dist/skills` (correct for both `node dist/index.js` and the bundle) and falls back to `../skills` only for `tsx` dev — choosing whichever actually contains `manifest.json`.

## Verification
- Built server resolves to `dist/skills` with `manifest.json` present.
- `tsx` fallback logic returns repo-root `skills/` (no `src/skills`).
- All 309 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
