### PR TITLE
fix: unify data dir to ~/.imap-mcp + duplicate-instance guard (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to IMAP MCP Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.33.0] - 2026-07-12
+
+### Fixed
+- **Extension used a different data store than the CLI/service — accounts added elsewhere were invisible** (#288) — the Claude Desktop extension defaulted its **Data Directory** to `~/.imap-mcp-pro`, while `server-config`, the CLI, the launchd Web UI service, the outbox, and the encryption key all use `~/.imap-mcp`. So an account added via one entry point lived in a *different* SQLite DB (and even a different `colin` user_id) than the MCP session read. The manifest `database_path` default is now `${HOME}/.imap-mcp`, unifying the store across every entry point. **Existing installs:** set Data Directory to `~/.imap-mcp` in Settings → Extensions and restart Claude Desktop to see accounts added via the CLI/Web-UI service.
+
+### Added
+- **Duplicate-instance guard** (#288) — installing the extension twice starts two MCP servers against one data dir. `registerInstance()` writes a pidfile in the data dir at startup and logs a clear warning when another live instance already holds it (non-blocking), so a duplicate install doesn't silently create confusing/split state.
+
 ## [2.32.4] - 2026-07-12
 
 ### Fixed

--- a/dxt/manifest.template.json
+++ b/dxt/manifest.template.json
@@ -53,8 +53,8 @@
     "database_path": {
       "type": "directory",
       "title": "Data Directory",
-      "description": "Where IMAP MCP Pro stores its SQLite database, staged uploads, and result cache. Choose a writable location.",
-      "default": "${HOME}/.imap-mcp-pro",
+      "description": "Where IMAP MCP Pro stores its SQLite database, staged uploads, and result cache. Choose a writable location. Default is ~/.imap-mcp — the same store the CLI and Web UI service use, so accounts are shared across all entry points.",
+      "default": "${HOME}/.imap-mcp",
       "required": true
     },
     "encryption_key": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.32.4",
+  "version": "2.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@temple-of-epiphany/imap-mcp-pro",
-      "version": "2.32.4",
+      "version": "2.33.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temple-of-epiphany/imap-mcp-pro",
-  "version": "2.32.4",
+  "version": "2.33.0",
   "description": "Enterprise-grade IMAP MCP server with Level 1-3 reliability features, circuit breaker, metrics, and bulk operations for commercial and large-scale deployments",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { dispatchCli, EXIT_CODES } from './config/cli.js';
 import { loadConfig, ConfigError } from './config/loader.js';
 import { logEvent, timeStage, SERVER_CAPABILITIES } from './startup.js';
 import { PACKAGE_VERSION } from './utils/package-info.js';
+import { registerInstance } from './utils/instance-lock.js';
 
 // Resolve the bundled-skills directory across every runtime layout (#268).
 // postbuild copies skills/ -> dist/skills/, and the .mcpb ships only dist/
@@ -130,6 +131,20 @@ const {
       logEvent('[startup]', { stage: 'pre-handshake', outcome: 'error', component: 'DatabaseService', error: e?.message });
       process.exit(EXIT_CODES.DATABASE_ERROR);
     }
+
+    // Duplicate-instance guard (#288): warn if another IMAP MCP Pro is already
+    // running against this data dir (e.g. the extension installed twice). Two
+    // servers on one store is confusing and split-brain-prone; surface it.
+    try {
+      const dataDir = path.dirname(config.database.path);
+      const other = registerInstance(dataDir, { version: PACKAGE_VERSION });
+      if (other) {
+        logEvent('[startup]', {
+          stage: 'pre-handshake', outcome: 'warning', component: 'InstanceLock',
+          message: `Another IMAP MCP Pro instance (pid ${other.pid}, started ${new Date(other.startedAt).toISOString()}) is already running against ${dataDir}. Running two instances is unsupported — remove the duplicate extension install to avoid confusing/split state.`,
+        });
+      }
+    } catch { /* guard is best-effort */ }
 
     // 4. Downstream services
     const fileExport = new FileExportService(db);

--- a/src/utils/instance-lock.test.ts
+++ b/src/utils/instance-lock.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// Tests for registerInstance — the duplicate-instance guard (#288).
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { registerInstance } from './instance-lock.js';
+
+describe('registerInstance (#288)', () => {
+  let dir: string;
+  const lock = () => path.join(dir, '.instance.lock');
+
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'inst-lock-')); });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns null and writes the lock when no prior instance', () => {
+    const other = registerInstance(dir, { pid: 100, noExitHook: true, alive: () => true });
+    expect(other).toBeNull();
+    expect(JSON.parse(fs.readFileSync(lock(), 'utf8')).pid).toBe(100);
+  });
+
+  it('detects another LIVE instance holding the lock', () => {
+    registerInstance(dir, { pid: 100, noExitHook: true, alive: () => true });
+    const other = registerInstance(dir, { pid: 200, noExitHook: true, alive: (p) => p === 100 });
+    expect(other?.pid).toBe(100);
+    // The lock is re-pointed at us regardless.
+    expect(JSON.parse(fs.readFileSync(lock(), 'utf8')).pid).toBe(200);
+  });
+
+  it('ignores a stale lock whose pid is dead', () => {
+    registerInstance(dir, { pid: 100, noExitHook: true, alive: () => true });
+    const other = registerInstance(dir, { pid: 200, noExitHook: true, alive: () => false });
+    expect(other).toBeNull();
+  });
+
+  it('ignores its own pid (restart / re-register)', () => {
+    registerInstance(dir, { pid: 100, noExitHook: true, alive: () => true });
+    const other = registerInstance(dir, { pid: 100, noExitHook: true, alive: () => true });
+    expect(other).toBeNull();
+  });
+
+  it('overwrites a corrupt lockfile without throwing', () => {
+    fs.writeFileSync(lock(), 'not json');
+    const other = registerInstance(dir, { pid: 200, noExitHook: true, alive: () => true });
+    expect(other).toBeNull();
+    expect(JSON.parse(fs.readFileSync(lock(), 'utf8')).pid).toBe(200);
+  });
+});

--- a/src/utils/instance-lock.ts
+++ b/src/utils/instance-lock.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//
+// instance-lock.ts — detect a second IMAP MCP Pro instance on one data dir (#288).
+//
+// Installing the Claude Desktop extension twice (or running the extension +
+// launchd Web UI service) starts multiple MCP servers. Now that every entry
+// point defaults to the same data dir (~/.imap-mcp), a duplicate install shares
+// the store — but two servers writing the same SQLite file and both probing the
+// Web UI port is still a confusing, split-brain-prone setup. This writes a
+// pidfile in the data dir and, if another LIVE instance already holds it,
+// returns that instance's info so startup can log a clear warning. It does NOT
+// block (two instances can technically coexist) — it surfaces the risk.
+
+import fs from 'fs';
+import path from 'path';
+
+export interface InstanceInfo {
+  pid: number;
+  startedAt: number;
+  version?: string;
+}
+
+/** True if a process with `pid` currently exists (EPERM counts as alive). */
+export function isPidAlive(pid: number): boolean {
+  if (!pid || pid <= 0 || pid === process.pid) return pid === process.pid;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    return e?.code === 'EPERM'; // exists but owned by another user
+  }
+}
+
+export interface RegisterOptions {
+  version?: string;
+  /** Injectable liveness check (tests). */
+  alive?: (pid: number) => boolean;
+  /** Injectable pid (tests). */
+  pid?: number;
+  /** Skip installing the process 'exit' cleanup hook (tests). */
+  noExitHook?: boolean;
+}
+
+/**
+ * Claim `dataDir` for this process. Returns the other live instance's info if
+ * one already holds the lock (caller warns), else null. Always (re)writes the
+ * lockfile to point at us and, unless disabled, removes it on process exit.
+ */
+export function registerInstance(dataDir: string, opts: RegisterOptions = {}): InstanceInfo | null {
+  const alive = opts.alive ?? isPidAlive;
+  const selfPid = opts.pid ?? process.pid;
+  const lockPath = path.join(dataDir, '.instance.lock');
+
+  let other: InstanceInfo | null = null;
+  try {
+    if (fs.existsSync(lockPath)) {
+      const prev = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as InstanceInfo;
+      if (prev?.pid && prev.pid !== selfPid && alive(prev.pid)) {
+        other = prev;
+      }
+    }
+  } catch {
+    // Corrupt/unreadable lock — treat as stale and overwrite.
+  }
+
+  const info: InstanceInfo = { pid: selfPid, startedAt: Date.now(), version: opts.version };
+  try {
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify(info), { mode: 0o600 });
+    if (!opts.noExitHook) {
+      process.once('exit', () => {
+        try {
+          const cur = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as InstanceInfo;
+          if (cur?.pid === selfPid) fs.unlinkSync(lockPath);
+        } catch {
+          // best effort
+        }
+      });
+    }
+  } catch {
+    // Best effort — a missing lockfile just means no dup detection.
+  }
+
+  return other;
+}


### PR DESCRIPTION
Closes #288.

**Account-visibility bug.** The extension defaulted its Data Directory to `~/.imap-mcp-pro`; everything else (`server-config`, CLI, launchd service, outbox, encryption key) uses `~/.imap-mcp`. So accounts added via one entry point sat in a different SQLite DB (different `colin` user_id) than the MCP session read. Verified live: `a8af4eb4` is in `~/.imap-mcp` (10 accts) but not `~/.imap-mcp-pro` (1 acct). Manifest `database_path` default → `/Users/colin/.imap-mcp`.

**Duplicate-instance guard.** `registerInstance()` writes a data-dir pidfile at startup and logs a clear warning if another live instance holds it (non-blocking) — catches the installed-twice case.

Existing installs: set Data Directory to `~/.imap-mcp` + restart Claude Desktop.

5 new tests; full suite **337 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)