### PR TITLE
feat: surface IMAP_MCP_ALLOWED_EXPORT_DIRS as a Desktop config field (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.32.0] - 2026-07-05
 
 ### Added
+- **Export destination config** (#270) — `IMAP_MCP_ALLOWED_EXPORT_DIRS` is now surfaced as a Claude Desktop `user_config` field ("Allowed Export Directories"), so the `destPath` allow-list is configurable from the extension UI (leave empty = anywhere in home; set dirs to restrict; a nonexistent path disables direct export). The env var is now **comma-separated** (matching the attachment-dirs convention and the Desktop directory/multiple serialization, and correct on Windows where `:` appears in drive paths) and expands `~`. `env-resolver` recovers it from the settings JSON the same way it does the attachment allow-list.
 - **`make update-extension`** (#272) — one-command update of the installed Claude Desktop `.mcpb` to the latest release. The extension is a *local* `.mcpb` that Claude Desktop never auto-updates (only directory-sourced extensions get auto-updates), so it silently drifts behind the Web UI / registry; `make install` / `make update` only manage the launchd Web UI service. `scripts/update-extension.sh` resolves the latest release (or `VERSION=`), downloads + SHA-256-verifies the `.mcpb`, stage-extracts and asserts the version + skills manifest, then backs up the current install to `.bak` and swaps atomically. macOS default path; `EXT_DIR=` override. Spec: `docs/update-extension_specification.md`.
 
 ## [2.31.0] - 2026-07-05

--- a/dxt/manifest.template.json
+++ b/dxt/manifest.template.json
@@ -37,6 +37,7 @@
         "IMAP_MCP_DATABASE_PATH": "${user_config.database_path}/data.db",
         "IMAP_MCP_LOG_LEVEL": "${user_config.log_level}",
         "IMAP_MCP_ALLOWED_ATTACHMENT_DIRS": "${user_config.allowed_attachment_dirs}",
+        "IMAP_MCP_ALLOWED_EXPORT_DIRS": "${user_config.allowed_export_dirs}",
         "IMAP_MCP_ENCRYPTION_KEY": "${user_config.encryption_key}",
         "IMAP_MCP_MAX_ATTACHMENT_SIZE_BYTES": "${user_config.max_attachment_size_bytes}",
         "IMAP_MCP_MAX_TOTAL_ATTACHMENT_SIZE_BYTES": "${user_config.max_total_attachment_size_bytes}",
@@ -67,6 +68,14 @@
       "type": "directory",
       "title": "Allowed Attachment Directories",
       "description": "Directories the server may read attachments from for path-based attachment sends. Add only directories that contain files you want to send. Empty list disables the feature.",
+      "multiple": true,
+      "default": [],
+      "required": false
+    },
+    "allowed_export_dirs": {
+      "type": "directory",
+      "title": "Allowed Export Directories",
+      "description": "Directories the export tools may write .eml files DIRECTLY into via destPath (e.g. your Downloads folder). Leave empty to allow anywhere in your home directory (never inside the server's own data dir). Set specific directories to restrict, or a nonexistent path to disable direct export entirely.",
       "multiple": true,
       "default": [],
       "required": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/export-dest-resolver.test.ts
+++ b/src/services/export-dest-resolver.test.ts
@@ -77,4 +77,12 @@ describe('resolveExportDest', () => {
     delete process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS;
     expect(allowedExportRoots()).toEqual([os.homedir()]);
   });
+
+  it('parses a comma-separated list and expands ~', () => {
+    process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS = `${root}, ~/Downloads `;
+    expect(allowedExportRoots()).toEqual([
+      path.resolve(root),
+      path.join(os.homedir(), 'Downloads'),
+    ]);
+  });
 });

--- a/src/services/export-dest-resolver.ts
+++ b/src/services/export-dest-resolver.ts
@@ -31,17 +31,22 @@ import path from 'path';
 /**
  * Allowed roots an export `destPath` may resolve within. Defaults to the
  * user's home directory. Operators narrow or widen this with
- * IMAP_MCP_ALLOWED_EXPORT_DIRS (a path.delimiter-separated list of absolute
- * dirs); set it to a path that doesn't exist to effectively disable destPath.
+ * IMAP_MCP_ALLOWED_EXPORT_DIRS — a comma-separated list of absolute dirs
+ * (comma, not path.delimiter, so it matches the Claude Desktop
+ * directory/multiple config serialization and stays correct on Windows where
+ * `:` appears in drive paths). Set it to a path that doesn't exist to
+ * effectively disable destPath. `~` / `~/…` entries expand to the home dir.
  */
 export function allowedExportRoots(): string[] {
   const env = process.env.IMAP_MCP_ALLOWED_EXPORT_DIRS;
   if (env && env.trim()) {
-    return env
-      .split(path.delimiter)
+    const roots = env
+      .split(',')
       .map((s) => s.trim())
       .filter(Boolean)
+      .map((p) => (p === '~' || p.startsWith('~/') ? path.join(os.homedir(), p.slice(1)) : p))
       .map((p) => path.resolve(p));
+    if (roots.length > 0) return roots;
   }
   return [os.homedir()];
 }

--- a/src/utils/env-resolver.ts
+++ b/src/utils/env-resolver.ts
@@ -203,24 +203,31 @@ export function resolveEnvPlaceholders(): {
     }
   }
 
-  // Targeted recovery for the array case: if the allow-list env var got
-  // cleared (or was never set), pull it from the saved settings JSON.
-  if (!process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS) {
+  // Targeted recovery for the array case: if an allow-list env var got
+  // cleared (or was never set), pull it from the saved settings JSON. Both
+  // IMAP_MCP_ALLOWED_ATTACHMENT_DIRS and IMAP_MCP_ALLOWED_EXPORT_DIRS are
+  // directory/multiple user_config fields and hit the same unsubstituted-
+  // placeholder problem, so they recover identically.
+  const arrayRecoveries: Array<{ env: string; key: string }> = [
+    { env: 'IMAP_MCP_ALLOWED_ATTACHMENT_DIRS', key: 'allowed_attachment_dirs' },
+    { env: 'IMAP_MCP_ALLOWED_EXPORT_DIRS', key: 'allowed_export_dirs' },
+  ];
+  for (const { env, key } of arrayRecoveries) {
+    if (process.env[env]) continue;
     const file = findSettingsFile();
-    if (file) {
-      const settings = readSettings(file);
-      const dirs = settings?.userConfig?.allowed_attachment_dirs;
-      if (Array.isArray(dirs) && dirs.length > 0) {
-        // Each entry may itself contain ${HOME} / ~. Expand both.
-        const expandedDirs = dirs
-          .map(d => typeof d === 'string' ? d : '')
-          .filter(d => d.length > 0)
-          .map(d => expandShellVars(d))
-          .map(d => d.startsWith('~/') ? path.join(os.homedir(), d.slice(2)) : d);
-        if (expandedDirs.length > 0) {
-          process.env.IMAP_MCP_ALLOWED_ATTACHMENT_DIRS = expandedDirs.join(',');
-          recoveredFromSettings.push('IMAP_MCP_ALLOWED_ATTACHMENT_DIRS');
-        }
+    if (!file) break; // no settings file — nothing to recover for either
+    const settings = readSettings(file);
+    const dirs = settings?.userConfig?.[key];
+    if (Array.isArray(dirs) && dirs.length > 0) {
+      // Each entry may itself contain ${HOME} / ~. Expand both.
+      const expandedDirs = dirs
+        .map(d => typeof d === 'string' ? d : '')
+        .filter(d => d.length > 0)
+        .map(d => expandShellVars(d))
+        .map(d => d.startsWith('~/') ? path.join(os.homedir(), d.slice(2)) : d);
+      if (expandedDirs.length > 0) {
+        process.env[env] = expandedDirs.join(',');
+        recoveredFromSettings.push(env);
       }
     }
   }


### PR DESCRIPTION
Follow-up to #270 (pre-submission hardening for the security review).

## What
- Adds `allowed_export_dirs` (directory/multiple) to the extension `user_config` → **"Allowed Export Directories"** in the Claude Desktop UI, mapped to `IMAP_MCP_ALLOWED_EXPORT_DIRS`. Users can now restrict/disable the `destPath` write target without editing env.
- `allowedExportRoots()` now **comma-splits** (matches attachment-dirs + the Desktop directory/multiple serialization; `:` is wrong on Windows drive paths) and expands `~`.
- `env-resolver` recovers `IMAP_MCP_ALLOWED_EXPORT_DIRS` from the settings JSON exactly like the attachment allow-list.

## Safety
Defaults unchanged: empty ⇒ anywhere under home, never inside `~/.imap-mcp`, bare-home/dot-dir/symlink-escape rejected. Reviewers can see the destination is lockable from the UI.

## Verification
- +1 resolver test (comma list + `~` expansion); env-resolver tests green.
- Built manifest carries the new `user_config` field + env mapping.
- Full suite **318 passing**.

Also rolls the `[Unreleased]` `make update-extension` note into **2.32.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
