### PR TITLE
chore: make update-extension — one-command Claude Desktop .mcpb update (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`make update-extension`** (#272) — one-command update of the installed Claude Desktop `.mcpb` to the latest release. The extension is a *local* `.mcpb` that Claude Desktop never auto-updates (only directory-sourced extensions get auto-updates), so it silently drifts behind the Web UI / registry; `make install` / `make update` only manage the launchd Web UI service. `scripts/update-extension.sh` resolves the latest release (or `VERSION=`), downloads + SHA-256-verifies the `.mcpb`, stage-extracts and asserts the version + skills manifest, then backs up the current install to `.bak` and swaps atomically. macOS default path; `EXT_DIR=` override. Spec: `docs/update-extension_specification.md`.
+
 ## [2.31.0] - 2026-07-05
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Date: 2025-11-06
 # Version: 1.1.0
 
-.PHONY: help install uninstall start stop restart status logs update test build clean backup restore migrate migrate-status migrate-rollback migrate-dry-run
+.PHONY: help install uninstall start stop restart status logs update update-extension test build clean backup restore migrate migrate-status migrate-rollback migrate-dry-run
 
 # Detect OS
 UNAME_S := $(shell uname -s 2>/dev/null || echo "Windows")
@@ -90,7 +90,8 @@ help:
 	@echo "  make restart    - Restart the service"
 	@echo "  make status     - Check service status"
 	@echo "  make logs       - View service logs"
-	@echo "  make update     - Update to latest release"
+	@echo "  make update     - Update the Web UI service to latest release"
+	@echo "  make update-extension - Update the Claude Desktop .mcpb to latest release"
 	@echo "  make build      - Build the project"
 	@echo "  make backup     - Backup database and keys to a zip file"
 	@echo "  make restore    - Restore database and keys from a zip file"
@@ -159,6 +160,13 @@ logs:
 
 update:
 	@bash scripts/update.sh "$(INSTALL_DIR)" "$(DATA_DIR)" "$(LOG_DIR)"
+
+# Update the installed Claude Desktop extension (.mcpb) to the latest release.
+# Separate from `update` (which manages the launchd Web UI service) — the
+# Claude Desktop extension is a local .mcpb that Desktop never auto-updates.
+# Override with VERSION=x.y.z and/or EXT_DIR="/path". Requires gh.
+update-extension:
+	@VERSION="$(VERSION)" EXT_DIR="$(EXT_DIR)" bash scripts/update-extension.sh
 
 update-internal:
 	@echo "==========================================="; \

--- a/docs/update-extension_specification.md
+++ b/docs/update-extension_specification.md
@@ -1,0 +1,81 @@
+# update-extension.sh — Specification
+
+**Version:** 1.0.0
+**Author:** Colin Bitterfield
+**Email:** colin.bitterfield@templeofepiphany.com
+**Date Created:** 2026-07-05
+**Date Updated:** 2026-07-05
+**Artifact:** `scripts/update-extension.sh` (invoked via `make update-extension`)
+**Tracker:** #272
+
+## Purpose
+
+Install the latest **released** IMAP MCP Pro `.mcpb` into the Claude Desktop
+extensions directory in one command.
+
+The Claude Desktop extension is a *local* `.mcpb` (ID
+`local.mcpb.colin-bitterfield.imap-mcp-pro`), not installed from the Anthropic
+directory. Claude Desktop only auto-updates directory-sourced extensions, so the
+local install silently drifts behind the Web UI / registry. `make install` and
+`make update` manage only the launchd Web UI service and never touch this
+extension. This script closes that gap until the Anthropic directory submission
+lands (after which Desktop handles updates itself).
+
+## Invocation
+
+```
+make update-extension                 # latest release
+make update-extension VERSION=2.31.0  # a specific release
+make update-extension EXT_DIR="/path" # non-default install location
+```
+
+Direct: `scripts/update-extension.sh` with the same behavior via `VERSION` /
+`EXT_DIR` / `REPO` environment variables.
+
+## Inputs
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `VERSION` | latest GitHub release tag | Release version to install (leading `v` optional) |
+| `EXT_DIR` | `~/Library/Application Support/Claude/Claude Extensions/local.mcpb.colin-bitterfield.imap-mcp-pro` | Installed-extension directory |
+| `REPO` | `Temple-of-Epiphany/imap-mcp-pro` | Source GitHub repo |
+
+## Requirements
+
+`gh` (authenticated), `unzip`, `shasum`, `node`. macOS default path; other
+platforms supply `EXT_DIR`.
+
+## Behavior
+
+1. Resolve target tag (`gh release view` for latest, or `v$VERSION`).
+2. Short-circuit if the installed `manifest.json` version already equals the
+   target (idempotent). `VERSION=` forces a specific build check.
+3. `gh release download` the `.mcpb` and `.sha256` into a temp dir.
+4. Verify the SHA-256 (hard-fail on mismatch; warn only if no checksum asset).
+5. Stage-extract the `.mcpb`; assert the staged `manifest.json` version matches
+   the target and `server/dist/skills/manifest.json` is present.
+6. Back up the current install to a single `<EXT_DIR>.bak` (previous one
+   removed), then swap the staged tree into place.
+7. Verify the installed `manifest.json` version, then print a "quit & reopen
+   Claude Desktop" reminder (the running MCP process reloads only on restart).
+
+Temp files are removed on exit via a trap.
+
+## Failure modes
+
+- Missing tool / unauthenticated `gh` → hard error before any change.
+- Unresolvable release, missing `.mcpb`, checksum mismatch, staged-version
+  mismatch, or missing skills manifest → hard error **before** the swap, so the
+  existing install is untouched.
+
+## Recovery
+
+The previous version remains at `<EXT_DIR>.bak`. To roll back:
+`rm -rf "<EXT_DIR>" && mv "<EXT_DIR>.bak" "<EXT_DIR>"`, then restart Claude
+Desktop.
+
+## Out of scope
+
+- The launchd Web UI service (`make update`).
+- Automatic Claude Desktop restart (must be manual).
+- Directory-sourced auto-updates (handled by Claude Desktop once listed).

--- a/scripts/update-extension.sh
+++ b/scripts/update-extension.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# update-extension.sh — install the latest released .mcpb into the Claude
+# Desktop extensions directory (issue #272).
+#
+# The Claude Desktop extension is a *local* .mcpb (not installed from the
+# Anthropic directory), so Claude Desktop never auto-updates it and it drifts
+# behind the Web UI / registry. `make install` / `make update` only manage the
+# launchd Web UI service, not this extension. This script closes that gap by
+# fetching the latest RELEASED artifact, verifying its checksum, and swapping it
+# in atomically with a recoverable backup.
+#
+# Usage:
+#   scripts/update-extension.sh
+#   VERSION=2.31.0 scripts/update-extension.sh
+#   EXT_DIR="/custom/path" scripts/update-extension.sh
+#
+# Env:
+#   VERSION  Release version to install (default: latest GitHub release tag).
+#   EXT_DIR  Installed-extension directory (default: macOS Claude path).
+#   REPO     GitHub repo (default: Temple-of-Epiphany/imap-mcp-pro).
+#
+# Requires: gh (authenticated), unzip, shasum, node.
+#
+# Author: Colin Bitterfield
+# Email: colin.bitterfield@templeofepiphany.com
+# Date Created: 2026-07-05
+# Date Updated: 2026-07-05
+# Version: 1.0.0
+#
+# Changelog:
+#   1.0.0 (2026-07-05): Initial version — download+verify+stage+swap latest .mcpb.
+
+set -euo pipefail
+
+REPO="${REPO:-Temple-of-Epiphany/imap-mcp-pro}"
+EXT_ID="local.mcpb.colin-bitterfield.imap-mcp-pro"
+DEFAULT_EXT_DIR="${HOME}/Library/Application Support/Claude/Claude Extensions/${EXT_ID}"
+EXT_DIR="${EXT_DIR:-$DEFAULT_EXT_DIR}"
+
+err() { echo "error: $*" >&2; exit 1; }
+
+command -v gh >/dev/null 2>&1 || err "gh CLI not found — install it and run 'gh auth login'"
+command -v unzip >/dev/null 2>&1 || err "unzip not found"
+command -v shasum >/dev/null 2>&1 || err "shasum not found"
+command -v node >/dev/null 2>&1 || err "node not found"
+
+# Resolve the target version (default: latest release tag, minus the leading 'v').
+if [ -z "${VERSION:-}" ]; then
+  TAG="$(gh release view --repo "$REPO" --json tagName --jq .tagName 2>/dev/null)" \
+    || err "could not resolve the latest release from $REPO (is gh authenticated?)"
+else
+  TAG="v${VERSION#v}"
+fi
+VER="${TAG#v}"
+MCPB="imap-mcp-pro-${VER}.mcpb"
+
+echo "Repo:      $REPO"
+echo "Target:    $TAG ($MCPB)"
+echo "Extension: $EXT_DIR"
+
+CUR="none"
+if [ -f "$EXT_DIR/manifest.json" ]; then
+  CUR="$(node -p "require('$EXT_DIR/manifest.json').version" 2>/dev/null || echo unknown)"
+fi
+echo "Installed: $CUR"
+if [ "$CUR" = "$VER" ]; then
+  echo "Already at $VER — nothing to do. (Set VERSION= to force a specific build.)"
+  exit 0
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/imap-mcp-ext.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "==> downloading release asset"
+gh release download "$TAG" --repo "$REPO" \
+  --pattern "$MCPB" --pattern "${MCPB}.sha256" --dir "$TMP" --clobber \
+  || err "download failed — does $TAG include $MCPB?"
+
+echo "==> verifying checksum"
+if [ -f "$TMP/${MCPB}.sha256" ]; then
+  EXPECTED="$(awk '{print $1}' "$TMP/${MCPB}.sha256")"
+  ACTUAL="$(shasum -a 256 "$TMP/$MCPB" | awk '{print $1}')"
+  [ "$EXPECTED" = "$ACTUAL" ] || err "checksum mismatch (expected $EXPECTED, got $ACTUAL)"
+  echo "    sha256 OK"
+else
+  echo "    warning: no .sha256 published for $TAG — skipping checksum verification" >&2
+fi
+
+echo "==> staging fresh extract"
+STAGE="$TMP/stage"
+mkdir -p "$STAGE"
+unzip -q -o "$TMP/$MCPB" -d "$STAGE"
+STAGED_VER="$(node -p "require('$STAGE/manifest.json').version" 2>/dev/null || echo unknown)"
+[ "$STAGED_VER" = "$VER" ] || err "staged manifest version ($STAGED_VER) != target ($VER)"
+[ -f "$STAGE/server/dist/skills/manifest.json" ] || err "staged bundle missing server/dist/skills/manifest.json"
+echo "    staged $STAGED_VER, skills manifest present"
+
+echo "==> installing (backup old -> .bak, then swap)"
+mkdir -p "$(dirname "$EXT_DIR")"
+if [ -d "$EXT_DIR" ]; then
+  rm -rf "$EXT_DIR.bak"
+  mv "$EXT_DIR" "$EXT_DIR.bak"
+  echo "    previous $CUR backed up to $(basename "$EXT_DIR").bak"
+fi
+mv "$STAGE" "$EXT_DIR"
+
+INSTALLED="$(node -p "require('$EXT_DIR/manifest.json').version" 2>/dev/null || echo unknown)"
+[ "$INSTALLED" = "$VER" ] || err "post-install verification failed (found $INSTALLED)"
+
+echo ""
+echo "✓ Claude Desktop extension updated: $CUR -> $INSTALLED"
+echo "  Quit and reopen Claude Desktop to load the new server process."


### PR DESCRIPTION
Closes #272.

## What
Adds `make update-extension` (+ `scripts/update-extension.sh`, spec doc) to install the latest **released** `.mcpb` into the Claude Desktop extensions dir in one command. Closes the drift gap: the extension is a *local* `.mcpb` that Desktop never auto-updates, and `make install`/`make update` only touch the Web UI service.

## Safety
- Idempotent (no-op when already at target).
- `gh release download` + **SHA-256 verify** (hard-fail on mismatch).
- Stage-extract and assert staged version + `server/dist/skills/manifest.json` **before** swapping.
- Previous install backed up to `<EXT_DIR>.bak` (recoverable); atomic swap.
- All failure modes error out before touching the live install.

## Verification
- `make update-extension` at 2.31.0 → idempotent no-op.
- `make update-extension VERSION=2.31.0 EXT_DIR=<throwaway>` → full path: download, `sha256 OK`, staged 2.31.0 + skills manifest present, installed & verified.

No server change — CHANGELOG under `[Unreleased]`, no new `.mcpb` release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
