### PR TITLE
fix: fresh-install schema drift (#279) + imap_folder_status BigInt (#278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.32.1] - 2026-07-08
+
+### Fixed
+- **Fresh installs were missing three tables** (#279) — `schema.sql` seeds the `schema_version` ledger up through 1.7.0, so on a fresh DB the migrator treats migrations 1.4.0/1.5.0/1.6.0 as already-applied and skips them; but those tables were never mirrored into `schema.sql`. Result: every fresh install lacked `categories` (→ `imap_list_categories` / `imap_test_categories`: "no such table: categories") **and** the DNS-firewall tables `dns_firewall_cache` / `dns_firewall_providers`. Backfilled all three (idempotent `IF NOT EXISTS` / `INSERT OR IGNORE`) so `schema.sql` is a complete snapshot; since it runs on every startup, existing broken DBs self-heal on next launch. Added a regression test asserting `schema.sql` carries every table from every seeded migration.
+- **`imap_folder_status` crashed with `TypeError: Do not know how to serialize a BigInt`** (#278) — `selectFolder` returned ImapFlow's `uidValidity`/`uidNext` as `BigInt`, which `JSON.stringify` can't serialize. Now cast to `Number` at the source (matching `imap_get_mailbox_status`).
+
 ## [2.32.0] - 2026-07-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.32.0",
+  "version": "2.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.32.0",
+      "version": "2.32.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.32.0",
+  "version": "2.32.1",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/database/schema-completeness.test.ts
+++ b/src/database/schema-completeness.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Regression guard for #279: schema.sql must be a COMPLETE snapshot of the
+// current schema. Because schema.sql seeds schema_version up through the latest
+// release, the migrator skips the corresponding schema_update_*.sql files on a
+// fresh DB — so any table introduced only in a (seeded) migration and not
+// mirrored into schema.sql is silently absent on every fresh install.
+//
+// This test applies schema.sql to a fresh in-memory DB (twice, to prove
+// idempotency) and asserts that every table created by a migration whose
+// version is seeded in schema.sql actually exists.
+
+import { describe, expect, it } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function seededSchemaVersions(schema: string): Set<string> {
+  const versions = new Set<string>();
+  const re = /INSERT OR IGNORE INTO schema_version[^)]*\)\s*VALUES\s*\('([^']+)'/gi;
+  for (const m of schema.matchAll(re)) versions.add(m[1]);
+  return versions;
+}
+
+function tablesInSql(sql: string): string[] {
+  return [...sql.matchAll(/CREATE TABLE (?:IF NOT EXISTS )?([a-z_][a-z0-9_]*)/gi)].map((m) => m[1]);
+}
+
+describe('schema.sql completeness (#279)', () => {
+  const schema = fs.readFileSync(path.join(here, 'schema.sql'), 'utf8');
+  const manifest = JSON.parse(fs.readFileSync(path.join(here, 'migrations-manifest.json'), 'utf8'));
+  const seeded = seededSchemaVersions(schema);
+
+  it('applies cleanly and idempotently to a fresh DB', () => {
+    const db = new DatabaseSync(':memory:');
+    expect(() => { db.exec(schema); db.exec(schema); }).not.toThrow();
+    db.close();
+  });
+
+  it('contains every table from migrations whose version schema.sql seeds', () => {
+    const db = new DatabaseSync(':memory:');
+    db.exec(schema);
+    const live = new Set(
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all().map((r: any) => r.name),
+    );
+
+    const missing: string[] = [];
+    for (const mig of manifest.migrations) {
+      // Only migrations the fresh-DB seed marks as already-applied are the risk:
+      // those get skipped by the migrator, so schema.sql must carry their tables.
+      if (!seeded.has(mig.to)) continue;
+      const sql = fs.readFileSync(path.join(here, mig.file), 'utf8');
+      for (const t of tablesInSql(sql)) {
+        if (!live.has(t)) missing.push(`${t} (from ${mig.file})`);
+      }
+    }
+    db.close();
+    expect(missing, `tables missing from schema.sql: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('has the specific tables from the #279 report', () => {
+    const db = new DatabaseSync(':memory:');
+    db.exec(schema);
+    for (const t of ['categories', 'dns_firewall_cache', 'dns_firewall_providers']) {
+      const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(t);
+      expect(row, `${t} should exist in a fresh schema.sql DB`).toBeTruthy();
+    }
+    // Quad9 seed present exactly once (INSERT OR IGNORE, re-run safe)
+    db.exec(schema);
+    const n = (db.prepare('SELECT count(*) c FROM dns_firewall_providers').get() as any).c;
+    expect(n).toBe(1);
+    db.close();
+  });
+});

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -329,3 +329,87 @@ CREATE TABLE IF NOT EXISTS result_attachments (
 
 CREATE INDEX IF NOT EXISTS idx_result_attachments_result   ON result_attachments(result_id);
 CREATE INDEX IF NOT EXISTS idx_result_attachments_msg_uid  ON result_attachments(result_id, message_uid);
+
+-- ---------------------------------------------------------------------------
+-- Backfill of tables that were introduced ONLY in migrations 1.4.0/1.5.0/1.6.0
+-- but never mirrored here (#279). Because schema.sql seeds schema_version up
+-- through 1.7.0 (above), the migrator treats those migrations as already
+-- applied on a fresh DB and skips them — so without these definitions a fresh
+-- install is missing the categories + DNS firewall tables entirely. schema.sql
+-- runs on every startup with IF NOT EXISTS / INSERT OR IGNORE, so this is
+-- idempotent and also self-heals already-created DBs on next launch.
+-- ---------------------------------------------------------------------------
+
+-- DNS Firewall cache (from schema_update_1.3.0_TO_1.4.0.sql, Issue #59)
+CREATE TABLE IF NOT EXISTS dns_firewall_cache (
+  domain TEXT PRIMARY KEY,
+  is_safe BOOLEAN NOT NULL,
+  is_blocked BOOLEAN NOT NULL,
+  provider TEXT NOT NULL DEFAULT 'quad9',
+  checked_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  metadata TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_dns_cache_expires ON dns_firewall_cache(expires_at);
+CREATE INDEX IF NOT EXISTS idx_dns_cache_domain ON dns_firewall_cache(domain);
+
+-- DNS Firewall providers (from schema_update_1.4.0_TO_1.5.0.sql, Issue #60)
+CREATE TABLE IF NOT EXISTS dns_firewall_providers (
+  provider_id TEXT PRIMARY KEY,
+  provider_name TEXT NOT NULL,
+  provider_type TEXT NOT NULL CHECK(provider_type IN ('dns-over-https', 'dns-lookup')),
+  api_endpoint TEXT,
+  api_key TEXT,
+  is_enabled BOOLEAN NOT NULL DEFAULT 1,
+  is_default BOOLEAN NOT NULL DEFAULT 0,
+  timeout_ms INTEGER NOT NULL DEFAULT 5000,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  metadata TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_dns_providers_enabled ON dns_firewall_providers(is_enabled);
+CREATE INDEX IF NOT EXISTS idx_dns_providers_default ON dns_firewall_providers(is_default);
+
+-- Seed Quad9 as the default provider. INSERT OR IGNORE (not the migration's
+-- plain INSERT) because schema.sql re-runs on every startup.
+INSERT OR IGNORE INTO dns_firewall_providers (
+  provider_id, provider_name, provider_type, api_endpoint, api_key,
+  is_enabled, is_default, timeout_ms, created_at, updated_at, metadata
+) VALUES (
+  'quad9', 'Quad9', 'dns-over-https', 'dns.quad9.net', NULL,
+  1, 1, 5000,
+  strftime('%s', 'now') * 1000, strftime('%s', 'now') * 1000,
+  '{"description":"Quad9 DNS-over-HTTPS threat intelligence service"}'
+);
+
+CREATE TRIGGER IF NOT EXISTS ensure_single_default_provider
+BEFORE UPDATE ON dns_firewall_providers
+WHEN NEW.is_default = 1 AND OLD.is_default = 0
+BEGIN
+  UPDATE dns_firewall_providers SET is_default = 0 WHERE provider_id != NEW.provider_id;
+END;
+
+-- Quick Categories (from schema_update_1.5.0_TO_1.6.0.sql, Issue #71)
+CREATE TABLE IF NOT EXISTS categories (
+  category_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  category_name TEXT NOT NULL,
+  keywords TEXT NOT NULL,
+  target_folder TEXT NOT NULL,
+  enabled BOOLEAN DEFAULT 1,
+  match_count INTEGER DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  last_matched TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+  FOREIGN KEY (account_id) REFERENCES accounts(account_id) ON DELETE CASCADE,
+  UNIQUE(user_id, account_id, category_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_categories_user ON categories(user_id);
+CREATE INDEX IF NOT EXISTS idx_categories_account ON categories(account_id);
+CREATE INDEX IF NOT EXISTS idx_categories_enabled ON categories(enabled);
+CREATE INDEX IF NOT EXISTS idx_categories_name ON categories(category_name);

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -712,8 +712,11 @@ export class ImapService {
           new: 0, // ImapFlow doesn't provide this directly
           unseen: 0 // Not available in MailboxObject
         },
-        uidvalidity: mailbox.uidValidity,
-        uidnext: mailbox.uidNext,
+        // ImapFlow returns uidValidity (and sometimes uidNext) as BigInt, which
+        // JSON.stringify cannot serialize (#278). Cast to Number — both fit
+        // safely in a 53-bit float. Mirrors getMailboxStatus's handling.
+        uidvalidity: Number(mailbox.uidValidity ?? 0),
+        uidnext: Number(mailbox.uidNext ?? 0),
         flags: mailbox.flags,
         permanentFlags: mailbox.permanentFlags
       };


### PR DESCRIPTION
Closes #278. Closes #279.

## #279 — fresh installs missing tables (root cause was broader than reported)
`schema.sql` seeds `schema_version` up through **1.7.0**, so on a fresh DB the migrator treats migrations 1.4.0/1.5.0/1.6.0 as already-applied and **skips** them — but those tables were never mirrored into `schema.sql`. So every fresh install lacked:
- `categories` → `imap_list_categories` / `imap_test_categories` "no such table" (the reported symptom)
- `dns_firewall_cache`, `dns_firewall_providers` → the **DNS-firewall routes** would fail identically on a fresh DB

Backfilled all three into `schema.sql` (idempotent `CREATE … IF NOT EXISTS`, `INSERT OR IGNORE` for the Quad9 seed, `CREATE TRIGGER IF NOT EXISTS`). `schema.sql` runs on every startup, so **already-broken DBs self-heal on next launch** — no manual migration needed. Added `schema-completeness.test.ts` asserting `schema.sql` carries every table from every *seeded* migration (guards against this class of drift going forward).

## #278 — BigInt crash
`selectFolder` returned ImapFlow's `uidValidity`/`uidNext` as `BigInt`; `JSON.stringify` can't serialize it, so `imap_folder_status` threw. Cast to `Number` at the source (matches the working `imap_get_mailbox_status`).

## Verification
- Fresh in-memory DB from `schema.sql` now has all three tables; second `exec` is idempotent (Quad9 seed stays at 1 row).
- Full suite **321 passing** (+3 schema-completeness).

Note: #280 (parallel folder-scoped race) is a separate deeper fix, tracked on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
