### PR TITLE
fix: FTS5-optional account delete + duplicate-account guard (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.32.4] - 2026-07-12
+
+### Fixed
+- **Account deletion failed with `no such module: fts5` on SQLite builds without FTS5** (#286) — `node:sqlite` enables foreign keys by default, so deleting an account cascades into `messages_cache`, firing the FTS sync trigger that touches the `messages_cache_fts` FTS5 table; on builds compiled without FTS5 (seen on some Windows Node builds) that throws. `DatabaseService` now probes FTS5 at startup and, when absent, drops the `messages_cache` FTS triggers so cache sync and account deletion work without full-text search. `imap_search_cache` fulltext mode now returns a clear "FTS5 unavailable" message instead of the raw module error. FTS5-capable builds are unchanged.
+- **Adding an account didn't check for duplicates** (#286) — `accounts` has no unique constraint on the IMAP identity, so re-adding the same mailbox silently created a second account. `createAccount` now rejects a duplicate `(user_id, host, username)` (case-insensitive) with a clear error (new `findAccountByImapIdentity`); a different mailbox on the same host, or the same identity under a different user, are still allowed.
+
 ## [2.32.3] - 2026-07-08
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.32.3",
+  "version": "2.32.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.32.3",
+      "version": "2.32.4",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.32.3",
+  "version": "2.32.4",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/database-service.account-dedup.test.ts
+++ b/src/services/database-service.account-dedup.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for createAccount duplicate rejection + FTS5 reconciliation (#286).
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { DatabaseService } from './database-service.js';
+
+const KEY = 'a'.repeat(64); // 32-byte hex AES key for the test DB
+
+function baseAccount(userId: string, over: Record<string, unknown> = {}) {
+  return {
+    user_id: userId,
+    name: 'Test',
+    host: 'imap.example.com',
+    port: 993,
+    username: 'user@example.com',
+    password: 'secret',
+    tls: true,
+    ...over,
+  } as any;
+}
+
+describe('createAccount duplicate rejection (#286)', () => {
+  let dir: string;
+  let db: DatabaseService;
+  const userId = 'u1';
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dbsvc-dedup-'));
+    db = new DatabaseService({ dbPath: path.join(dir, 'data.db'), encryptionKey: KEY });
+    db.createUser({ user_id: userId, username: 'u1', email: null, organization: null, is_active: true, metadata: null } as any);
+  });
+
+  afterEach(() => {
+    try { db.close?.(); } catch { /* ignore */ }
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reconcileFts5 ran at init (FTS5 present in this build)', () => {
+    expect(db.isFtsAvailable()).toBe(true);
+  });
+
+  it('rejects a second account with the same IMAP identity', () => {
+    const first = db.createAccount(baseAccount(userId));
+    expect(first.account_id).toBeTruthy();
+    expect(() => db.createAccount(baseAccount(userId))).toThrow(/already exists/i);
+  });
+
+  it('matches identity case-insensitively (host + username)', () => {
+    db.createAccount(baseAccount(userId));
+    expect(() =>
+      db.createAccount(baseAccount(userId, { host: 'IMAP.Example.COM', username: 'User@Example.com' })),
+    ).toThrow(/already exists/i);
+    expect(db.findAccountByImapIdentity(userId, 'imap.example.com', 'USER@EXAMPLE.COM')).toBeTruthy();
+  });
+
+  it('allows a different mailbox on the same host', () => {
+    db.createAccount(baseAccount(userId));
+    const second = db.createAccount(baseAccount(userId, { username: 'other@example.com' }));
+    expect(second.account_id).toBeTruthy();
+    expect(db.listAccountsForUser(userId)).toHaveLength(2);
+  });
+
+  it('account deletion cascades into messages_cache and fires the FTS trigger cleanly (#286)', () => {
+    const acct = db.createAccount(baseAccount(userId));
+    const raw = db.getDb();
+    raw.prepare(
+      `INSERT INTO messages_cache (account_id, folder, uid, uid_validity, subject, from_address, from_name, cached_at)
+       VALUES (?,?,?,?,?,?,?,?)`,
+    ).run(acct.account_id, 'INBOX', 1, 1, 'hello world', 'a@b.com', 'Alice', 0);
+
+    // On an FTS5 build the delete-cascade fires messages_cache_fts_ad; on an
+    // FTS5-less build reconcileFts5 has dropped that trigger. Either way: no throw.
+    expect(() => db.deleteAccount(acct.account_id)).not.toThrow();
+    const row = raw.prepare('SELECT count(*) AS c FROM messages_cache WHERE account_id = ?').get(acct.account_id) as any;
+    expect(row.c).toBe(0);
+  });
+
+  it('allows the same identity for a different user (multi-tenant isolation)', () => {
+    db.createUser({ user_id: 'u2', username: 'u2', email: null, organization: null, is_active: true, metadata: null } as any);
+    db.createAccount(baseAccount(userId));
+    const other = db.createAccount(baseAccount('u2'));
+    expect(other.account_id).toBeTruthy();
+  });
+});

--- a/src/services/database-service.ts
+++ b/src/services/database-service.ts
@@ -274,6 +274,52 @@ export class DatabaseService {
         console.error(`[DatabaseService] Applied ${result.applied.length} migration(s)`);
       }
     }
+
+    // Reconcile FTS5 availability. node:sqlite on some platforms (e.g. certain
+    // Windows Node builds) is compiled without FTS5. The messages_cache
+    // AI/AU/AD triggers reference the fts5 virtual table, so on such builds ANY
+    // cache write — and the account-delete cascade into messages_cache — throws
+    // "no such module: fts5" (#286). This drops those triggers when FTS5 is
+    // absent so the rest works; full-text search is then guarded off.
+    this.reconcileFts5();
+  }
+
+  /** Whether this SQLite build has the FTS5 module. Set at init. */
+  private ftsAvailable = true;
+
+  /** True if full-text cache search (messages_cache_fts) is usable here. */
+  isFtsAvailable(): boolean {
+    return this.ftsAvailable;
+  }
+
+  /**
+   * Detect FTS5 support and, if absent, drop the messages_cache FTS sync
+   * triggers so cache writes / account deletes don't hit "no such module: fts5".
+   * Dropping a trigger doesn't load the module, so it's safe on FTS5-less
+   * builds. The inert virtual table can't be dropped without the module and is
+   * simply never queried (searchFullText guards on isFtsAvailable()).
+   */
+  private reconcileFts5(): void {
+    try {
+      this.db.exec('CREATE VIRTUAL TABLE IF NOT EXISTS __fts5_probe__ USING fts5(x)');
+      try { this.db.exec('DROP TABLE IF EXISTS __fts5_probe__'); } catch { /* ignore */ }
+      this.ftsAvailable = true;
+      return;
+    } catch {
+      this.ftsAvailable = false;
+    }
+
+    for (const trg of ['messages_cache_fts_ai', 'messages_cache_fts_au', 'messages_cache_fts_ad']) {
+      try {
+        this.db.exec(`DROP TRIGGER IF EXISTS ${trg}`);
+      } catch (e: any) {
+        console.error(`[DatabaseService] FTS trigger cleanup warning (${trg}):`, e?.message);
+      }
+    }
+    console.error(
+      '[DatabaseService] FTS5 not available in this SQLite build — full-text cache search disabled; ' +
+      'dropped messages_cache FTS triggers so sync and account deletion work without it.',
+    );
   }
 
   /**
@@ -384,7 +430,31 @@ export class DatabaseService {
   // Account Management
   // ===================
 
+  /**
+   * Find an existing account with the same IMAP identity (same user, host and
+   * username, compared case-insensitively) — used to prevent duplicates.
+   */
+  findAccountByImapIdentity(userId: string, host: string, username: string): Account | null {
+    const stmt = this.db.prepare(
+      `SELECT * FROM accounts
+       WHERE user_id = ? AND LOWER(host) = LOWER(?) AND LOWER(username) = LOWER(?)
+       LIMIT 1`,
+    );
+    return (stmt.get(userId, host, username) as Account | undefined) ?? null;
+  }
+
   createAccount(account: Omit<DecryptedAccount, 'account_id' | 'created_at' | 'updated_at' | 'last_connected'>): Account {
+    // Reject duplicates up front — the accounts table has no unique constraint
+    // on the IMAP identity, so without this a second add silently creates a
+    // second account for the same mailbox.
+    const existing = this.findAccountByImapIdentity(account.user_id, account.host, account.username);
+    if (existing) {
+      throw new Error(
+        `An account for ${account.username}@${account.host} already exists (account_id: ${existing.account_id}). ` +
+        `Remove it first with imap_remove_account, or use the existing account.`,
+      );
+    }
+
     const accountId = crypto.randomUUID();
 
     // Encrypt password

--- a/src/services/message-cache-service.ts
+++ b/src/services/message-cache-service.ts
@@ -404,6 +404,12 @@ export class MessageCacheService {
     query: string,
     options: SearchOptions = {},
   ): Promise<CachedMessageRow[]> {
+    if (!this.db.isFtsAvailable()) {
+      throw new Error(
+        'Full-text search is unavailable: this SQLite build was compiled without FTS5. ' +
+        'Use search mode by_domain or by_address instead, or run on a build that includes FTS5.',
+      );
+    }
     this.assertSynced(accountId, folder);
 
     const ftsQuery = String(query ?? '')


### PR DESCRIPTION
Closes #286.

**Bug 1 — `no such module: fts5` on account delete.** node:sqlite enables FKs by default, so `DELETE FROM accounts` cascades into `messages_cache` → fires the FTS sync trigger → touches the FTS5 vtable → throws on FTS5-less builds (some Windows Node). `reconcileFts5()` probes FTS5 at init and drops the `messages_cache` FTS triggers when absent (safe; no module load); `searchFullText` guards on `isFtsAvailable()`. FTS5 builds unchanged.

**Bug 2 — no duplicate check.** `createAccount` now rejects a duplicate `(user_id, host, username)` (case-insensitive) with a clear error; different mailbox / different user still allowed.

6 new tests (incl. delete-cascade + FTS trigger). Full suite **332 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)