### PR TITLE
feat: direct export to a path outside the MCP (destPath) (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.31.0] - 2026-07-05
+
+### Added
+- **Direct export to a path outside the MCP** (#270) — `imap_export_email`, `imap_export_folder`, and `imap_export_account` gained an optional `destPath`. When set, `.eml` files are written **directly** to that path (e.g. `~/Downloads/sent-mail`) instead of the managed outbox — no export-to-outbox-then-relocate two-hop. Folder/account exports still mirror the mailbox hierarchy under `destPath`. `destPath` is validated by `resolveExportDest()`: must be absolute, resolve within an allowed export root (default: home dir; narrow/widen via `IMAP_MCP_ALLOWED_EXPORT_DIRS`), never inside `~/.imap-mcp`, not the bare home root or a top-level hidden dir, and symlink-escape guarded — preserving the MSP multi-tenant boundary. Omit `destPath` for unchanged outbox behavior.
+
 ## [2.30.1] - 2026-07-04
 
 ### Fixed

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -79,9 +79,9 @@
 
 | Tool | Description |
 | --- | --- |
-| `imap_export_account` | Export the entire account to .eml files, mirroring the full mailbox folder structure under exports/[subfolder]/. |
+| `imap_export_account` | Export the entire account to .eml files, mirroring the full mailbox folder structure under exports/[subfolder]/ (or directly under destPath). |
 | `imap_export_email` | Export one or more messages to standard .eml files on the server host (download & save). |
-| `imap_export_folder` | Export all messages in a folder to standard .eml files on the server host, mirroring the folder hierarchy under the per-user outbox (exports/[subfolder]/{folder path}/). |
+| `imap_export_folder` | Export all messages in a folder to standard .eml files on the server host, mirroring the folder hierarchy under the per-user outbox (exports/[subfolder]/{folder path}/), or directly under destPath. |
 | `imap_extract_attachments` | Extract file attachments from a block of messages and save them to disk under the per-user outbox (exports/attachments/[subfolder]/). |
 | `imap_get_attachment` | Fetch a single attachment from a message for preview or download. |
 | `imap_get_email_sizes` | List messages by size to find large emails — uses RFC822.SIZE (no body download, cheap even on big folders). |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.30.1",
+  "version": "2.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.30.1",
+      "version": "2.31.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.30.1",
+  "version": "2.31.0",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/export-dest-resolver.test.ts
+++ b/src/services/export-dest-resolver.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for resolveExportDest — the destPath guard for direct exports (#270).
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { resolveExportDest, allowedExportRoots } from './export-dest-resolver.js';
+
+describe('resolveExportDest', () => {
+  let root: string;
+  const prevEnv = process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS;
+
+  beforeEach(() => {
+    // Use a real temp dir as the allow-listed root so tests never touch $HOME.
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'export-dest-'));
+    process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS = root;
+  });
+
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS;
+    else process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS = prevEnv;
+    try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('creates and returns a dir within an allowed root', () => {
+    const dest = path.join(root, 'sent-mail');
+    const out = resolveExportDest(dest);
+    expect(out).toBe(path.resolve(dest));
+    expect(fs.existsSync(out)).toBe(true);
+    expect(fs.statSync(out).isDirectory()).toBe(true);
+  });
+
+  it('rejects a relative path', () => {
+    expect(() => resolveExportDest('relative/dir')).toThrow(/absolute/i);
+  });
+
+  it('rejects a path outside every allowed root', () => {
+    const other = fs.mkdtempSync(path.join(os.tmpdir(), 'other-'));
+    try {
+      expect(() => resolveExportDest(path.join(other, 'x'))).toThrow(/not within an allowed export root/i);
+    } finally {
+      fs.rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the MCP data dir even when it is under an allowed root', () => {
+    // Allow-list home so ~/.imap-mcp passes the root check but fails the MCP guard.
+    process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS = os.homedir();
+    const mcp = path.join(os.homedir(), '.imap-mcp', 'users', 'u', 'outbox', 'x');
+    expect(() => resolveExportDest(mcp)).toThrow(/outside the MCP data dir/i);
+  });
+
+  it('rejects the bare home root', () => {
+    process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS = os.homedir();
+    expect(() => resolveExportDest(os.homedir())).toThrow(/subdirectory/i);
+  });
+
+  it('rejects a top-level hidden dir under home', () => {
+    process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS = os.homedir();
+    expect(() => resolveExportDest(path.join(os.homedir(), '.ssh'))).toThrow(/hidden \(dot\) directory/i);
+  });
+
+  it('rejects a symlink that escapes the allowed root', () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'escape-'));
+    const link = path.join(root, 'link');
+    try {
+      fs.symlinkSync(outside, link);
+      expect(() => resolveExportDest(path.join(link, 'sub'))).toThrow(/symlink/i);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('defaults the allow-list to the home directory', () => {
+    delete process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS;
+    expect(allowedExportRoots()).toEqual([os.homedir()]);
+  });
+});

--- a/src/services/export-dest-resolver.ts
+++ b/src/services/export-dest-resolver.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// export-dest-resolver.ts — validate a user-chosen export destination (#270).
+//
+// The export tools normally write under the managed per-user outbox
+// (~/.imap-mcp/users/{userId}/outbox/exports/). This resolver backs the
+// optional `destPath` argument that lets a caller write .eml files DIRECTLY to
+// a path outside the MCP (e.g. ~/Downloads/sent-mail) — no outbox two-hop.
+//
+// Direct writes are a security-relevant capability (the outbox scoping is the
+// MSP multi-tenant boundary), so every destPath is validated:
+//   - absolute; `..` collapsed via path.resolve
+//   - within an allowed export root (default: home; override via
+//     IMAP_MCP_ALLOWED_EXPORT_DIRS so operators can restrict/disable it)
+//   - never inside the MCP data tree (~/.imap-mcp) — that's the outbox's job
+//   - not the bare home root, and not a top-level hidden (dot) dir under home
+//   - symlink-escape guarded: the nearest existing ancestor is realpath'd and
+//     re-checked so a symlink can't redirect the write outside the allow-list
+//
+// Author: Colin Bitterfield
+// Email: colin.bitterfield@templeofepiphany.com
+// Date Created: 2026-07-05
+// Version: 0.1.0
+//
+// Tracker: #270.
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Allowed roots an export `destPath` may resolve within. Defaults to the
+ * user's home directory. Operators narrow or widen this with
+ * IMAP_MCP_ALLOWED_EXPORT_DIRS (a path.delimiter-separated list of absolute
+ * dirs); set it to a path that doesn't exist to effectively disable destPath.
+ */
+export function allowedExportRoots(): string[] {
+  const env = process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS;
+  if (env && env.trim()) {
+    return env
+      .split(path.delimiter)
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((p) => path.resolve(p));
+  }
+  return [os.homedir()];
+}
+
+function mcpDataDir(): string {
+  return path.join(os.homedir(), '.imap-mcp');
+}
+
+function withinRoot(target: string, root: string): boolean {
+  return target === root || target.startsWith(root + path.sep);
+}
+
+/**
+ * Validate a caller-supplied absolute export destination and return the
+ * resolved directory (created 0700 if absent). Throws on any policy violation.
+ */
+export function resolveExportDest(destPath: string): string {
+  if (!destPath || !path.isAbsolute(destPath)) {
+    throw new Error(`destPath must be an absolute path (got: ${destPath || '<empty>'})`);
+  }
+
+  const resolved = path.resolve(destPath);
+  const home = os.homedir();
+  const mcpDir = mcpDataDir();
+
+  // destPath is explicitly for writing OUTSIDE the MCP — never let it target
+  // the MCP data/outbox tree (omit destPath to use the managed outbox).
+  if (withinRoot(resolved, mcpDir)) {
+    throw new Error(
+      `destPath must be outside the MCP data dir (${mcpDir}); omit destPath to use the managed outbox`,
+    );
+  }
+
+  const roots = allowedExportRoots();
+  if (!roots.some((root) => withinRoot(resolved, root))) {
+    throw new Error(
+      `destPath ${resolved} is not within an allowed export root (${roots.join(', ')}). ` +
+        'Set IMAP_MCP_ALLOWED_EXPORT_DIRS to widen the allow-list.',
+    );
+  }
+
+  if (resolved === home) {
+    throw new Error('destPath must be a subdirectory, not the home directory root');
+  }
+
+  // Reject top-level hidden dirs under home (e.g. ~/.ssh, ~/.config) to avoid
+  // clobbering config trees. Only applies when the target is under home.
+  const relFromHome = path.relative(home, resolved);
+  if (relFromHome && !relFromHome.startsWith('..') && relFromHome.split(path.sep)[0].startsWith('.')) {
+    throw new Error(`destPath must not target a hidden (dot) directory under home: ${resolved}`);
+  }
+
+  // Symlink-escape guard: walk up to the nearest existing ancestor, realpath
+  // it, and re-verify it stays within an allowed root and outside the MCP dir.
+  let probe = resolved;
+  while (!fs.existsSync(probe)) {
+    const parent = path.dirname(probe);
+    if (parent === probe) break;
+    probe = parent;
+  }
+  // Compare against realpath'd roots/mcpDir too — the roots themselves may sit
+  // under a symlinked prefix (e.g. macOS /var -> /private/var).
+  const realOf = (p: string): string => {
+    try { return fs.realpathSync(p); } catch { return p; }
+  };
+  try {
+    const real = fs.realpathSync(probe);
+    const realRoots = roots.map(realOf);
+    const realMcp = realOf(mcpDir);
+    const realOk =
+      realRoots.some((root) => withinRoot(real, root)) && !withinRoot(real, realMcp);
+    if (!realOk) {
+      throw new Error(`destPath resolves via symlink outside allowed roots: ${real}`);
+    }
+  } catch (e) {
+    throw new Error(`destPath could not be validated: ${(e as Error).message}`);
+  }
+
+  fs.mkdirSync(resolved, { recursive: true, mode: 0o700 });
+  return resolved;
+}

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -17,6 +17,7 @@ import {
 import { getToolContext } from './tool-context.js';
 import { ContextReductionConfig as Cfg } from '../config/context-reduction.js';
 import { getOutboxDir, sanitizeFilename } from '../services/attachment-validator.js';
+import { resolveExportDest } from '../services/export-dest-resolver.js';
 import { MessageExportService } from '../services/message-export-service.js';
 import path from 'path';
 
@@ -231,8 +232,23 @@ interface FolderExportSummary {
 }
 
 /**
+ * Resolve the base directory an export writes into. When `destPath` is given
+ * the files land DIRECTLY there (validated by resolveExportDest — #270),
+ * optionally grouped in a sanitized `subfolder`; otherwise they go under the
+ * managed per-user outbox (`{outbox}/exports/[subfolder]/`).
+ */
+function exportBaseDir(userId: string, subfolder?: string, destPath?: string): string {
+  const seg = subfolder ? sanitizeFilename(subfolder).replace(/[\\/]/g, '') : '';
+  if (destPath) {
+    const base = resolveExportDest(destPath);
+    return seg ? path.join(base, seg) : base;
+  }
+  return path.join(getOutboxDir(userId), 'exports', seg);
+}
+
+/**
  * Export up to `limit` messages of one folder to .eml on disk, mirroring the
- * folder hierarchy under `{outbox}/exports/[subfolder]/{folder path}/`. Raw
+ * folder hierarchy under the resolved base (`{base}/{folder path}/`). Raw
  * sources are fetched in chunks of 100 to keep memory and the IMAP fetch bounded.
  */
 async function exportFolderToDisk(
@@ -243,6 +259,7 @@ async function exportFolderToDisk(
   folder: string,
   limit: number,
   subfolder?: string,
+  destPath?: string,
   // Return type is inferred (FolderExportSummary) — an explicit Promise<…>
   // annotation here trips the angle-bracket description lint's approximate scanner.
 ) {
@@ -250,8 +267,7 @@ async function exportFolderToDisk(
   const uids = all.map((m) => m.uid);
   const selected = uids.slice(0, limit);
 
-  const seg = subfolder ? sanitizeFilename(subfolder).replace(/[\\/]/g, '') : '';
-  const outputDir = path.join(getOutboxDir(userId), 'exports', seg, exporter.folderToDiskPath(folder));
+  const outputDir = path.join(exportBaseDir(userId, subfolder, destPath), exporter.folderToDiskPath(folder));
 
   let exported = 0;
   let totalBytes = 0;
@@ -618,25 +634,26 @@ export function emailTools(
       'Export one or more messages to standard .eml files on the server host (download & save). ' +
       '.eml is the raw RFC822 source — lossless, opens in Outlook/Thunderbird/Apple Mail, with attachments ' +
       'and inline images preserved. Files are written under the per-user outbox ' +
-      '(~/.imap-mcp/users/{userId}/outbox/exports/), optionally grouped in a named subfolder. All processing is local.',
+      '(~/.imap-mcp/users/{userId}/outbox/exports/), optionally grouped in a named subfolder. Pass destPath ' +
+      'to write directly to a path outside the MCP (e.g. ~/Downloads/sent-mail). All processing is local.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder containing the messages (default: INBOX)'),
       uids: z.array(z.number()).min(1).describe('UIDs of the messages to export'),
-      subfolder: z.string().optional().describe('Optional subfolder name under exports/ to group the files (sanitized to a single path segment)'),
+      subfolder: z.string().optional().describe('Optional subfolder name to group the files (sanitized to a single path segment)'),
+      destPath: z.string().optional().describe('Absolute path to write .eml files DIRECTLY into (e.g. /Users/you/Downloads/sent-mail). Must be inside an allowed export root (default: your home dir; set IMAP_MCP_ALLOWED_EXPORT_DIRS to restrict) and outside ~/.imap-mcp. Omit to use the managed outbox.'),
     }
-  }, withErrorHandling(async ({ accountId, folder, uids, subfolder }) => {
+  }, withErrorHandling(async ({ accountId, folder, uids, subfolder, destPath }) => {
     const userId = resolveUserId(db) ?? 'default';
     const messages = await imapService.getRawMessages(accountId, folder, uids);
     if (messages.length === 0) {
       return jsonResult({ success: false, message: 'No messages found for the given UIDs', folder, requestedUids: uids });
     }
 
-    // Output dir lives under the per-user outbox (always allow-listed). The
-    // optional subfolder is reduced to a single sanitized segment so it cannot
-    // escape the outbox via path traversal.
-    const seg = subfolder ? sanitizeFilename(subfolder).replace(/[\\/]/g, '') : '';
-    const outputDir = path.join(getOutboxDir(userId), 'exports', seg);
+    // Output dir is either the managed outbox (default) or a validated
+    // caller-supplied destPath (#270). The optional subfolder is reduced to a
+    // single sanitized segment so it cannot escape via path traversal.
+    const outputDir = exportBaseDir(userId, subfolder, destPath);
 
     const result = await new MessageExportService().exportEml(outputDir, messages);
 
@@ -658,18 +675,19 @@ export function emailTools(
   server.registerTool('imap_export_folder', {
     description:
       'Export all messages in a folder to standard .eml files on the server host, mirroring the folder ' +
-      'hierarchy under the per-user outbox (exports/[subfolder]/{folder path}/). Capped by `limit` ' +
-      '(default 1000; `truncated` flags when the folder held more). Lossless raw-source write. Local only.',
+      'hierarchy under the per-user outbox (exports/[subfolder]/{folder path}/), or directly under destPath. ' +
+      'Capped by `limit` (default 1000; `truncated` flags when the folder held more). Lossless raw-source write. Local only.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder to export (default: INBOX)'),
       limit: z.number().optional().default(1000).describe('Maximum messages to export (default 1000)'),
-      subfolder: z.string().optional().describe('Optional top-level subfolder under exports/ to group this export'),
+      subfolder: z.string().optional().describe('Optional top-level subfolder to group this export'),
+      destPath: z.string().optional().describe('Absolute path to write DIRECTLY into (folder hierarchy mirrored under it). Must be inside an allowed export root and outside ~/.imap-mcp. Omit to use the managed outbox.'),
     }
-  }, withErrorHandling(async ({ accountId, folder, limit, subfolder }) => {
+  }, withErrorHandling(async ({ accountId, folder, limit, subfolder, destPath }) => {
     const userId = resolveUserId(db) ?? 'default';
     const summary = await exportFolderToDisk(
-      imapService, new MessageExportService(), userId, accountId, folder, limit ?? 1000, subfolder,
+      imapService, new MessageExportService(), userId, accountId, folder, limit ?? 1000, subfolder, destPath,
     );
     return jsonResult({ success: true, format: 'eml', ...summary });
   }));
@@ -678,14 +696,15 @@ export function emailTools(
   server.registerTool('imap_export_account', {
     description:
       'Export the entire account to .eml files, mirroring the full mailbox folder structure under ' +
-      'exports/[subfolder]/. Skips non-selectable folders (\\Noselect). Each folder is capped by ' +
+      'exports/[subfolder]/ (or directly under destPath). Skips non-selectable folders (\\Noselect). Each folder is capped by ' +
       '`perFolderLimit` (default 1000). Fetched in chunks. Local only — can be large.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       perFolderLimit: z.number().optional().default(1000).describe('Max messages to export per folder (default 1000)'),
-      subfolder: z.string().optional().describe('Optional top-level subfolder under exports/ to group this export'),
+      subfolder: z.string().optional().describe('Optional top-level subfolder to group this export'),
+      destPath: z.string().optional().describe('Absolute path to write DIRECTLY into (full mailbox structure mirrored under it). Must be inside an allowed export root and outside ~/.imap-mcp. Omit to use the managed outbox.'),
     }
-  }, withErrorHandling(async ({ accountId, perFolderLimit, subfolder }) => {
+  }, withErrorHandling(async ({ accountId, perFolderLimit, subfolder, destPath }) => {
     const userId = resolveUserId(db) ?? 'default';
     const exporter = new MessageExportService();
     const folders = await imapService.listFolders(accountId);
@@ -696,7 +715,7 @@ export function emailTools(
     const perFolder: FolderExportSummary[] = [];
     for (const f of selectable) {
       try {
-        perFolder.push(await exportFolderToDisk(imapService, exporter, userId, accountId, f.name, perFolderLimit ?? 1000, subfolder));
+        perFolder.push(await exportFolderToDisk(imapService, exporter, userId, accountId, f.name, perFolderLimit ?? 1000, subfolder, destPath));
       } catch (e: any) {
         perFolder.push({ folder: f.name, outputDir: '', totalInFolder: 0, exported: 0, truncated: false, totalBytes: 0, totalSize: e?.message ?? 'export failed' });
       }


### PR DESCRIPTION
Closes #270.

## What
Adds an optional `destPath` to `imap_export_email`, `imap_export_folder`, and `imap_export_account`. When set, `.eml` files are written **directly** to that path (e.g. `~/Downloads/sent-mail`) — no export-to-outbox-then-relocate two-hop. Folder/account exports mirror the mailbox hierarchy under `destPath`. Omit `destPath` → unchanged managed-outbox behavior.

## Safety (`resolveExportDest`, new module + 8 tests)
- Absolute path required; `..` collapsed via `path.resolve`.
- Must resolve **within an allowed export root** — default `os.homedir()`, override/narrow with `IMAP_MCP_ALLOWED_EXPORT_DIRS` (operators can restrict or effectively disable it).
- **Never** inside `~/.imap-mcp` (that's the outbox's job).
- Rejects the bare home root and top-level hidden (dot) dirs (`~/.ssh`, …).
- **Symlink-escape guarded**: realpath the nearest existing ancestor and re-check against realpath'd roots (also fixes the macOS `/var`→`/private/var` case).
- Created `mode 0700`.

Preserves the MSP multi-tenant boundary — the outbox scoping is unchanged; `destPath` is an explicit, allowlisted, owner-initiated action.

## Verification
- 8 new resolver unit tests (relative reject, outside-root reject, MCP-dir reject, bare-home reject, hidden-dir reject, symlink-escape reject, happy path, default allow-list).
- Full suite **317 passing**; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
