### PR TITLE
fix: serialize folder-scoped ops per account — concurrency race (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.32.2] - 2026-07-08
+
+### Fixed
+- **Concurrency race: parallel folder-scoped calls returned cross-contaminated data** (#280) — a single account's IMAP connection is one stateful channel (exactly one mailbox SELECTed at a time), so running folder-scoped tools concurrently (e.g. a batch of `imap_get_unread_count` / `imap_get_largest_emails` / `imap_search_emails`) let one operation's `SELECT` redefine another's mailbox mid-flight — yielding silently wrong counts and search results (no error raised). Introduced a **re-entrant per-account serializer** (`AccountSerializer`, `AsyncLocalStorage`-based) wired at the `withRetry` choke point: each SELECT+operation now runs to completion before the next begins on that connection, while different accounts still run in parallel. Re-entrancy prevents deadlock where a serialized op calls another on the same account (e.g. `getMultipleMailboxStatus` → `getMailboxStatus`). (Per-account serialization matches IMAP's inherently serial single connection — no legitimate throughput is lost.)
+
 ## [2.32.1] - 2026-07-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.32.1",
+  "version": "2.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.32.1",
+      "version": "2.32.2",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.32.1",
+  "version": "2.32.2",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -39,6 +39,7 @@ import {
 } from '../types/index.js';
 import { LRUCache } from '../utils/memory-manager.js';
 import { WorkerPool } from '../utils/worker-pool.js';
+import { AccountSerializer } from '../utils/account-serial.js';
 import { ContextReductionConfig as Cfg } from '../config/context-reduction.js';
 
 /** Per-message size + light envelope info from a RFC822.SIZE fetch (no body). */
@@ -95,6 +96,12 @@ export class ImapService {
   private capabilitiesCache: Map<string, { capabilities: ServerCapabilities; timestamp: number }> = new Map();
   private db?: any; // Optional DatabaseService for auto-capability storage (Issue #58)
   private workerPool?: WorkerPool;
+
+  // Per-account command serializer (#280): folder-scoped operations on one
+  // account share a single stateful IMAP connection, so they must run one at a
+  // time or a concurrent SELECT corrupts another op's mailbox context. Wraps
+  // withRetry; re-entrant so nested ops on the same account don't deadlock.
+  private readonly serializer = new AccountSerializer();
 
   // Level 3: Operation queue with size limit (Issue #22 - prevent unbounded growth)
   private operationQueue: QueuedOperation[] = [];
@@ -520,6 +527,21 @@ export class ImapService {
    * Level 2: Retry wrapper for all operations
    */
   private async withRetry<T>(
+    accountId: string,
+    operation: () => Promise<T>,
+    operationName: string
+  ): Promise<T> {
+    // Serialize per account so a folder-scoped SELECT+operation completes before
+    // the next begins on the shared connection (#280). Re-entrant: nested
+    // withRetry calls on the same account (e.g. getMultipleMailboxStatus ->
+    // getMailboxStatus) run inline instead of deadlocking. The whole retry loop
+    // is held so a retry never yields the connection mid-sequence.
+    return this.serializer.run(accountId, () =>
+      this.runWithRetry(accountId, operation, operationName),
+    );
+  }
+
+  private async runWithRetry<T>(
     accountId: string,
     operation: () => Promise<T>,
     operationName: string

--- a/src/utils/account-serial.test.ts
+++ b/src/utils/account-serial.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for AccountSerializer — the per-account concurrency guard (#280).
+
+import { describe, expect, it } from 'vitest';
+import { AccountSerializer } from './account-serial.js';
+
+const tick = (ms = 0) => new Promise((r) => setTimeout(r, ms));
+
+describe('AccountSerializer', () => {
+  it('serializes operations on the same key (no interleaving)', async () => {
+    const s = new AccountSerializer();
+    const events: string[] = [];
+    // Simulate SELECT+op: enter (SELECT), await, exit (op reads current folder).
+    const op = (id: string) => s.run('acct', async () => {
+      events.push(`enter:${id}`);
+      await tick(5);
+      events.push(`exit:${id}`);
+    });
+    await Promise.all([op('A'), op('B'), op('C')]);
+    // Each op's enter must be immediately followed by its own exit — no
+    // interleaving like enter:A, enter:B, exit:A.
+    expect(events).toEqual([
+      'enter:A', 'exit:A',
+      'enter:B', 'exit:B',
+      'enter:C', 'exit:C',
+    ]);
+  });
+
+  it('reproduces the #280 cross-contamination WITHOUT the guard, and fixes it WITH it', async () => {
+    // Shared "connection": mailboxOpen sets currentFolder; the op reads it back
+    // after an await. Concurrent unguarded runs leak one folder into another.
+    let currentFolder = '';
+    const unguarded = async (folder: string) => {
+      currentFolder = folder;          // SELECT
+      await tick(5);                   // yield mid-operation
+      return currentFolder;            // SEARCH sees whatever folder is selected now
+    };
+    const bad = await Promise.all([unguarded('INBOX'), unguarded('Junk'), unguarded('Archive')]);
+    expect(bad).toEqual(['Archive', 'Archive', 'Archive']); // all leaked to the last SELECT
+
+    const s = new AccountSerializer();
+    const guarded = (folder: string) => s.run('acct', () => unguarded(folder));
+    const good = await Promise.all([guarded('INBOX'), guarded('Junk'), guarded('Archive')]);
+    expect(good).toEqual(['INBOX', 'Junk', 'Archive']); // each op sees its own folder
+  });
+
+  it('is re-entrant: a held key run inline (getMultipleMailboxStatus -> getMailboxStatus)', async () => {
+    const s = new AccountSerializer();
+    let deadlocked = true;
+    await s.run('acct', async () => {
+      // Nested call on the same key must NOT wait on the outer lock.
+      const inner = await s.run('acct', async () => {
+        expect(s.holds('acct')).toBe(true);
+        return 42;
+      });
+      expect(inner).toBe(42);
+      deadlocked = false;
+    });
+    expect(deadlocked).toBe(false);
+  });
+
+  it('runs different keys concurrently', async () => {
+    const s = new AccountSerializer();
+    const order: string[] = [];
+    await Promise.all([
+      s.run('A', async () => { order.push('A-start'); await tick(10); order.push('A-end'); }),
+      s.run('B', async () => { order.push('B-start'); await tick(1); order.push('B-end'); }),
+    ]);
+    // B (different key) is not blocked by A: it starts and finishes during A's await.
+    expect(order.indexOf('B-end')).toBeLessThan(order.indexOf('A-end'));
+    expect(order.slice(0, 2).sort()).toEqual(['A-start', 'B-start']);
+  });
+
+  it('a failed op does not wedge the queue', async () => {
+    const s = new AccountSerializer();
+    await expect(s.run('acct', async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    // The next op on the same key still runs.
+    await expect(s.run('acct', async () => 'ok')).resolves.toBe('ok');
+  });
+});

--- a/src/utils/account-serial.ts
+++ b/src/utils/account-serial.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// account-serial.ts — per-key re-entrant serialization (#280).
+//
+// An IMAP connection is a single stateful channel: exactly one mailbox is
+// SELECTed at a time and a folder-scoped operation is really a SELECT followed
+// by SEARCH/FETCH/STORE. If two such operations run concurrently over one
+// shared connection, ImapFlow interleaves them and one operation's SELECT
+// redefines the current mailbox mid-flight for the other — yielding silently
+// wrong counts/search results (#280).
+//
+// AccountSerializer serializes operations per key (account id) so each
+// SELECT+operation runs to completion before the next begins. It is
+// RE-ENTRANT: a serialized operation that internally calls another serialized
+// operation on the SAME key runs inline instead of deadlocking on a lock it
+// already holds (e.g. getMultipleMailboxStatus -> getMailboxStatus). Different
+// keys run concurrently (different accounts don't share a connection).
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export class AccountSerializer {
+  /** Tail of each key's promise chain. Absent when the key is idle. */
+  private chains = new Map<string, Promise<void>>();
+  /** Set of keys whose critical section the current async context holds. */
+  private held = new AsyncLocalStorage<Set<string>>();
+
+  /**
+   * Run `fn` in `key`'s serial queue. Re-entrant calls on a key already held
+   * by the current async context run immediately (no re-queue, no deadlock).
+   */
+  async run<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const current = this.held.getStore();
+    if (current?.has(key)) {
+      return fn();
+    }
+
+    const prev = this.chains.get(key) ?? Promise.resolve();
+    const result = prev.then(() => {
+      const next = new Set(current ?? []);
+      next.add(key);
+      return this.held.run(next, fn);
+    });
+
+    // The stored tail swallows errors so one failed op never wedges the queue,
+    // and drops the map entry once this is the last op so the map stays bounded.
+    const tail: Promise<void> = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.chains.set(key, tail);
+    void tail.then(() => {
+      if (this.chains.get(key) === tail) this.chains.delete(key);
+    });
+
+    return result;
+  }
+
+  /** True if the current async context is inside `key`'s critical section. */
+  holds(key: string): boolean {
+    return this.held.getStore()?.has(key) ?? false;
+  }
+}


### PR DESCRIPTION
Closes #280.

## Problem
One account = one stateful IMAP connection (a single SELECTed mailbox). Folder-scoped tools do `SELECT` then `SEARCH`/`FETCH`/`STORE`. Running them concurrently interleaves those sequences, so one op's `SELECT` redefines another's mailbox mid-flight → **silently wrong counts/search results, no error**. p1 because it can mislead bulk move/delete driven by a bad UID scan.

## Fix
`AccountSerializer` — a **re-entrant, per-account** serializer (`AsyncLocalStorage`-based) wired at the single `withRetry` choke point. Each `SELECT`+operation now completes before the next begins on that connection; different accounts still run in parallel. Re-entrancy prevents deadlock when a serialized op calls another on the same account (e.g. `getMultipleMailboxStatus` → `getMailboxStatus`, both `withRetry`). The full retry loop is held so a retry never yields the connection mid-sequence.

No legitimate throughput lost — a single IMAP connection is inherently serial; the "parallel" folder ops were racing, not truly concurrent.

## Tests
`src/utils/account-serial.test.ts` (5) — serialization (no interleaving), a **direct #280 reproduction** (unguarded leaks the last `SELECT` into every result `['Archive','Archive','Archive']`; guarded → `['INBOX','Junk','Archive']`), re-entrancy/no-deadlock, cross-key concurrency, error isolation. Full suite **326 passing**; no deadlock/regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
