### PR TITLE
chore: universal-only .mcpb build + release hygiene (#276)

### DIFF
--- a/.github/workflows/build-dxt.yml
+++ b/.github/workflows/build-dxt.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm ci
 
       - name: Build universal .mcpb
-        run: node dxt/build.mjs --universal
+        run: node dxt/build.mjs
 
       - name: Verify artifact exists
         shell: bash

--- a/dxt/build.mjs
+++ b/dxt/build.mjs
@@ -2,27 +2,35 @@
 /**
  * dxt/build.mjs — build a Claude Desktop Extension (.mcpb) for imap-mcp-pro
  *
+ * The runtime is pure JS (node:sqlite, no native deps since v2.16), so the
+ * output is a SINGLE universal .mcpb that runs on macOS, Windows, and Linux —
+ * there is no per-platform build.
+ *
  * Steps:
  *   1. Read version from package.json
  *   2. Run npm run build to produce dist/
  *   3. Stage server/ (dist/ + node_modules/) under dxt/build/server/
- *   4. Rebuild native modules for the target platform (better-sqlite3)
- *   5. Copy icon, screenshots, and merged manifest into dxt/build/
- *   6. Generate tools array via `node dist/index.js --print-tools-manifest`
+ *   4. Copy icon, screenshots, and merged manifest into dxt/build/
+ *   5. Generate tools array via `node dist/index.js --print-tools-manifest`
  *      and merge into manifest.json
- *   7. Zip dxt/build/ into dxt/build/imap-mcp-pro-{version}-{platform}.mcpb
- *   8. Compute SHA-256 alongside
+ *   6. Zip dxt/build/ into dxt/build/imap-mcp-pro-{version}.mcpb
+ *   7. Compute SHA-256 alongside
  *
  * Usage:
- *   node dxt/build.mjs                  # build for current platform
- *   node dxt/build.mjs --skip-rebuild   # skip npm rebuild (faster, native
- *                                       # bindings stay as-installed)
- *   node dxt/build.mjs --skip-zip       # build the layout, skip the zip
+ *   node dxt/build.mjs               # build the universal .mcpb
+ *   node dxt/build.mjs --skip-zip    # build the layout, skip the zip
  *
  * Author: Colin Bitterfield
  * Email: colin.bitterfield@templeofepiphany.com
  * Date Created: 2026-04-29
- * Version: 0.1.0
+ * Date Updated: 2026-07-06
+ * Version: 0.2.0
+ *
+ * Changelog:
+ *   0.2.0 (2026-07-06): Universal-only build. Removed the dead per-platform
+ *     mode (platformLabel/--universal/--skip-rebuild) — with no native deps the
+ *     output is always a single universal .mcpb. Fixed stale better-sqlite3 doc.
+ *   0.1.0 (2026-04-29): Initial version.
  *
  * Tracker: #102. Phase 4 issue: #106.
  */
@@ -41,12 +49,7 @@ const buildDir = path.join(dxtDir, 'build');
 const serverDir = path.join(buildDir, 'server');
 
 const args = new Set(process.argv.slice(2));
-const skipRebuild = args.has('--skip-rebuild');
 const skipZip = args.has('--skip-zip');
-// Universal mode: the runtime is pure JS (node:sqlite, no native deps), so one
-// bundle runs on every platform. Drops the platform suffix from the archive
-// name (imap-mcp-pro-<version>.mcpb) — used for the single MCP Registry artifact.
-const universal = args.has('--universal');
 
 function log(...m) {
   process.stderr.write(`[dxt/build] ${m.join(' ')}\n`);
@@ -65,21 +68,10 @@ function cpr(src, dst) {
   fs.cpSync(src, dst, { recursive: true });
 }
 
-function platformLabel() {
-  const p = process.platform;
-  const a = process.arch;
-  if (p === 'darwin') return a === 'arm64' ? 'macos-arm64' : 'macos-x64';
-  if (p === 'win32') return 'windows-x64';
-  if (p === 'linux') return a === 'arm64' ? 'linux-arm64' : 'linux-x64';
-  return `${p}-${a}`;
-}
-
 // 1. Read version
 const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
 const version = pkg.version;
 log(`version: ${version}`);
-const platform = platformLabel();
-log(`platform: ${platform}`);
 
 // 2. Clean and build
 rmrf(buildDir);
@@ -138,27 +130,22 @@ function pruneNodeModules() {
 }
 pruneNodeModules();
 
-// 4. Native module rebuild — no longer needed.
-//
-// We migrated from better-sqlite3 to node:sqlite (Node 22.5+ built-in)
-// in v2.16. node:sqlite ships inside Node itself, so its native binding
-// inherits the host process's code signature. This means it loads cleanly
-// inside macOS-hardened apps like Claude Desktop, where third-party
-// .node binaries are rejected by library-validation regardless of which
-// Electron headers they were built against.
-//
-// If a future native dep gets reintroduced, mirror the previous
-// `npm rebuild --runtime=electron --target=...` pattern here.
-void skipRebuild;
+// No native-module rebuild step: we migrated from better-sqlite3 to node:sqlite
+// (Node 22.5+ built-in) in v2.16. node:sqlite ships inside Node itself, so its
+// native binding inherits the host process's code signature and loads cleanly
+// inside macOS-hardened apps like Claude Desktop (where third-party .node
+// binaries are rejected by library-validation). This is why the bundle is
+// universal. If a native dep is ever reintroduced, a per-platform build matrix
+// and an `npm rebuild --runtime=electron --target=...` step would be needed.
 
-// 5. Copy assets
+// 4. Copy assets
 cpr(path.join(dxtDir, 'icon.png'), path.join(buildDir, 'icon.png'));
 const screenshotsSrc = path.join(dxtDir, 'screenshots');
 if (fs.existsSync(screenshotsSrc) && fs.readdirSync(screenshotsSrc).length > 0) {
   cpr(screenshotsSrc, path.join(buildDir, 'screenshots'));
 }
 
-// 6. Build manifest with version + tools array
+// 5. Build manifest with version + tools array
 const tplPath = path.join(dxtDir, 'manifest.template.json');
 const manifest = JSON.parse(fs.readFileSync(tplPath, 'utf8'));
 manifest.version = version;
@@ -192,15 +179,14 @@ fs.writeFileSync(
   JSON.stringify(manifest, null, 2) + '\n'
 );
 
-// 7. Zip
+// 6. Zip
 if (skipZip) {
   log('--skip-zip set; layout written to dxt/build/');
   process.exit(0);
 }
 
-const archiveName = universal
-  ? `imap-mcp-pro-${version}.mcpb`
-  : `imap-mcp-pro-${version}-${platform}.mcpb`;
+// Single universal artifact — no platform suffix (see the note above).
+const archiveName = `imap-mcp-pro-${version}.mcpb`;
 const archivePath = path.join(dxtDir, 'build', archiveName);
 
 // Use system zip on macOS/Linux; on Windows use PowerShell Compress-Archive.
@@ -227,7 +213,7 @@ if (process.platform === 'win32') {
   fs.renameSync(tmpArchive, archivePath);
 }
 
-// 8. Compute SHA-256
+// 7. Compute SHA-256
 const buf = fs.readFileSync(archivePath);
 const sha = crypto.createHash('sha256').update(buf).digest('hex');
 fs.writeFileSync(`${archivePath}.sha256`, `${sha}  ${archiveName}\n`);


### PR DESCRIPTION
Closes #276.

## What
- **`dxt/build.mjs` → universal-only.** Removed the dead per-platform mode (`platformLabel`, `--universal`, `--skip-rebuild`). No native deps since v2.16 ⇒ output is always one universal `.mcpb`; the per-OS mode only ever produced identically-behaving bundles under `-linux-x64/-macos-arm64/-windows-x64` names (origin of the legacy v2.17.x assets). Fixed the stale better-sqlite3 header; script bumped to 0.2.0 with an in-file changelog.
- **`build-dxt.yml`** drops the now-removed `--universal` flag.
- **Deleted** the malformed draft `v2.8.1` release (duplicate, bogus `0001-01-01` date). Published v2.8.1 untouched.

## Verification
`node dxt/build.mjs` → `imap-mcp-pro-2.32.0.mcpb` (universal, no platform suffix) + `.sha256`; syntax check clean; no stray refs to removed identifiers.

No server/runtime change — no version bump, no new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)